### PR TITLE
Ajoute les BAL publiées en dehors de Mes Adresses aux statistiques du dashboard

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -15,4 +15,4 @@ RUN_MIGRATION=0
 API_DEPOT_URL=https://plateforme.adresse.data.gouv.fr/api-depot
 API_DEPOT_CLIENT_ID=
 API_DEPOT_CLIENT_SECRET=
-BAN_API_URL=https://plateforme.adresse.data.gouv.fr/ban
+BAN_API_URL=https://plateforme.adresse.data.gouv.fr

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -1,5 +1,5 @@
 const Joi = require('joi')
-const {omit, uniqBy, difference, uniq} = require('lodash')
+const {omit, uniqBy, difference, uniq, keyBy} = require('lodash')
 const {generateBase62String} = require('../util/base62')
 const {validPayload} = require('../util/payload')
 const mongo = require('../util/mongo')
@@ -14,6 +14,7 @@ const {extractFromCsv} = require('../populate/extract-csv')
 const adressesToCsv = require('../export/csv-bal').exportAsCsv
 const {transformToGeoJSON} = require('../export/geojson')
 const {getCommune: getCommuneCOG, getCodesCommunes} = require('../util/cog')
+const {getCommunesSummary} = require('../util/api-ban')
 const Voie = require('./voie')
 const Numero = require('./numero')
 const Toponyme = require('./toponyme')
@@ -343,6 +344,18 @@ async function computeStats() {
     }}
   ]).toArray()
 
+  const resultsIndex = keyBy(results, '_id')
+
+  const communesSummary = await getCommunesSummary()
+
+  const publishedCommunes = new Set(
+    communesSummary
+      .filter(c => c.typeComposition === 'bal')
+      .map(c => c.codeCommune)
+  )
+
+  const communes = new Set([...publishedCommunes, ...results.map(r => r._id)])
+
   function getStatus(communeResult) {
     if (communeResult.statuses.includes('published')) {
       return 'published'
@@ -350,6 +363,10 @@ async function computeStats() {
 
     if (communeResult.statuses.includes('replaced')) {
       return 'replaced'
+    }
+
+    if (publishedCommunes.has(communeResult._id)) {
+      return 'published-other'
     }
 
     if (communeResult.statuses.includes('ready-to-publish')) {
@@ -361,19 +378,21 @@ async function computeStats() {
 
   return {
     type: 'FeatureCollection',
-    features: results
-      .filter(r => getContourCommune(r._id))
-      .map(r => {
-        const contourCommune = getContourCommune(r._id)
+    features: [...communes]
+      .filter(codeCommune => getContourCommune(codeCommune))
+      .map(codeCommune => {
+        const communeResult = resultsIndex[codeCommune]
+        const contourCommune = getContourCommune(codeCommune)
         const {nom, code} = contourCommune.properties
-        const properties = {
-          code,
-          nom,
-          maxStatus: getStatus(r)
-        }
+        const maxStatus = communeResult ? getStatus(communeResult) : 'published-other'
+
         return {
           type: 'Feature',
-          properties,
+          properties: {
+            code,
+            nom,
+            maxStatus
+          },
           geometry: contourCommune.geometry
         }
       })

--- a/lib/populate/extract-ban.js
+++ b/lib/populate/extract-ban.js
@@ -6,12 +6,12 @@ const pumpify = require('pumpify')
 const {ObjectId} = require('../util/mongo')
 const {extractFromCsv} = require('./extract-csv')
 
-const BAN_API_URL = process.env.BAN_API_URL || 'https://plateforme.adresse.data.gouv.fr/ban'
+const BAN_API_URL = process.env.BAN_API_URL || 'https://plateforme.adresse.data.gouv.fr'
 const API_DEPOT_URL = process.env.API_DEPOT_URL || 'https://plateforme.adresse.data.gouv.fr/api-depot'
 
 async function extractFromBAN(codeCommune) {
   const adresses = await getStream(pumpify.obj(
-    got.stream(`${BAN_API_URL}/communes/${codeCommune}/download/csv-legacy/adresses`, {responseType: 'buffer'}),
+    got.stream(`${BAN_API_URL}/ban/communes/${codeCommune}/download/csv-legacy/adresses`, {responseType: 'buffer'}),
     csvParse({separator: ';'})
   ))
 

--- a/lib/sync/api-depot.js
+++ b/lib/sync/api-depot.js
@@ -22,7 +22,7 @@ async function getCurrentRevision(codeCommune) {
   throw new Error(response.body.message)
 }
 
-async function getCurrentRevisions(publishedSince) {
+async function getCurrentRevisions(publishedSince = new Date('1970-01-01')) {
   return got(`${API_DEPOT_URL}/current-revisions?publishedSince=${publishedSince.toISOString()}`).json()
 }
 

--- a/lib/util/api-ban.js
+++ b/lib/util/api-ban.js
@@ -1,0 +1,9 @@
+const got = require('got')
+
+const BAN_API_URL = process.env.BAN_API_URL || 'https://plateforme.adresse.data.gouv.fr'
+
+function getCommunesSummary() {
+  return got(`${BAN_API_URL}/api/communes-summary`).json()
+}
+
+module.exports = {getCommunesSummary}


### PR DESCRIPTION
## Contexte
Actuellement, seules les Bases Adresses Locales publiées via Mes Adresses sont affichées sur le tableau de bord. Cette PR propose d'ajouter les également les BAL publiées en dehors de l'outil dans les statistiques envoyées au tableau de bord.