### PR TITLE
Modification du code erreur lorsqu'une BAL n'est pas valide lors de la publication

### DIFF
--- a/lib/sync/api-depot.js
+++ b/lib/sync/api-depot.js
@@ -61,7 +61,7 @@ async function publishNewRevision(codeCommune, balId, balFile, habilitationId) {
   if (!computedRevision.validation.valid) {
     console.log(`Export BAL non valide : ${balId}`)
     console.log(computedRevision.validation.errors)
-    throw createError(500, 'La fichier BAL n’est pas valide. Merci de contacter le support.')
+    throw createError(417, 'La fichier BAL n’est pas valide. Merci de contacter le support.')
   }
 
   const publishedRevision = await got.post(


### PR DESCRIPTION
## Contexte
Lorsqu'une tentative publication d'une BAL échoue, car celle-ci n'est pas valide, une erreur `500` accompagnée du message `La fichier BAL n’est pas valide. Merci de contacter le support.` est renvoyée.
Cependant, notre système de gestion des erreurs attribue automatiquement le message `Une erreur inattendue est survenue.` aux erreurs 500 afin de ne pas exposé des messages illisibles pour les utilisateurs.

## Modification
Cette PR propose de modifier le code `500` en `417` `Expectation failed`.