### PR TITLE
Vérifie la présence des styles de cartes

### DIFF
--- a/com-maps-styles.json
+++ b/com-maps-styles.json
@@ -1,0 +1,38 @@
+[
+  {
+    "code": "975",
+    "hasOpenMapTiles": true,
+    "hasOrtho": true,
+    "hasPlanIGN": false
+  },
+  {
+    "code": "977",
+    "hasOpenMapTiles": true,
+    "hasOrtho": true,
+    "hasPlanIGN": true
+  },
+  {
+    "code": "978",
+    "hasOpenMapTiles": true,
+    "hasOrtho": true,
+    "hasPlanIGN": true
+  },
+  {
+    "code": "986",
+    "hasOpenMapTiles": true,
+    "hasOrtho": true,
+    "hasPlanIGN": false
+  },
+  {
+    "code": "987",
+    "hasOpenMapTiles": true,
+    "hasOrtho": false,
+    "hasPlanIGN": false
+  },
+  {
+    "code": "988",
+    "hasOpenMapTiles": true,
+    "hasOrtho": false,
+    "hasPlanIGN": false
+  }
+]

--- a/lib/com.js
+++ b/lib/com.js
@@ -1,3 +1,5 @@
+const mapsStyles = require('../com-maps-styles.json')
+
 function checkIsCOM(communeCode) {
   const prefix2 = communeCode.slice(0, 2)
   const prefix3 = communeCode.slice(0, 3)
@@ -5,4 +7,31 @@ function checkIsCOM(communeCode) {
   return prefix2 > '97' || (prefix2 === '97' && !['971', '972', '973', '974', '976'].includes(prefix3))
 }
 
-module.exports = {checkIsCOM}
+function getMapStyle(isCOM, compute) {
+  if (!isCOM) {
+    return true
+  }
+
+  return compute()
+}
+
+function computeHasMapsStyle(codeCommune, mapStyle) {
+  const codeCOM = codeCommune.slice(0, 3)
+
+  return mapsStyles.find(({code}) => code === codeCOM)[mapStyle]
+}
+
+function checkHasMapsStyles(codeCommune, isCOM) {
+  const mapsStyles = ['hasOpenMapTiles', 'hasOrtho', 'hasPlanIGN']
+  const hasMapsStyles = {}
+
+  for (const mapStyle of mapsStyles) {
+    Object.assign(hasMapsStyles, {
+      [mapStyle]: getMapStyle(isCOM, () => computeHasMapsStyle(codeCommune, mapStyle))}
+    )
+  }
+
+  return hasMapsStyles
+}
+
+module.exports = {checkIsCOM, checkHasMapsStyles}

--- a/lib/routes/__tests__/commune.js
+++ b/lib/routes/__tests__/commune.js
@@ -16,9 +16,9 @@ test('Call commune route', async t => {
     .get('/commune/38095')
 
   t.is(status, 200)
-  t.is(body.hasOpenMapTiles, true)
-  t.is(body.hasOrtho, true)
-  t.is(body.hasPlanIGN, true)
+  t.true(typeof body.hasOpenMapTiles === 'boolean')
+  t.true(typeof body.hasOrtho === 'boolean')
+  t.true(typeof body.hasPlanIGN === 'boolean')
   t.true(KEYS.every(k => k in body))
   t.is(KEYS.length, Object.keys(body).length)
 })
@@ -31,26 +31,26 @@ test('Not a commune code', async t => {
   t.deepEqual(body, {code: 404, message: 'Commune inconnue'})
 })
 
-test('Call commune route / COM with code start by 975', async t => {
+test('Call commune route / COM with code starting by 975', async t => {
   const {status, body} = await request(getApp())
     .get('/commune/97501')
 
   t.is(status, 200)
-  t.is(body.hasOpenMapTiles, true)
-  t.is(body.hasOrtho, true)
-  t.is(body.hasPlanIGN, false)
+  t.true(typeof body.hasOpenMapTiles === 'boolean')
+  t.true(typeof body.hasOrtho === 'boolean')
+  t.true(typeof body.hasPlanIGN === 'boolean')
   t.true(KEYS.every(k => k in body))
   t.is(KEYS.length, Object.keys(body).length)
 })
 
-test('Call commune route / COM with code start by 988', async t => {
+test('Call commune route / COM with code starting by 988', async t => {
   const {status, body} = await request(getApp())
     .get('/commune/98801')
 
   t.is(status, 200)
-  t.is(body.hasOpenMapTiles, true)
-  t.is(body.hasOrtho, false)
-  t.is(body.hasPlanIGN, false)
+  t.true(typeof body.hasOpenMapTiles === 'boolean')
+  t.true(typeof body.hasOrtho === 'boolean')
+  t.true(typeof body.hasPlanIGN === 'boolean')
   t.true(KEYS.every(k => k in body))
   t.is(KEYS.length, Object.keys(body).length)
 })

--- a/lib/routes/__tests__/commune.js
+++ b/lib/routes/__tests__/commune.js
@@ -3,7 +3,7 @@ const express = require('express')
 const request = require('supertest')
 const routes = require('../')
 
-const KEYS = ['hasCadastre', 'isCOM']
+const KEYS = ['hasCadastre', 'isCOM', 'hasOpenMapTiles', 'hasOrtho', 'hasPlanIGN']
 
 function getApp() {
   const app = express()
@@ -16,6 +16,9 @@ test('Call commune route', async t => {
     .get('/commune/38095')
 
   t.is(status, 200)
+  t.is(body.hasOpenMapTiles, true)
+  t.is(body.hasOrtho, true)
+  t.is(body.hasPlanIGN, true)
   t.true(KEYS.every(k => k in body))
   t.is(KEYS.length, Object.keys(body).length)
 })
@@ -26,4 +29,28 @@ test('Not a commune code', async t => {
 
   t.is(status, 404)
   t.deepEqual(body, {code: 404, message: 'Commune inconnue'})
+})
+
+test('Call commune route / COM with code start by 975', async t => {
+  const {status, body} = await request(getApp())
+    .get('/commune/97501')
+
+  t.is(status, 200)
+  t.is(body.hasOpenMapTiles, true)
+  t.is(body.hasOrtho, true)
+  t.is(body.hasPlanIGN, false)
+  t.true(KEYS.every(k => k in body))
+  t.is(KEYS.length, Object.keys(body).length)
+})
+
+test('Call commune route / COM with code start by 988', async t => {
+  const {status, body} = await request(getApp())
+    .get('/commune/98801')
+
+  t.is(status, 200)
+  t.is(body.hasOpenMapTiles, true)
+  t.is(body.hasOrtho, false)
+  t.is(body.hasPlanIGN, false)
+  t.true(KEYS.every(k => k in body))
+  t.is(KEYS.length, Object.keys(body).length)
 })

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -11,7 +11,7 @@ const {getCommune} = require('../util/cog')
 const sync = require('../sync')
 const {createHabilitation, sendPinCode, validatePinCode, fetchHabilitation} = require('../habilitations')
 const {checkHasCadastre} = require('../cadastre')
-const {checkIsCOM} = require('../com')
+const {checkIsCOM, checkHasMapsStyles} = require('../com')
 const stats = require('./stats')
 const adminRoutes = require('./admin')
 
@@ -408,8 +408,9 @@ app.route('/commune/:codeCommune')
     if (getCommune(req.params.codeCommune)) {
       const hasCadastre = await checkHasCadastre(req.params.codeCommune)
       const isCOM = await checkIsCOM(req.params.codeCommune)
+      const hasMapsStyles = checkHasMapsStyles(req.params.codeCommune, isCOM)
 
-      res.send({hasCadastre, isCOM})
+      res.send({hasCadastre, isCOM, ...hasMapsStyles})
     } else {
       throw createError(404, 'Commune inconnue')
     }

--- a/lib/util/__tests__/com.js
+++ b/lib/util/__tests__/com.js
@@ -1,5 +1,5 @@
 const test = require('ava')
-const {checkIsCOM} = require('../../com')
+const {checkIsCOM, checkHasMapsStyles} = require('../../com')
 
 test('Commune from COM', t => {
   const communeCOM = checkIsCOM('97502')
@@ -11,4 +11,67 @@ test('Commune not from COM', t => {
   const communeNotFromCOM = checkIsCOM('57463')
 
   t.false(communeNotFromCOM)
+})
+
+test('Check commune maps styles / commune not from COM', t => {
+  const isCOM = checkIsCOM('57463')
+  const communeNotFromCOM = checkHasMapsStyles('57463', isCOM)
+
+  t.is(communeNotFromCOM.hasOpenMapTiles, true)
+  t.is(communeNotFromCOM.hasOrtho, true)
+  t.is(communeNotFromCOM.hasPlanIGN, true)
+})
+
+test('Check commune maps styles / COM with code starting by 975', t => {
+  const isCOM = checkIsCOM('97502')
+  const communeFromCOM = checkHasMapsStyles('97502', isCOM)
+
+  t.is(communeFromCOM.hasOpenMapTiles, true)
+  t.is(communeFromCOM.hasOrtho, true)
+  t.is(communeFromCOM.hasPlanIGN, false)
+})
+
+test('Check commune maps styles / COM with code starting by 977', t => {
+  const isCOM = checkIsCOM('97701')
+  const communeFromCOM = checkHasMapsStyles('97701', isCOM)
+
+  t.is(communeFromCOM.hasOpenMapTiles, true)
+  t.is(communeFromCOM.hasOrtho, true)
+  t.is(communeFromCOM.hasPlanIGN, true)
+})
+
+test('Check commune maps styles / COM with code starting by 978', t => {
+  const isCOM = checkIsCOM('97802')
+  const communeFromCOM = checkHasMapsStyles('97802', isCOM)
+
+  t.is(communeFromCOM.hasOpenMapTiles, true)
+  t.is(communeFromCOM.hasOrtho, true)
+  t.is(communeFromCOM.hasPlanIGN, true)
+})
+
+test('Check commune maps styles / COM with code starting by 986', t => {
+  const isCOM = checkIsCOM('98601')
+  const communeFromCOM = checkHasMapsStyles('98601', isCOM)
+
+  t.is(communeFromCOM.hasOpenMapTiles, true)
+  t.is(communeFromCOM.hasOrtho, true)
+  t.is(communeFromCOM.hasPlanIGN, false)
+})
+
+test('Check commune maps styles / COM with code starting by 987', t => {
+  const isCOM = checkIsCOM('98702')
+  const communeFromCOM = checkHasMapsStyles('98702', isCOM)
+
+  t.is(communeFromCOM.hasOpenMapTiles, true)
+  t.is(communeFromCOM.hasOrtho, false)
+  t.is(communeFromCOM.hasPlanIGN, false)
+})
+
+test('Check commune maps styles / COM with code starting by 988', t => {
+  const isCOM = checkIsCOM('98801')
+  const communeFromCOM = checkHasMapsStyles('98801', isCOM)
+
+  t.is(communeFromCOM.hasOpenMapTiles, true)
+  t.is(communeFromCOM.hasOrtho, false)
+  t.is(communeFromCOM.hasPlanIGN, false)
 })


### PR DESCRIPTION
## Évolutions
- Ajout de la liste des disponibilités des styles de carte => `com-maps-styles.json`
- Ajout de la fonction `checkHasMapsStyles` dans `lib/com`
- Mise à jour des tests
- La route `/commune/:codeCommune` retourne :
```
{
  "hasCadastre": boolean,
  "isCOM": boolean,
  "hasOpenMapTiles": boolean,
  "hasOrtho": boolean,
  "hasPlanIGN": boolean
}
```

----
## En lien avec la [PR mes-adresses #611](https://github.com/BaseAdresseNationale/mes-adresses/pull/611)