### PR TITLE
Modif count() par countDocuments

### DIFF
--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -402,8 +402,8 @@ async function getAssignedParcelles(balId) {
 }
 
 async function getNumerosCount(idBal) {
-  const nbNumeros = await mongo.db.collection('numeros').find({_bal: mongo.parseObjectID(idBal)}).count()
-  const nbNumerosCertifies = await mongo.db.collection('numeros').find({_bal: mongo.parseObjectID(idBal), certifie: true}).count()
+  const nbNumeros = await mongo.db.collection('numeros').countDocuments({_bal: mongo.parseObjectID(idBal)})
+  const nbNumerosCertifies = await mongo.db.collection('numeros').countDocuments({_bal: mongo.parseObjectID(idBal), certifie: true})
 
   return {nbNumeros, nbNumerosCertifies}
 }

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -353,10 +353,10 @@ async function publishedBasesLocalesStats(codesCommunes = null) {
   const publishedBasesLocalesIds = await mongo.db.collection('bases_locales')
     .distinct('_id', basesLocalesQuery)
 
-  const nbVoies = await mongo.db.collection('voies').count({_bal: {$in: publishedBasesLocalesIds}})
-  const nbLieuxDits = await mongo.db.collection('toponymes').count({_bal: {$in: publishedBasesLocalesIds}})
-  const nbNumeros = await mongo.db.collection('numeros').count({_bal: {$in: publishedBasesLocalesIds}})
-  const nbNumerosCertifies = await mongo.db.collection('numeros').count({_bal: {$in: publishedBasesLocalesIds}, certifie: true})
+  const nbVoies = await mongo.db.collection('voies').countDocuments({_bal: {$in: publishedBasesLocalesIds}})
+  const nbLieuxDits = await mongo.db.collection('toponymes').countDocuments({_bal: {$in: publishedBasesLocalesIds}})
+  const nbNumeros = await mongo.db.collection('numeros').countDocuments({_bal: {$in: publishedBasesLocalesIds}})
+  const nbNumerosCertifies = await mongo.db.collection('numeros').countDocuments({_bal: {$in: publishedBasesLocalesIds}, certifie: true})
 
   return {
     nbCommunes: publishedBasesLocalesIds.length,

--- a/lib/models/voie.js
+++ b/lib/models/voie.js
@@ -148,8 +148,8 @@ async function remove(id) {
 
 async function getVoie(id) {
   const voie = await mongo.db.collection('voies').findOne({_id: mongo.parseObjectID(id)})
-  const nbNumeros = await mongo.db.collection('numeros').find({voie: mongo.parseObjectID(id)}).count()
-  const nbNumerosCertifies = await mongo.db.collection('numeros').find({voie: mongo.parseObjectID(id), certifie: true}).count()
+  const nbNumeros = await mongo.db.collection('numeros').countDocuments({voie: mongo.parseObjectID(id)})
+  const nbNumerosCertifies = await mongo.db.collection('numeros').countDocuments({voie: mongo.parseObjectID(id), certifie: true})
 
   return {...voie, nbNumeros, nbNumerosCertifies}
 }


### PR DESCRIPTION
En lien avec issue #333 : 
J'ai remplacé le count() par countDocuments, il me semblait plus judicieux d'utiliser countDocuments qu'estimateDocumentCount.
Il y avait d'autres syntaxes avec le find : mongo.db.collection('numeros').find({voie: mongo.parseObjectID(id)}).count()
Je ne savais pas trop si ca concernait aussi ces cas la, si oui je ferai les modifications.