### PR TITLE
Améliore les performances du dashboard

### DIFF
--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -1,5 +1,5 @@
 const Joi = require('joi')
-const {omit, uniqBy, difference, uniq} = require('lodash')
+const {omit, uniqBy, difference, uniq, flatten, groupBy} = require('lodash')
 const {generateBase62String} = require('../util/base62')
 const {validPayload} = require('../util/payload')
 const mongo = require('../util/mongo')
@@ -358,6 +358,11 @@ async function getBALStatsByStatus(codesCommunes = null) {
   }
 }
 
+function groupBALByCommune(basesLocales) {
+  const BALAddedOneCodeCommune = flatten(basesLocales.map(b => b.communes.map(c => ({...b, commune: c}))))
+  return groupBy(BALAddedOneCodeCommune, 'commune')
+}
+
 async function computeStats() {
   const results = await mongo.db.collection('bases_locales').aggregate([
     {$match: {status: {$ne: 'demo'}}},
@@ -522,6 +527,7 @@ module.exports = {
   fetchOne,
   fetchAll,
   getBALStatsByStatus,
+  groupBALByCommune,
   fetchByCommunes,
   remove,
   renewToken,

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -332,6 +332,32 @@ function filterSensitiveFields(baseLocale) {
   return omit(baseLocale, 'token', 'emails')
 }
 
+async function getBALStatsByStatus(codesCommunes = null) {
+  const getQuery = status => {
+    const basesLocalesQuery = {status}
+
+    if (!codesCommunes) {
+      return basesLocalesQuery
+    }
+
+    basesLocalesQuery.communes = {$elemMatch: {$in: codesCommunes}}
+
+    return basesLocalesQuery
+  }
+
+  const nbBALPublished = await mongo.db.collection('bases_locales').count(getQuery('published'))
+  const nbBALReplaced = await mongo.db.collection('bases_locales').count(getQuery('replaced'))
+  const nbBALReadyToPublished = await mongo.db.collection('bases_locales').count(getQuery('ready-to-publish'))
+  const nbBALDraft = await mongo.db.collection('bases_locales').count(getQuery('draft'))
+
+  return {
+    nbBALPublished,
+    nbBALReplaced,
+    nbBALReadyToPublished,
+    nbBALDraft
+  }
+}
+
 async function computeStats() {
   const results = await mongo.db.collection('bases_locales').aggregate([
     {$match: {status: {$ne: 'demo'}}},
@@ -495,6 +521,7 @@ module.exports = {
   transformToDraftSchema,
   fetchOne,
   fetchAll,
+  getBALStatsByStatus,
   fetchByCommunes,
   remove,
   renewToken,

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -92,6 +92,13 @@ app.route('/bases-locales')
     res.status(201).send(baseLocale)
   }))
 
+app.route('/bases-locales/excluded-demo')
+  .get(w(async (req, res) => {
+    const basesLocales = await BaseLocale.fetchAll()
+    const filteredBasesLocales = basesLocales.filter(({status}) => status !== 'demo')
+    res.send(filteredBasesLocales.map(bal => BaseLocale.filterSensitiveFields(bal)))
+  }))
+
 app.route('/bases-locales/create-demo')
   .post(w(async (req, res) => {
     const baseLocale = await BaseLocale.createDemo(req.body)

--- a/lib/routes/stats.js
+++ b/lib/routes/stats.js
@@ -71,7 +71,15 @@ app.route('/departements/:codeDepartement')
 
     const stats = await useCache(
       `bal-stats-${codeDepartement}`, 300,
-      () => BaseLocale.publishedBasesLocalesStats(codesCommunes)
+      async () => {
+        const basesLocalesStats = await BaseLocale.publishedBasesLocalesStats(codesCommunes)
+        const basesLocalesStatsByStatus = await BaseLocale.getBALStatsByStatus(codesCommunes)
+
+        return {
+          basesLocalesStats,
+          basesLocalesStatsByStatus
+        }
+      }
     )
     const basesLocales = await BaseLocale.fetchByCommunes(codesCommunes)
 

--- a/lib/routes/stats.js
+++ b/lib/routes/stats.js
@@ -82,9 +82,10 @@ app.route('/departements/:codeDepartement')
       }
     )
     const basesLocales = await BaseLocale.fetchByCommunes(codesCommunes)
+    const filteredBasesLocales = basesLocales.filter(bal => bal.status !== 'demo')
 
     res.send({
-      basesLocales: basesLocales.map(bal => BaseLocale.filterSensitiveFields(bal)),
+      basesLocales: filteredBasesLocales.map(bal => BaseLocale.filterSensitiveFields(bal)),
       stats
     })
   }))

--- a/lib/routes/stats.js
+++ b/lib/routes/stats.js
@@ -4,6 +4,7 @@ const zlib = require('zlib')
 const vtpbf = require('vt-pbf')
 const geojsonVt = require('geojson-vt')
 const express = require('express')
+const {uniq} = require('lodash')
 const w = require('../util/w')
 const BaseLocale = require('../models/base-locale')
 const {getCommunesByDepartement, getDepartement} = require('../util/cog')
@@ -68,6 +69,7 @@ app.route('/departements/:codeDepartement')
     }
 
     const codesCommunes = getCommunesByDepartement(codeDepartement).map(c => c.code)
+    const codes = []
 
     const stats = await useCache(
       `bal-stats-${codeDepartement}`, 300,
@@ -85,10 +87,17 @@ app.route('/departements/:codeDepartement')
     const filteredBasesLocales = basesLocales.filter(bal => bal.status !== 'demo')
     const BALGroupedByCommune = BaseLocale.groupBALByCommune(filteredBasesLocales)
 
+    filteredBasesLocales.forEach(bal => {
+      bal.communes.forEach(commune => {
+        codes.push(commune)
+      })
+    })
+
     res.send({
       basesLocales: filteredBasesLocales.map(bal => BaseLocale.filterSensitiveFields(bal)),
       BALGroupedByCommune,
-      stats
+      stats,
+      codesCommunes: uniq(codes)
     })
   }))
 

--- a/lib/routes/stats.js
+++ b/lib/routes/stats.js
@@ -16,7 +16,16 @@ const app = new express.Router()
 
 app.route('/')
   .get(w(async (req, res) => {
-    const stats = await useCache('bal-stats', 300, () => BaseLocale.publishedBasesLocalesStats())
+    const stats = await useCache('bal-stats', 300, async () => {
+      const basesLocalesStats = await BaseLocale.publishedBasesLocalesStats()
+      const basesLocalesStatsByStatus = await BaseLocale.getBALStatsByStatus()
+
+      return {
+        basesLocalesStats,
+        basesLocalesStatsByStatus
+      }
+    })
+
     res.send(stats)
   }))
 

--- a/lib/routes/stats.js
+++ b/lib/routes/stats.js
@@ -83,9 +83,11 @@ app.route('/departements/:codeDepartement')
     )
     const basesLocales = await BaseLocale.fetchByCommunes(codesCommunes)
     const filteredBasesLocales = basesLocales.filter(bal => bal.status !== 'demo')
+    const BALGroupedByCommune = BaseLocale.groupBALByCommune(filteredBasesLocales)
 
     res.send({
       basesLocales: filteredBasesLocales.map(bal => BaseLocale.filterSensitiveFields(bal)),
+      BALGroupedByCommune,
       stats
     })
   }))


### PR DESCRIPTION
## Liée à la PR 123

- Nouvelle route qui liste les BAL sans les BAL de demo
- L'API retourne :
  - les BAL triées par statut
  - les BAL regroupées par code commune
  - les `codesCommunes` pour la route /stats/departement
