### PR TITLE
Remplace les messages de validation Joi par ceux du Validateur BAL

### DIFF
--- a/lib/models/__tests__/base-locale.schema.js
+++ b/lib/models/__tests__/base-locale.schema.js
@@ -46,7 +46,7 @@ test('not valid payload: nom over 200 caracters', t => {
 
   const {error} = createSchema.validate(baseLocale)
 
-  t.true(error.message.includes('"nom" length must be less than or equal to 200 characters long'))
+  t.is(error.message, 'Le nom est trop long (200 caractères maximum)')
 })
 
 test('not valid payload: empty emails array', t => {

--- a/lib/models/__tests__/numero.schema.js
+++ b/lib/models/__tests__/numero.schema.js
@@ -1,3 +1,4 @@
+const {getLabel} = require('@etalab/bal')
 const test = require('ava')
 const mongo = require('../../util/mongo')
 const {createSchema, updateSchema, expandModel, normalizeSuffixe} = require('../numero')
@@ -73,8 +74,8 @@ test('not valid payload: numero invalid', t => {
   const string = createSchema.validate({numero: '42'})
 
   t.is(zero.error, undefined)
-  t.true(negative.error.message.includes('must be greater than or equal to 0'))
-  t.true(tenTousand.error.message.includes('must be less than or equal to 9999'))
+  t.is(negative.error.message, getLabel('numero.trop_grand'))
+  t.is(tenTousand.error.message, getLabel('numero.trop_grand'))
   t.is(string.value.numero, 42)
 })
 

--- a/lib/models/__tests__/toponyme.schema.js
+++ b/lib/models/__tests__/toponyme.schema.js
@@ -34,7 +34,7 @@ test('not valid payload: nom over 200 caracters', t => {
 
   const {error} = createSchema.validate(toponyme)
 
-  t.true(error.message.includes('"nom" length must be less than or equal to 200 characters long'))
+  t.is(error.message, 'Le nom est trop long (200 caractères maximum)')
 })
 
 test('not valid payload: nom missing', t => {

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -20,7 +20,7 @@ const Numero = require('./numero')
 const Toponyme = require('./toponyme')
 
 const nomValidation = Joi.string()
-  .min(1).message('Le nom est trop court (1 caractères minimum)')
+  .min(1).message('Le nom est trop court (1 caractère minimum)')
   .max(200).message('Le nom est trop long (200 caractères maximum)')
 const emailsValidation = Joi.array().min(1).items(Joi.string().email())
 

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -19,7 +19,9 @@ const Voie = require('./voie')
 const Numero = require('./numero')
 const Toponyme = require('./toponyme')
 
-const nomValidation = Joi.string().min(1).max(200)
+const nomValidation = Joi.string()
+  .min(1).message('Le nom est trop court (1 caractères minimum)')
+  .max(200).message('Le nom est trop long (200 caractères maximum)')
 const emailsValidation = Joi.array().min(1).items(Joi.string().email())
 
 const createSchema = Joi.object().keys({

--- a/lib/models/numero.js
+++ b/lib/models/numero.js
@@ -27,7 +27,7 @@ const suffixeValidation = Joi.string()
   .regex(/^[a-z\d]+$/i).message(getLabel('suffixe.debut_invalide'))
   .max(9).message(getLabel('suffixe.trop_long'))
 
-const commentValidation = Joi.string().max(5000).message('Le commentiare est trop long (200 caractères maximum)')
+const commentValidation = Joi.string().max(5000).message('Le commentiare est trop long (5000 caractères maximum)')
 const positionsValidation = Joi.array().items(position.createSchema)
 const toponymeValidation = Joi.string().custom(validObjectID)
 const parcellesValidation = Joi.array().items(Joi.string().regex(/^[A-Z\d]+$/).length(14)).default([])

--- a/lib/models/numero.js
+++ b/lib/models/numero.js
@@ -1,6 +1,7 @@
 const Joi = require('joi')
 const {uniqBy, omit} = require('lodash')
 const createError = require('http-errors')
+const {getLabel} = require('@etalab/bal')
 const {getFilteredPayload} = require('../util/payload')
 const mongo = require('../util/mongo')
 const {validPayload} = require('../util/payload')
@@ -17,9 +18,16 @@ function validObjectID(id) {
   }
 }
 
-const numeroValidation = Joi.number().min(0).max(9999).integer()
-const suffixeValidation = Joi.string().regex(/^[a-z\d]+$/i).max(9)
-const commentValidation = Joi.string().max(5000)
+const numeroValidation = Joi.number()
+  .min(0).message(getLabel('numero.trop_grand'))
+  .max(9999).message(getLabel('numero.trop_grand'))
+  .integer().message(getLabel('numero.type_invalide'))
+
+const suffixeValidation = Joi.string()
+  .regex(/^[a-z\d]+$/i).message(getLabel('suffixe.debut_invalide'))
+  .max(9).message(getLabel('suffixe.trop_long'))
+
+const commentValidation = Joi.string().max(5000).message('Le commentiare est trop long (200 caractères maximum)')
 const positionsValidation = Joi.array().items(position.createSchema)
 const toponymeValidation = Joi.string().custom(validObjectID)
 const parcellesValidation = Joi.array().items(Joi.string().regex(/^[A-Z\d]+$/).length(14)).default([])

--- a/lib/models/toponyme.js
+++ b/lib/models/toponyme.js
@@ -6,7 +6,7 @@ const position = require('./position')
 const {cleanNom} = require('./voie')
 
 const nomValidation = Joi.string()
-  .min(1).message('Le nom est trop court (1 caractères minimum)')
+  .min(1).message('Le nom est trop court (1 caractère minimum)')
   .max(200).message('Le nom est trop long (200 caractères maximum)')
 
 const positionsValidation = Joi.array().items(position.createSchema)

--- a/lib/models/toponyme.js
+++ b/lib/models/toponyme.js
@@ -5,11 +5,15 @@ const {getFilteredPayload} = require('../util/payload')
 const position = require('./position')
 const {cleanNom} = require('./voie')
 
+const nomValidation = Joi.string()
+  .min(1).message('Le nom est trop court (1 caractères minimum)')
+  .max(200).message('Le nom est trop long (200 caractères maximum)')
+
 const positionsValidation = Joi.array().items(position.createSchema)
 const parcellesValidation = Joi.array().items(Joi.string().regex(/^[A-Z\d]+$/).length(14)).default([])
 
 const createSchema = Joi.object().keys({
-  nom: Joi.string().min(1).max(200).required(),
+  nom: nomValidation.required(),
   positions: positionsValidation,
   parcelles: parcellesValidation
 })
@@ -41,7 +45,7 @@ async function create(idBal, codeCommune, payload) {
 }
 
 const updateSchema = Joi.object().keys({
-  nom: Joi.string().min(1).max(200),
+  nom: nomValidation,
   positions: positionsValidation,
   parcelles: parcellesValidation
 })

--- a/lib/models/voie.js
+++ b/lib/models/voie.js
@@ -1,4 +1,5 @@
 const Joi = require('joi')
+const {getLabel} = require('@etalab/bal')
 const {getFilteredPayload} = require('../util/payload')
 const mongo = require('../util/mongo')
 const {validPayload} = require('../util/payload')
@@ -8,7 +9,9 @@ function cleanNom(nom) {
   return nom.replace(/^\s+/g, '').replace(/\s+$/g, '').replace(/\s\s+/g, ' ')
 }
 
-const nomValidation = Joi.string().min(3).max(200)
+const nomValidation = Joi.string()
+  .min(3).message(getLabel('voie_nom.trop_court'))
+  .max(200).message(getLabel('voie_nom.trop_long'))
 
 const createSchema = Joi.object().keys({
   nom: nomValidation.required(),


### PR DESCRIPTION
## Contexte
Les schémas de validation des différents modèles (base-locale, voie, toponyme, numéro, etc) renvois actuellement des messages d'erreur prédéfinis et en anglais.
Afin de garder une interface entièrement en français, ces messages ne sont pas affichés dans l'éditeur et prive l'utilisateur de comprendre une erreur de validation quand celle-ci arrive.

## Évolutions
Lorsqu'ils correspondent à une erreur que peut faire l'utilisateur depuis un formulaire, alors les messages d'erreur on était remplacés par de nouveaux messages en français.
De plus, si ces erreurs correspondent à une validation du format BAL, alors c'est l'erreur du Validateur BAL qui est renvoyée.

Ces messages ont pour objectif de pouvoir être afficher dans les différents formulaires de l'éditeur.

**Exemple**:
![Capture d’écran 2022-04-28 à 15 08 22](https://user-images.githubusercontent.com/7040549/165759203-3ffe2ab0-1b34-4ad0-bf4a-20a5e2c607c2.png)
