### PR TITLE
Corrige les schemas de validation 

### DIFF
--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -19,11 +19,12 @@ const Voie = require('./voie')
 const Numero = require('./numero')
 const Toponyme = require('./toponyme')
 
+const nomValidation = Joi.string().min(1).max(200)
+const emailsValidation = Joi.array().min(1).items(Joi.string().email())
+
 const createSchema = Joi.object().keys({
-  nom: Joi.string().min(1).max(200).required(),
-  emails: Joi.array().min(1).items(
-    Joi.string().email()
-  ).required()
+  nom: nomValidation.required(),
+  emails: emailsValidation.required()
 })
 
 async function create(payload) {
@@ -86,11 +87,9 @@ async function createDemo(payload) {
 }
 
 const updateSchema = Joi.object().keys({
-  nom: Joi.string().min(1).max(200),
+  nom: nomValidation,
   status: Joi.string().valid('draft', 'ready-to-publish'),
-  emails: Joi.array().min(1).items(
-    Joi.string().email()
-  )
+  emails: emailsValidation
 })
 
 async function update(id, payload) {

--- a/lib/models/numero.js
+++ b/lib/models/numero.js
@@ -5,20 +5,6 @@ const mongo = require('../util/mongo')
 const {validPayload} = require('../util/payload')
 const position = require('./position')
 
-const createSchema = Joi.object().keys({
-  numero: Joi.number().min(0).max(9999).integer().required(),
-  suffixe: Joi.string().regex(/^[a-z\d]+$/i).max(9).allow(null),
-  comment: Joi.string().max(5000).allow(null),
-  positions: Joi.array().items(
-    position.createSchema
-  ),
-  toponyme: Joi.string().custom(validObjectID).allow(null),
-  parcelles: Joi.array().items(
-    Joi.string().regex(/^[A-Z\d]+$/).length(14)
-  ).default([]),
-  certifie: Joi.boolean().default(false)
-})
-
 function validObjectID(id) {
   if (id) {
     const objectID = mongo.ObjectId.createFromHexString(id)
@@ -29,6 +15,24 @@ function validObjectID(id) {
     throw new Error('ObjectId is invalid')
   }
 }
+
+const numeroValidation = Joi.number().min(0).max(9999).integer()
+const suffixeValidation = Joi.string().regex(/^[a-z\d]+$/i).max(9)
+const commentValidation = Joi.string().max(5000)
+const positionsValidation = Joi.array().items(position.createSchema)
+const toponymeValidation = Joi.string().custom(validObjectID)
+const parcellesValidation = Joi.array().items(Joi.string().regex(/^[A-Z\d]+$/).length(14)).default([])
+const certifieValidation = Joi.boolean()
+
+const createSchema = Joi.object().keys({
+  numero: numeroValidation.required(),
+  suffixe: suffixeValidation.allow(null),
+  comment: commentValidation.allow(null),
+  positions: positionsValidation,
+  toponyme: toponymeValidation.allow(null),
+  parcelles: parcellesValidation,
+  certifie: certifieValidation.default(false)
+})
 
 async function create(idVoie, payload) {
   const numero = validPayload(payload, createSchema)
@@ -133,16 +137,12 @@ function filterSensitiveFields(numero) {
 const updateSchema = Joi.object().keys({
   numero: Joi.number().min(0).max(9999).integer(),
   voie: Joi.string().custom(validObjectID),
-  suffixe: Joi.string().regex(/^[a-z\d]+$/i).max(9).allow(null),
-  comment: Joi.string().max(5000).allow(null),
-  positions: Joi.array().items(
-    position.createSchema
-  ),
-  toponyme: Joi.string().custom(validObjectID).allow(null),
-  parcelles: Joi.array().items(
-    Joi.string().regex(/^[A-Z\d]+$/).length(14)
-  ).default([]),
-  certifie: Joi.boolean()
+  suffixe: suffixeValidation.allow(null),
+  comment: commentValidation.allow(null),
+  positions: positionsValidation,
+  toponyme: toponymeValidation.allow(null),
+  parcelles: parcellesValidation,
+  certifie: certifieValidation
 })
 
 async function update(id, payload) {

--- a/lib/models/numero.js
+++ b/lib/models/numero.js
@@ -7,7 +7,7 @@ const position = require('./position')
 
 const createSchema = Joi.object().keys({
   numero: Joi.number().min(0).max(9999).integer().required(),
-  suffixe: Joi.string().regex(/^[a-z\d]+$/i).max(10).allow(null),
+  suffixe: Joi.string().regex(/^[a-z\d]+$/i).max(9).allow(null),
   comment: Joi.string().max(5000).allow(null),
   positions: Joi.array().items(
     position.createSchema
@@ -133,7 +133,7 @@ function filterSensitiveFields(numero) {
 const updateSchema = Joi.object().keys({
   numero: Joi.number().min(0).max(9999).integer(),
   voie: Joi.string().custom(validObjectID),
-  suffixe: Joi.string().regex(/^[a-z\d]+$/i).max(10).allow(null),
+  suffixe: Joi.string().regex(/^[a-z\d]+$/i).max(9).allow(null),
   comment: Joi.string().max(5000).allow(null),
   positions: Joi.array().items(
     position.createSchema

--- a/lib/models/toponyme.js
+++ b/lib/models/toponyme.js
@@ -5,14 +5,13 @@ const {getFilteredPayload} = require('../util/payload')
 const position = require('./position')
 const {cleanNom} = require('./voie')
 
+const positionsValidation = Joi.array().items(position.createSchema)
+const parcellesValidation = Joi.array().items(Joi.string().regex(/^[A-Z\d]+$/).length(14)).default([])
+
 const createSchema = Joi.object().keys({
   nom: Joi.string().min(1).max(200).required(),
-  positions: Joi.array().items(
-    position.createSchema
-  ),
-  parcelles: Joi.array().items(
-    Joi.string().regex(/^[A-Z\d]+$/).length(14)
-  ).default([])
+  positions: positionsValidation,
+  parcelles: parcellesValidation
 })
 
 async function create(idBal, codeCommune, payload) {
@@ -43,12 +42,8 @@ async function create(idBal, codeCommune, payload) {
 
 const updateSchema = Joi.object().keys({
   nom: Joi.string().min(1).max(200),
-  positions: Joi.array().items(
-    position.createSchema
-  ),
-  parcelles: Joi.array().items(
-    Joi.string().regex(/^[A-Z\d]+$/).length(14)
-  ).default([])
+  positions: positionsValidation,
+  parcelles: parcellesValidation
 })
 
 async function update(id, payload) {

--- a/lib/models/voie.js
+++ b/lib/models/voie.js
@@ -9,7 +9,7 @@ function cleanNom(nom) {
 }
 
 const createSchema = Joi.object().keys({
-  nom: Joi.string().min(1).max(200).required(),
+  nom: Joi.string().min(3).max(200).required(),
   typeNumerotation: Joi.string().valid('numerique', 'metrique'),
   trace: Joi.object({
     type: Joi.string().valid('LineString').required(),
@@ -87,7 +87,7 @@ async function importMany(idBal, rawVoies, options = {}) {
 }
 
 const updateSchema = Joi.object().keys({
-  nom: Joi.string().min(1).max(200),
+  nom: Joi.string().min(3).max(200),
   code: Joi.string().regex(/^[\dA-Z]\d{3}$/).allow(null),
   typeNumerotation: Joi.string().valid('numerique', 'metrique'),
   trace: Joi.object({

--- a/lib/models/voie.js
+++ b/lib/models/voie.js
@@ -8,8 +8,10 @@ function cleanNom(nom) {
   return nom.replace(/^\s+/g, '').replace(/\s+$/g, '').replace(/\s\s+/g, ' ')
 }
 
+const nomValidation = Joi.string().min(3).max(200)
+
 const createSchema = Joi.object().keys({
-  nom: Joi.string().min(3).max(200).required(),
+  nom: nomValidation.required(),
   typeNumerotation: Joi.string().valid('numerique', 'metrique'),
   trace: Joi.object({
     type: Joi.string().valid('LineString').required(),
@@ -87,7 +89,7 @@ async function importMany(idBal, rawVoies, options = {}) {
 }
 
 const updateSchema = Joi.object().keys({
-  nom: Joi.string().min(3).max(200),
+  nom: nomValidation,
   code: Joi.string().regex(/^[\dA-Z]\d{3}$/).allow(null),
   typeNumerotation: Joi.string().valid('numerique', 'metrique'),
   trace: Joi.object({


### PR DESCRIPTION
## Contexte
Il est apparu que les schémas de validation de l'API pouvaient être différents de ceux demandés par le format BAL.

## Correction
Cette PR corrige :
- le nombre de caractères minimal du nom d'une voie à 3
- le nombre de caractères maximum du suffixe d'un numéro à 9

Corrige [Mes Adresses #562](https://github.com/BaseAdresseNationale/mes-adresses/issues/562) et [Mes Adresses #492](https://github.com/BaseAdresseNationale/mes-adresses/issues/492)