### PR TITLE
Passage au COG 2022

### DIFF
--- a/lib/export/csv-bal.js
+++ b/lib/export/csv-bal.js
@@ -4,9 +4,7 @@ const intoStream = require('into-stream')
 const {keyBy} = require('lodash')
 const pumpify = require('pumpify')
 const proj = require('@etalab/project-legal')
-const communes = require('@etalab/decoupage-administratif/data/communes.json')
-
-const communesIndex = keyBy(communes, 'code')
+const {getCommune} = require('../util/cog')
 
 function roundCoordinate(coordinate, precision) {
   return Number.parseFloat(coordinate.toFixed(precision))
@@ -33,10 +31,6 @@ function toCsvBoolean(certifie) {
 
 /* eslint camelcase: off */
 function createRow(obj) {
-  const nomCommune = obj.codeCommune && obj.codeCommune in communesIndex
-    ? communesIndex[obj.codeCommune].nom
-    : ''
-
   const row = {
     cle_interop: formatCleInterop(obj.codeCommune, obj.codeVoie, obj.numero, obj.suffixe),
     uid_adresse: '',
@@ -46,7 +40,7 @@ function createRow(obj) {
     suffixe: obj.suffixe || '',
     certification_commune: toCsvBoolean(obj.certifie),
     commune_insee: obj.codeCommune,
-    commune_nom: nomCommune,
+    commune_nom: getCommune(obj.codeCommune).nom,
     position: '',
     long: '',
     lat: '',

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -1,4 +1,3 @@
-const communes = require('@etalab/decoupage-administratif/data/communes.json')
 const Joi = require('joi')
 const {omit, uniqBy, difference, uniq} = require('lodash')
 const {generateBase62String} = require('../util/base62')
@@ -14,7 +13,7 @@ const {extract} = require('../populate/extract-ban')
 const {extractFromCsv} = require('../populate/extract-csv')
 const adressesToCsv = require('../export/csv-bal').exportAsCsv
 const {transformToGeoJSON} = require('../export/geojson')
-const {getNomCommune, getCodesCommunes} = require('../util/cog')
+const {getCommune: getCommuneCOG, getCodesCommunes} = require('../util/cog')
 const Voie = require('./voie')
 const Numero = require('./numero')
 const Toponyme = require('./toponyme')
@@ -70,7 +69,7 @@ async function createDemo(payload) {
     _id: new mongo.ObjectId(),
     token: generateBase62String(20),
     communes: [commune],
-    nom: `Adresses de ${getNomCommune(commune)} [démo]`,
+    nom: `Adresses de ${getCommuneCOG(commune).nom} [démo]`,
     status: 'demo'
   }
 
@@ -143,7 +142,7 @@ async function transformToDraft(currentBaseLocale, payload) {
   const {nom, email} = validPayload(payload, transformToDraftSchema)
 
   const changes = {
-    nom: nom ? nom : `Adresses de ${getNomCommune(currentBaseLocale.communes[0])}`,
+    nom: nom ? nom : `Adresses de ${getCommuneCOG(currentBaseLocale.communes[0]).nom}`,
     status: 'draft',
     emails: [email]
   }
@@ -197,7 +196,7 @@ async function renewToken(id) {
 }
 
 async function addCommune(id, codeCommune) {
-  if (!communes.some(c => c.code === codeCommune && ['commune-actuelle', 'arrondissement-municipal'].includes(c.type))) {
+  if (!getCommuneCOG(codeCommune)) {
     throw new Error('Code commune inconnu')
   }
 
@@ -231,8 +230,8 @@ async function cleanCommune(id, codeCommune) {
 }
 
 async function removeCommune(id, codeCommune) {
-  if (!communes.some(c => c.code === codeCommune)) {
-    throw new Error('Code commune inconnu')
+  if (codeCommune.length !== 5) {
+    throw new Error('Code commune invalide')
   }
 
   const {value} = await mongo.db.collection('bases_locales').findOneAndUpdate(

--- a/lib/populate/extract-csv.js
+++ b/lib/populate/extract-csv.js
@@ -107,7 +107,7 @@ function extractData(rows, codeCommune) {
 
 async function extractFromCsv(file, codeCommune) {
   try {
-    const {rows, parseOk} = await validate(file)
+    const {rows, parseOk} = await validate(file, {relaxFieldsDetection: true})
 
     if (!parseOk) {
       return {isValid: false}

--- a/lib/routes/__tests__/base-locale.js
+++ b/lib/routes/__tests__/base-locale.js
@@ -502,7 +502,7 @@ test.serial('remove a commune from a BaseLocal / invalid commune', async t => {
   })
 
   const {status} = await request(getApp())
-    .delete(`/bases-locales/${_id}/communes/12345`)
+    .delete(`/bases-locales/${_id}/communes/123456`)
     .set({Authorization: 'Token coucou'})
 
   t.is(status, 500)

--- a/lib/routes/stats.js
+++ b/lib/routes/stats.js
@@ -1,8 +1,7 @@
 const express = require('express')
-const departements = require('@etalab/decoupage-administratif/data/departements.json')
 const w = require('../util/w')
 const BaseLocale = require('../models/base-locale')
-const {getCommunesByDepartement} = require('../util/cog')
+const {getCommunesByDepartement, getDepartement} = require('../util/cog')
 
 const {useCache} = require('../util/cache')
 
@@ -23,7 +22,7 @@ app.route('/couverture-bal')
 app.route('/departements/:codeDepartement')
   .get(w(async (req, res) => {
     const {codeDepartement} = req.params
-    if (!departements.some(d => d.code === codeDepartement)) {
+    if (!getDepartement(codeDepartement)) {
       return res.status(404).send({code: 404, message: `Le département ${codeDepartement} n’existe pas.`})
     }
 

--- a/lib/util/cog.js
+++ b/lib/util/cog.js
@@ -1,24 +1,28 @@
 const {groupBy, keyBy} = require('lodash')
+
 const communes = require('@etalab/decoupage-administratif/data/communes.json')
   .filter(c => ['commune-actuelle', 'arrondissement-municipal'].includes(c.type))
 
+const departements = require('@etalab/decoupage-administratif/data/departements.json')
+
 const communesByDepartementIndex = groupBy(communes, 'departement')
 const communesIndex = keyBy(communes, 'code')
+const departementsIndex = keyBy(departements, 'code')
 
 function getCommunesByDepartement(codeDepartement) {
   return communesByDepartementIndex[codeDepartement] || []
 }
 
-function getNomCommune(codeCommune) {
-  if (!communesIndex[codeCommune]) {
-    throw new Error(`Commune ${codeCommune} inconnue`)
-  }
-
-  return communesIndex[codeCommune].nom
+function getCommune(codeCommune) {
+  return communesIndex[codeCommune]
 }
 
 function getCodesCommunes() {
   return communes.map(c => c.code)
 }
 
-module.exports = {getCommunesByDepartement, getNomCommune, getCodesCommunes}
+function getDepartement(codeDepartement) {
+  return departementsIndex[codeDepartement]
+}
+
+module.exports = {getCommunesByDepartement, getCommune, getCodesCommunes, getDepartement}

--- a/lib/util/contours-communes.js
+++ b/lib/util/contours-communes.js
@@ -10,9 +10,8 @@ async function getRemoteFeatures(url) {
 
 async function prepareContoursCommunes() {
   const communesFeatures = await getRemoteFeatures('http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/2022/geojson/communes-100m.geojson')
-  const arrFeatures = await getRemoteFeatures('http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/2022/geojson/arrondissements-municipaux-100m.geojson')
 
-  communesIndex = keyBy([...communesFeatures, ...arrFeatures], f => f.properties.code)
+  communesIndex = keyBy([...communesFeatures], f => f.properties.code)
 }
 
 function getContourCommune(codeCommune) {

--- a/lib/util/contours-communes.js
+++ b/lib/util/contours-communes.js
@@ -9,8 +9,8 @@ async function getRemoteFeatures(url) {
 }
 
 async function prepareContoursCommunes() {
-  const communesFeatures = await getRemoteFeatures('http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/latest/geojson/communes-100m.geojson')
-  const arrFeatures = await getRemoteFeatures('http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/latest/geojson/arrondissements-municipaux-100m.geojson')
+  const communesFeatures = await getRemoteFeatures('http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/2022/geojson/communes-100m.geojson')
+  const arrFeatures = await getRemoteFeatures('http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/2022/geojson/arrondissements-municipaux-100m.geojson')
 
   communesIndex = keyBy([...communesFeatures, ...arrFeatures], f => f.properties.code)
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@etalab/bal": "^2.3.0",
-    "@etalab/decoupage-administratif": "^0.8.0",
+    "@etalab/decoupage-administratif": "^2.0.0",
     "@etalab/project-legal": "^0.4.1",
     "body-parser": "^1.19.1",
     "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@etalab/bal": "^2.3.0",
     "@etalab/decoupage-administratif": "^2.0.0",
-    "@etalab/project-legal": "^0.4.1",
+    "@etalab/project-legal": "^0.5.0",
     "body-parser": "^1.19.1",
     "cors": "^2.8.5",
     "csv-parser": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "start": "node server"
   },
   "dependencies": {
-    "@etalab/bal": "^1.8.0",
+    "@etalab/bal": "^2.3.0",
     "@etalab/decoupage-administratif": "^0.8.0",
     "@etalab/project-legal": "^0.4.1",
     "body-parser": "^1.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -438,12 +438,10 @@
     papaparse "^5.3.1"
     yargs "^17.3.1"
 
-"@etalab/decoupage-administratif@^0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@etalab/decoupage-administratif/-/decoupage-administratif-0.8.0.tgz#378a73a00737de5432179394dd28244a93bcbd46"
-  integrity sha512-BNO0BLfPyUvLpGAStdKpZAX80hUHdkhhD3GMu7HcwERqmshl96uIU0v3/1LlL23DiMs9qRyVIRnfDDIAfHaG/w==
-  dependencies:
-    lodash "^4.17.15"
+"@etalab/decoupage-administratif@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@etalab/decoupage-administratif/-/decoupage-administratif-2.0.0.tgz#24ee640070c47e3c62883873c35450197fa5f78c"
+  integrity sha512-X+pQDnm0Sk8T5KPhT5kU9cLyMKc+LagK8ObYxyzVDoQapjLNZl9/KY2VFr42aw4LEiTnUfqCgNZc9lhHfi6shQ==
 
 "@etalab/project-legal@^0.4.1":
   version "0.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -422,20 +422,21 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@etalab/bal@^1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@etalab/bal/-/bal-1.8.0.tgz#9a33f6849c4f574404477d10ba7fdc3167d9fd93"
-  integrity sha512-fz6Rs+YFjwmAcd4zvkbI4ZHixnSYaOjxpGsc4OUMJCN1imsEOz8PsJX9w4oLo1dBr7bBqxWqfR59pbH3Xsw0rA==
+"@etalab/bal@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@etalab/bal/-/bal-2.3.0.tgz#c4655794d67e593baba8d01ea5cfcc37395c1fe0"
+  integrity sha512-VCTFnsnNGK8PRKFPvBrzxeqHxGoUgx1E3caJv5PbWCGg2GQb6U4JL+P0T/2gTvtwXeMtwJs3iKygYu1Ev6QRew==
   dependencies:
     blob-to-buffer "^1.2.9"
+    bluebird "^3.7.2"
     chalk "^4.1.2"
     chardet "^1.4.0"
-    date-fns "^2.26.0"
+    date-fns "^2.28.0"
     file-type "^12.4.2"
     iconv-lite "^0.6.3"
     lodash "^4.17.21"
     papaparse "^5.3.1"
-    yargs "^17.2.1"
+    yargs "^17.3.1"
 
 "@etalab/decoupage-administratif@^0.8.0":
   version "0.8.0"
@@ -1063,6 +1064,11 @@ blob-to-buffer@^1.2.9:
   resolved "https://registry.yarnpkg.com/blob-to-buffer/-/blob-to-buffer-1.2.9.tgz#a17fd6c1c564011408f8971e451544245daaa84a"
   integrity sha512-BF033y5fN6OCofD3vgHmNtwZWRcq9NLyyxyILx9hfMy1sXYy4ojFl765hJ2lP0YaN2fuxPaLO2Vzzoxy0FLFFA==
 
+bluebird@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
+  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
+
 blueimp-md5@^2.10.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/blueimp-md5/-/blueimp-md5-2.11.0.tgz#eff55d30fe3daddd7e801072e2c4483e5fcfc87c"
@@ -1609,15 +1615,15 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-date-fns@^2.26.0:
-  version "2.26.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.26.0.tgz#fa45305543c392c4f914e50775fd2a4461e60fbd"
-  integrity sha512-VQI812dRi3cusdY/fhoBKvc6l2W8BPWU1FNVnFH9Nttjx4AFBRzfSVb/Eyc7jBT6e9sg1XtAGsYpBQ6c/jygbg==
-
 date-fns@^2.27.0:
   version "2.27.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.27.0.tgz#e1ff3c3ddbbab8a2eaadbb6106be2929a5a2d92b"
   integrity sha512-sj+J0Mo2p2X1e306MHq282WS4/A8Pz/95GIFcsPNMPMZVI3EUrAdSv90al1k+p74WGLCruMXk23bfEDZa71X9Q==
+
+date-fns@^2.28.0:
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
+  integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
 
 date-time@^3.1.0:
   version "3.1.0"
@@ -5341,6 +5347,15 @@ string-width@^4.1.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^5.2.0"
 
+string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string.prototype.trimend@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz#e75ae90c2942c63504686c18b287b4a0b1a45f80"
@@ -6007,6 +6022,11 @@ yargs-parser@^20.2.9:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
+yargs-parser@^21.0.0:
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.0.tgz#a485d3966be4317426dd56bdb6a30131b281dc55"
+  integrity sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==
+
 yargs@^15.0.2:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
@@ -6037,18 +6057,18 @@ yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.2.1:
-  version "17.2.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.2.1.tgz#e2c95b9796a0e1f7f3bf4427863b42e0418191ea"
-  integrity sha512-XfR8du6ua4K6uLGm5S6fA+FIJom/MdJcFNVY8geLlp2v8GYbOXD4EB1tPNZsRn4vBzKGMgb5DRZMeWuFc2GO8Q==
+yargs@^17.3.1:
+  version "17.3.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.3.1.tgz#da56b28f32e2fd45aefb402ed9c26f42be4c07b9"
+  integrity sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==
   dependencies:
     cliui "^7.0.2"
     escalade "^3.1.1"
     get-caller-file "^2.0.5"
     require-directory "^2.1.1"
-    string-width "^4.2.0"
+    string-width "^4.2.3"
     y18n "^5.0.5"
-    yargs-parser "^20.2.2"
+    yargs-parser "^21.0.0"
 
 yauzl@^2.10.0:
   version "2.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -443,10 +443,10 @@
   resolved "https://registry.yarnpkg.com/@etalab/decoupage-administratif/-/decoupage-administratif-2.0.0.tgz#24ee640070c47e3c62883873c35450197fa5f78c"
   integrity sha512-X+pQDnm0Sk8T5KPhT5kU9cLyMKc+LagK8ObYxyzVDoQapjLNZl9/KY2VFr42aw4LEiTnUfqCgNZc9lhHfi6shQ==
 
-"@etalab/project-legal@^0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@etalab/project-legal/-/project-legal-0.4.1.tgz#45588249552ebb1d129fea8e8e3309cf814b16d7"
-  integrity sha512-/GMuRVGprAo8MNXwvSk7dFa89iH985pwVjO4op/rE7FwBAgTSlmJZzDnAyrnBqPC4Z5kSxFoGyuTzEauE7pMHQ==
+"@etalab/project-legal@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@etalab/project-legal/-/project-legal-0.5.0.tgz#2631e8351385a0eb60536d1a0accaa3afa267a81"
+  integrity sha512-LuujaPT1FfVHCPqUFP4sKidtMiYvb9EzKITlcvfLetfrz/Sou8X2xF2vvJWqEJTHSPp2dQUb2nYV0WTvJANb5A==
   dependencies:
     proj4 "^2.6.3"
 


### PR DESCRIPTION
Cette PR a pour objectif de passer au COG 2022.
La migration des données a été réalisée à la main, et ne concernait qu'une seule commune.

En résumé :
- Mise à jour de `@etalab/bal` (et adaptation du code lié au passage à la version `2.x`
- Mise à jour du lien de téléchargement des contours administratifs
- Mise à jour de `@etalab/decoupage-administratif` (`2.0.0`)