### PR TITLE
Ajoute la propriété `isCom` à la route commune

### DIFF
--- a/lib/cadastre.js
+++ b/lib/cadastre.js
@@ -1,7 +1,7 @@
 const cadastre = require('../cadastre-communes.json')
 
-function checkCadastre(communeCode) {
+function checkHasCadastre(communeCode) {
   return cadastre.includes(communeCode)
 }
 
-module.exports = {checkCadastre}
+module.exports = {checkHasCadastre}

--- a/lib/com.js
+++ b/lib/com.js
@@ -1,8 +1,8 @@
-function checkCOM(communeCode) {
+function checkIsCOM(communeCode) {
   const prefix2 = communeCode.slice(0, 2)
   const prefix3 = communeCode.slice(0, 3)
 
   return prefix2 > '97' || (prefix2 === '97' && !['971', '972', '973', '974', '976'].includes(prefix3))
 }
 
-module.exports = {checkCOM}
+module.exports = {checkIsCOM}

--- a/lib/com.js
+++ b/lib/com.js
@@ -1,0 +1,8 @@
+function isCOM(communeCode) {
+  const prefix2 = communeCode.slice(0, 2)
+  const prefix3 = communeCode.slice(0, 3)
+
+  return prefix2 > '97' || (prefix2 === '97' && !['971', '972', '973', '974', '976'].includes(prefix3))
+}
+
+module.exports = {isCOM}

--- a/lib/com.js
+++ b/lib/com.js
@@ -1,8 +1,8 @@
-function isCOM(communeCode) {
+function checkCOM(communeCode) {
   const prefix2 = communeCode.slice(0, 2)
   const prefix3 = communeCode.slice(0, 3)
 
   return prefix2 > '97' || (prefix2 === '97' && !['971', '972', '973', '974', '976'].includes(prefix3))
 }
 
-module.exports = {isCOM}
+module.exports = {checkCOM}

--- a/lib/routes/__tests__/commune.js
+++ b/lib/routes/__tests__/commune.js
@@ -32,3 +32,19 @@ test('Not a commune code', async t => {
   t.is(status, 404)
   t.deepEqual(body, {code: 404, message: 'Commune inconnue'})
 })
+
+test('Commune not in COM', async t => {
+  const {status, body} = await request(getApp())
+    .get('/commune/57463')
+
+  t.is(status, 200)
+  t.false(body.isCom)
+})
+
+test('Commune is COM', async t => {
+  const {status, body} = await request(getApp())
+    .get('/commune/97502')
+
+  t.is(status, 200)
+  t.true(body.isCom)
+})

--- a/lib/routes/__tests__/commune.js
+++ b/lib/routes/__tests__/commune.js
@@ -3,6 +3,8 @@ const express = require('express')
 const request = require('supertest')
 const routes = require('../')
 
+const KEYS = ['hasCadastre', 'isCOM']
+
 function getApp() {
   const app = express()
   app.use(routes)
@@ -12,8 +14,6 @@ function getApp() {
 test('Call commune route', async t => {
   const {status, body} = await request(getApp())
     .get('/commune/38095')
-
-  const KEYS = ['hasCadastre', 'isCOM']
 
   t.is(status, 200)
   t.true(KEYS.every(k => k in body))

--- a/lib/routes/__tests__/commune.js
+++ b/lib/routes/__tests__/commune.js
@@ -9,20 +9,15 @@ function getApp() {
   return app
 }
 
-test('Commune with cadastre', async t => {
+test('Call commune route', async t => {
   const {status, body} = await request(getApp())
     .get('/commune/38095')
 
-  t.is(status, 200)
-  t.true(body.hasCadastre)
-})
-
-test('Commune without cadastre', async t => {
-  const {status, body} = await request(getApp())
-    .get('/commune/29084')
+  const KEYS = ['hasCadastre', 'isCOM']
 
   t.is(status, 200)
-  t.false(body.hasCadastre)
+  t.true(KEYS.every(k => k in body))
+  t.is(KEYS.length, Object.keys(body).length)
 })
 
 test('Not a commune code', async t => {
@@ -31,20 +26,4 @@ test('Not a commune code', async t => {
 
   t.is(status, 404)
   t.deepEqual(body, {code: 404, message: 'Commune inconnue'})
-})
-
-test('Commune not in COM', async t => {
-  const {status, body} = await request(getApp())
-    .get('/commune/57463')
-
-  t.is(status, 200)
-  t.false(body.isCom)
-})
-
-test('Commune is COM', async t => {
-  const {status, body} = await request(getApp())
-    .get('/commune/97502')
-
-  t.is(status, 200)
-  t.true(body.isCom)
 })

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -10,8 +10,8 @@ const errorHandler = require('../util/error-handler')
 const {getCommune} = require('../util/cog')
 const sync = require('../sync')
 const {createHabilitation, sendPinCode, validatePinCode, fetchHabilitation} = require('../habilitations')
-const {checkCadastre} = require('../cadastre')
-const {checkCOM} = require('../com')
+const {checkHasCadastre} = require('../cadastre')
+const {checkIsCOM} = require('../com')
 const stats = require('./stats')
 const adminRoutes = require('./admin')
 
@@ -445,8 +445,8 @@ app.route('/toponymes/:toponymeId/numeros')
 app.route('/commune/:codeCommune')
   .get(w(async (req, res) => {
     if (getCommune(req.params.codeCommune)) {
-      const hasCadastre = await checkCadastre(req.params.codeCommune)
-      const isCOM = await checkCOM(req.params.codeCommune)
+      const hasCadastre = await checkHasCadastre(req.params.codeCommune)
+      const isCOM = await checkIsCOM(req.params.codeCommune)
 
       res.send({hasCadastre, isCOM})
     } else {

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -11,7 +11,7 @@ const {getCommune} = require('../util/cog')
 const sync = require('../sync')
 const {createHabilitation, sendPinCode, validatePinCode, fetchHabilitation} = require('../habilitations')
 const {checkCadastre} = require('../cadastre')
-const {isCOM} = require('../com')
+const {checkCOM} = require('../com')
 const stats = require('./stats')
 const adminRoutes = require('./admin')
 
@@ -446,9 +446,9 @@ app.route('/commune/:codeCommune')
   .get(w(async (req, res) => {
     if (getCommune(req.params.codeCommune)) {
       const hasCadastre = await checkCadastre(req.params.codeCommune)
-      const isCom = await isCOM(req.params.codeCommune)
+      const isCOM = await checkCOM(req.params.codeCommune)
 
-      res.send({hasCadastre, isCom})
+      res.send({hasCadastre, isCOM})
     } else {
       throw createError(404, 'Commune inconnue')
     }

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -11,6 +11,7 @@ const {getCommune} = require('../util/cog')
 const sync = require('../sync')
 const {createHabilitation, sendPinCode, validatePinCode, fetchHabilitation} = require('../habilitations')
 const {checkCadastre} = require('../cadastre')
+const {isCOM} = require('../com')
 const stats = require('./stats')
 const adminRoutes = require('./admin')
 
@@ -445,8 +446,9 @@ app.route('/commune/:codeCommune')
   .get(w(async (req, res) => {
     if (getCommune(req.params.codeCommune)) {
       const hasCadastre = await checkCadastre(req.params.codeCommune)
+      const isCom = await isCOM(req.params.codeCommune)
 
-      res.send({hasCadastre})
+      res.send({hasCadastre, isCom})
     } else {
       throw createError(404, 'Commune inconnue')
     }

--- a/lib/util/__tests__/cadastre.js
+++ b/lib/util/__tests__/cadastre.js
@@ -1,14 +1,14 @@
 const test = require('ava')
-const {checkCadastre} = require('../../cadastre')
+const {checkHasCadastre} = require('../../cadastre')
 
 test('Commune with cadastre', t => {
-  const communeWithCadastre = checkCadastre('38095')
+  const communeWithCadastre = checkHasCadastre('38095')
 
   t.true(communeWithCadastre)
 })
 
 test('Commune without cadastre', t => {
-  const communeWithoutCadastre = checkCadastre('29084')
+  const communeWithoutCadastre = checkHasCadastre('29084')
 
   t.false(communeWithoutCadastre)
 })

--- a/lib/util/__tests__/com.js
+++ b/lib/util/__tests__/com.js
@@ -1,14 +1,14 @@
 const test = require('ava')
-const {isCOM} = require('../../com')
+const {checkCOM} = require('../../com')
 
 test('Commune from COM', t => {
-  const communeCOM = isCOM('97502')
+  const communeCOM = checkCOM('97502')
 
   t.true(communeCOM)
 })
 
 test('Commune not from COM', t => {
-  const communeNotFromCOM = isCOM('57463')
+  const communeNotFromCOM = checkCOM('57463')
 
   t.false(communeNotFromCOM)
 })

--- a/lib/util/__tests__/com.js
+++ b/lib/util/__tests__/com.js
@@ -1,14 +1,14 @@
 const test = require('ava')
-const {checkCOM} = require('../../com')
+const {checkIsCOM} = require('../../com')
 
 test('Commune from COM', t => {
-  const communeCOM = checkCOM('97502')
+  const communeCOM = checkIsCOM('97502')
 
   t.true(communeCOM)
 })
 
 test('Commune not from COM', t => {
-  const communeNotFromCOM = checkCOM('57463')
+  const communeNotFromCOM = checkIsCOM('57463')
 
   t.false(communeNotFromCOM)
 })

--- a/lib/util/__tests__/com.js
+++ b/lib/util/__tests__/com.js
@@ -1,0 +1,14 @@
+const test = require('ava')
+const {isCOM} = require('../../com')
+
+test('Commune from COM', t => {
+  const communeCOM = isCOM('97502')
+
+  t.true(communeCOM)
+})
+
+test('Commune not from COM', t => {
+  const communeNotFromCOM = isCOM('57463')
+
+  t.false(communeNotFromCOM)
+})


### PR DESCRIPTION
Cette PR propose d’ajouter la propriété `isCom` à la route `/commune` .

Cette propriété permet d’identifier si la commune fait partie des [Collectivités d’Outre-Mer](https://fr.wikipedia.org/wiki/Collectivit%C3%A9_d%27outre-mer).

La route `/commune/{codeCommune}` renverra donc un objet : 
```json
{
    "hasCadastre": false,
    "isCom": true
}
```

- Ajout de la fonction isCOM
- Ajout de la fonction isCOM à la route `/commune` 
- Mise à jour des tests

