### PR TITLE
Correction de la procédure de détection des conflits

### DIFF
--- a/lib/sync/index.js
+++ b/lib/sync/index.js
@@ -1,4 +1,5 @@
 const {setTimeout} = require('timers/promises')
+const bluebird = require('bluebird')
 const createError = require('http-errors')
 const hasha = require('hasha')
 const {sub} = require('date-fns')
@@ -232,10 +233,11 @@ async function detectConflict() {
 
   detectConflictPublishedSince = futurePublishedSince
 
-  await Promise.all(revisedCommunes.map(async codeCommune => {
-    await setTimeout(5000)
+  await setTimeout(5000)
+
+  await bluebird.map(revisedCommunes, async codeCommune => {
     await updateConflictStatus(codeCommune)
-  }))
+  }, {concurrency: 10})
 }
 
 async function syncOutdated() {

--- a/lib/sync/index.js
+++ b/lib/sync/index.js
@@ -182,12 +182,12 @@ async function resume(balId) {
 }
 
 async function updateConflictStatus(codeCommune) {
-  const baseLocales = await mongo.db.collection('bases_locales').find({
+  const basesLocales = await mongo.db.collection('bases_locales').find({
     communes: codeCommune,
     status: {$in: ['replaced', 'published']}
   }).toArray()
 
-  if (baseLocales.length === 0) {
+  if (basesLocales.length === 0) {
     return
   }
 
@@ -198,7 +198,7 @@ async function updateConflictStatus(codeCommune) {
     return
   }
 
-  await Promise.all(baseLocales.map(async baseLocale => {
+  await Promise.all(basesLocales.map(async baseLocale => {
     if (currentRevision._id === baseLocale.sync.lastUploadedRevisionId) {
       await mongo.db.collection('bases_locales').updateOne(
         {_id: baseLocale._id, status: 'replaced'},

--- a/lib/sync/index.js
+++ b/lib/sync/index.js
@@ -181,42 +181,45 @@ async function resume(balId) {
 }
 
 async function updateConflictStatus(codeCommune) {
-  const baseLocale = await mongo.db.collection('bases_locales').find({
+  const baseLocales = await mongo.db.collection('bases_locales').find({
     communes: codeCommune,
     status: {$in: ['replaced', 'published']}
-  })
+  }).toArray()
 
-  if (!baseLocale) {
+  if (baseLocales.length === 0) {
     return
   }
 
   const currentRevision = await getCurrentRevision(codeCommune)
 
   if (!currentRevision) {
+    console.error(`Comportement inattendu : pas de révision courante pour la commune ${codeCommune}`)
     return
   }
 
-  if (currentRevision._id === baseLocale.sync.lastUploadedRevisionId) {
-    await mongo.db.collection('bases_locales').updateOne(
-      {_id: baseLocale._id, status: 'replaced'},
-      {
-        $set: {
-          status: 'published',
-          'sync.status': 'synced'
+  await Promise.all(baseLocales.map(async baseLocale => {
+    if (currentRevision._id === baseLocale.sync.lastUploadedRevisionId) {
+      await mongo.db.collection('bases_locales').updateOne(
+        {_id: baseLocale._id, status: 'replaced'},
+        {
+          $set: {
+            status: 'published',
+            'sync.status': 'synced'
+          }
         }
-      }
-    )
-  } else {
-    await mongo.db.collection('bases_locales').updateOne(
-      {_id: baseLocale._id, status: 'published'},
-      {
-        $set: {
-          status: 'replaced',
-          'sync.status': 'conflict'
+      )
+    } else {
+      await mongo.db.collection('bases_locales').updateOne(
+        {_id: baseLocale._id, status: 'published'},
+        {
+          $set: {
+            status: 'replaced',
+            'sync.status': 'conflict'
+          }
         }
-      }
-    )
-  }
+      )
+    }
+  }))
 }
 
 let detectConflictPublishedSince = new Date('2000-01-01')

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@etalab/bal": "^2.3.3",
     "@etalab/decoupage-administratif": "^2.0.0",
     "@etalab/project-legal": "^0.5.0",
+    "bluebird": "^3.7.2",
     "body-parser": "^1.19.1",
     "cors": "^2.8.5",
     "csv-parser": "^3.0.0",


### PR DESCRIPTION
Corrige une anomalie majeure dans la fonction `updateConflictStatus` dont le premier appel MongoDB retournait un curseur.

Désormais on retourne un tableau et on gère toutes les BAL retournées.

En supplément, l'exécution en parallèle des items de la boucle detectConflict est plafonnée à 10 pour éviter les goulets d'étranglement sur les machines lentes.

Lié à #318 mais ne suffit probablement pas à fermer l'issue.