### PR TITLE
Mise à jour de got en v11.8.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "express": "^4.17.2",
     "geojson-vt": "^3.2.1",
     "get-stream": "^6.0.1",
-    "got": "^11.8.3",
+    "got": "^11.8.5",
     "hasha": "^5.2.2",
     "http-errors": "^2.0.0",
     "into-stream": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2838,10 +2838,10 @@ globby@^12.0.2:
     merge2 "^1.4.1"
     slash "^4.0.0"
 
-got@^11.8.3:
-  version "11.8.3"
-  resolved "https://registry.yarnpkg.com/got/-/got-11.8.3.tgz#f496c8fdda5d729a90b4905d2b07dbd148170770"
-  integrity sha512-7gtQ5KiPh1RtGS9/Jbv1ofDpBFuq42gyfEib+ejaRBJuj/3tQFeR5+gw57e4ipaU8c/rCjvX6fkQz2lyDlGAOg==
+got@^11.8.5:
+  version "11.8.5"
+  resolved "https://registry.yarnpkg.com/got/-/got-11.8.5.tgz#ce77d045136de56e8f024bebb82ea349bc730046"
+  integrity sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==
   dependencies:
     "@sindresorhus/is" "^4.0.0"
     "@szmarczak/http-timer" "^4.0.5"


### PR DESCRIPTION
## Contexte
Mise à jour de got de `v11.8.3` à `v11.8.5`