### PR TITLE
Gestion des communes sans adresse connue

### DIFF
--- a/lib/populate/extract-ban.js
+++ b/lib/populate/extract-ban.js
@@ -84,7 +84,12 @@ async function extract(codeCommune) {
     return data
   }
 
-  return extractFromBAN(codeCommune)
+  try {
+    const dataBAN = await extractFromBAN(codeCommune)
+    return dataBAN
+  } catch {}
+
+  return {voies: [], numeros: [], toponymes: []}
 }
 
 module.exports = {extract, extractFromBAN}

--- a/lib/populate/extract-ban.js
+++ b/lib/populate/extract-ban.js
@@ -87,9 +87,10 @@ async function extract(codeCommune) {
   try {
     const dataBAN = await extractFromBAN(codeCommune)
     return dataBAN
-  } catch {}
-
-  return {voies: [], numeros: [], toponymes: []}
+  } catch {
+    console.error(`Aucune adresse n’a pu être extraite avec le code commune: ${codeCommune}`)
+    return {voies: [], numeros: [], toponymes: []}
+  }
 }
 
 module.exports = {extract, extractFromBAN}


### PR DESCRIPTION
## Contexte
Certaines communes, les Collectivités d’Outre-Mer notamment, ne disposent d'aucune adresse pouvant être extraite depuis l'API de dépôt ou de Base Adresse Nationale.
Pour ces communes, il n'est pas possible d'utiliser la fonctionnalité `populate` permettant d'initialiser une Base Adresse Locale avec des adresses déjà connues. 

Ce cas n'est actuellement pas géré et provoque une erreur.

## Évolution
Cette PR propose de résoudre simplement le cas où aucune adresse n'est trouvée en renvoyant `{voies: [], numeros: [], toponymes: []}` comme valeur par défaut.