### PR TITLE
Correction de l'importation de fichier BAL Corse

### DIFF
--- a/lib/populate/extract-csv.js
+++ b/lib/populate/extract-csv.js
@@ -116,7 +116,7 @@ async function extractFromCsv(file, codeCommune) {
     const accepted = rows.filter(({isValid}) => isValid)
     const rejected = rows.filter(({isValid}) => !isValid)
     const parsedValues = accepted.map(({parsedValues}) => parsedValues)
-      .filter(p => p.cle_interop.slice(0, 5) === codeCommune)
+      .filter(p => p.cle_interop.slice(0, 5) === codeCommune.toLowerCase()) // For match code with letters
 
     const communesData = extractData(parsedValues, codeCommune)
 


### PR DESCRIPTION
## Contexte
Lorsqu'une BAL est créée à partir d'un fichier CSV les données valides sont extraites grâce à la comparaison du `code commune` et de la `cle_interop`.
Cependant, pour ce qui est des codes communes contenant des lettres comme en Corse (ex: 2B112), la comparaison ne peut se faire, car la `cle_interop` sera toujours écrite avec des lettres minuscules, tandis que les lettres seront majuscule sur le code commune.

## Résolution
Le code commune est passé en minuscule afin de pouvoir être comparé à la clé interopérabilité.