### PR TITLE
Modification d'un titre dans la notification de publication

### DIFF
--- a/lib/emails/__tests__/bal-publication-notification.js
+++ b/lib/emails/__tests__/bal-publication-notification.js
@@ -107,7 +107,7 @@ test('formatEmail', t => {
     </section>
 
     <section>
-      <h4>🚀 Ne vous arrêtez pas en si bon chemin !</h4>
+      <h4>🚀 Continuez l’édition de cette Base Adresse Locale</h4>
       <p>
         Si vous souhaitez <b>mettre à jour</b> vos adresses ou effecter des <b>corrections</b>, continuer simplement l’édition de cette Base Adresse Locale.<br />
         Les changements seront <b>enregistrés automatiquement</b> et transmis à la Base Adresse Nationale.

--- a/lib/emails/bal-publication-notification.js
+++ b/lib/emails/bal-publication-notification.js
@@ -100,7 +100,7 @@ const bodyTemplate = template(`
     </section>
 
     <section>
-      <h4>🚀 Ne vous arrêtez pas en si bon chemin !</h4>
+      <h4>🚀 Continuez l’édition de cette Base Adresse Locale</h4>
       <p>
         Si vous souhaitez <b>mettre à jour</b> vos adresses ou effecter des <b>corrections</b>, continuer simplement l’édition de cette Base Adresse Locale.<br />
         Les changements seront <b>enregistrés automatiquement</b> et transmis à la Base Adresse Nationale.


### PR DESCRIPTION
Le titre `Ne vous arrêtez pas en si bon chemin !` devient `Continuez l’édition de cette Base Adresse Locale` afin d'apporter de la clarté pour les communes qui justement n'ont pas édité leur BAL.