### PR TITLE
Validation des schémas de données grâce au validateur-bal

### DIFF
--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -149,10 +149,12 @@ test('update a BaseLocale', async t => {
   const baseLocale = await BaseLocale.update(_id, {
     nom: 'foo2',
     emails: ['me2@domain.co', 'me3@domain.co'],
-    status: 'ready-to-publish'
+    status: 'ready-to-publish',
+    token: 'hack'
   })
 
   t.is(baseLocale.nom, 'foo2')
+  t.is(baseLocale.token, 'coucou')
   t.deepEqual(baseLocale.emails, ['me2@domain.co', 'me3@domain.co'])
   t.is(baseLocale.status, 'ready-to-publish')
   t.is(Object.keys(baseLocale).length, 8)

--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -40,7 +40,7 @@ test('create a BaseLocale / without nom', async t => {
   const error = await t.throwsAsync(() => BaseLocale.create({commune: '27115', emails: ['me@domain.co']}))
 
   t.deepEqual(error.validation, {
-    nom: ['"nom" is required']
+    nom: ['Le champ nom est obligatoire']
   })
 
   t.is(error.message, 'Invalid payload')
@@ -50,7 +50,7 @@ test('create a BaseLocale / without commune', async t => {
   const error = await t.throwsAsync(() => BaseLocale.create({nom: 'foo', emails: ['me@domain.co']}))
 
   t.deepEqual(error.validation, {
-    commune: ['"commune" is required']
+    commune: ['Le champ commune est obligatoire']
   })
 
   t.is(error.message, 'Invalid payload')
@@ -70,7 +70,7 @@ test('create a BaseLocale / empty nom', async t => {
   const error = await t.throwsAsync(() => BaseLocale.create({nom: '', emails: ['me@domain.co'], commune: '27115'}))
 
   t.deepEqual(error.validation, {
-    nom: ['"nom" is not allowed to be empty']
+    nom: ['Le nom est trop court (1 caractère minimum)']
   })
 
   t.is(error.message, 'Invalid payload')
@@ -115,7 +115,7 @@ test('create a demo BaseLocale / no commune', async t => {
     t.fail()
   } catch (error) {
     t.deepEqual(error.validation, {
-      commune: ['"commune" is required']
+      commune: ['Le champ commune est obligatoire']
     })
 
     t.is(error.message, 'Invalid payload')
@@ -149,13 +149,11 @@ test('update a BaseLocale', async t => {
   const baseLocale = await BaseLocale.update(_id, {
     nom: 'foo2',
     emails: ['me2@domain.co', 'me3@domain.co'],
-    status: 'ready-to-publish',
-    token: 'hack'
+    status: 'ready-to-publish'
   })
 
   t.is(baseLocale.nom, 'foo2')
   t.deepEqual(baseLocale.emails, ['me2@domain.co', 'me3@domain.co'])
-  t.is(baseLocale.token, 'coucou')
   t.is(baseLocale.status, 'ready-to-publish')
   t.is(Object.keys(baseLocale).length, 8)
 })
@@ -486,11 +484,10 @@ test('batch baselocale numeros / invalid certifie', async t => {
   const idBal = new mongo.ObjectId()
 
   const error = await t.throwsAsync(() => BaseLocale.batchUpdateNumeros(idBal, {
-    numeros: [],
     certifie: 'foo'
   }))
 
   t.deepEqual(error.validation, {
-    certifie: ['"certifie" must be a boolean']
+    certifie: ['Le champ certifie doit être de type "boolean"']
   })
 })

--- a/lib/models/__tests__/base-locale.schema.js
+++ b/lib/models/__tests__/base-locale.schema.js
@@ -90,21 +90,6 @@ test('not valid payload: invalid email address', async t => {
   })
 })
 
-test('not valid payload: not allowed extra param', async t => {
-  const baseLocale = {
-    nom: 'nom',
-    emails: ['mail@domain.net'],
-    extra: 'extra-param',
-    commune: '27115'
-  }
-
-  const {error} = await validSchema(baseLocale, createSchema)
-
-  t.deepEqual(error, {
-    extra: ['Le champ extra n’est pas autorisé']
-  })
-})
-
 test('not valid payload: invalid status', async t => {
   const baseLocale = {
     status: 'invalid-status'

--- a/lib/models/__tests__/base-locale.schema.js
+++ b/lib/models/__tests__/base-locale.schema.js
@@ -1,83 +1,96 @@
 const test = require('ava')
+const {validSchema} = require('../../util/payload')
 const {createSchema, createDemoSchema, updateSchema, transformToDraftSchema} = require('../base-locale')
 
-test('valid payload', t => {
+test('valid payload', async t => {
   const baseLocale = {
     nom: 'nom',
     emails: ['mail@domain.net'],
     commune: '27115'
   }
 
-  const {error} = createSchema.validate(baseLocale)
-
-  t.is(error, undefined)
+  const {value, error} = await validSchema(baseLocale, createSchema)
+  t.deepEqual(value, baseLocale)
+  t.deepEqual(error, {})
 })
 
-test('valid payload: minimalist', t => {
+test('valid payload: minimalist', async t => {
   const baseLocale = {
     nom: 'nom',
     emails: ['mail@domain.net'],
     commune: '27115'
   }
 
-  const {error} = createSchema.validate(baseLocale)
-
-  t.is(error, undefined)
+  const {value, error} = await validSchema(baseLocale, createSchema)
+  t.deepEqual(value, baseLocale)
+  t.deepEqual(error, {})
 })
 
-test('not valid payload: no nom', t => {
+test('not valid payload: no nom', async t => {
   const baseLocale = {
     emails: ['mail@domain.net'],
     commune: '27115'
   }
 
-  const {error} = createSchema.validate(baseLocale)
+  const {error} = await validSchema(baseLocale, createSchema)
 
-  t.true(error.message.includes('"nom" is required'))
+  t.deepEqual(error, {
+    nom: ['Le champ nom est obligatoire']
+  })
 })
 
-test('not valid payload: empty object', t => {
-  const {error} = createSchema.validate({})
-  t.truthy(error)
+test('not valid payload: empty object', async t => {
+  const {error} = await validSchema({}, createSchema)
+  t.deepEqual(error, {
+    nom: ['Le champ nom est obligatoire'],
+    emails: ['Le champ emails est obligatoire'],
+    commune: ['Le champ commune est obligatoire']
+  })
 })
 
-test('not valid payload: nom over 200 caracters', t => {
+test('not valid payload: nom over 200 caracters', async t => {
   const baseLocale = {
     nom: ''.padStart(201, 'a'),
     emails: ['mail@domain.net'],
     commune: '27115'
   }
 
-  const {error} = createSchema.validate(baseLocale)
+  const {error} = await validSchema(baseLocale, createSchema)
 
-  t.is(error.message, 'Le nom est trop long (200 caractères maximum)')
+  t.deepEqual(error, {
+    nom: ['Le nom est trop long (200 caractères maximum)']
+  })
 })
 
-test('not valid payload: empty emails array', t => {
+test('not valid payload: empty emails array', async t => {
   const baseLocale = {
     nom: 'nom',
     emails: [],
     commune: '27115'
   }
 
-  const {error} = createSchema.validate(baseLocale)
+  const {error} = await validSchema(baseLocale, createSchema)
 
-  t.true(error.message.includes('"emails" must contain at least 1 items'))
+  t.deepEqual(error, {
+    emails: ['Le champ emails doit contenir au moins une adresse email']
+  })
 })
 
-test('not valid payload: invalid email address', t => {
+test('not valid payload: invalid email address', async t => {
   const baseLocale = {
     nom: 'nom',
     emails: ['invalid-mail'],
     commune: '27115'
   }
 
-  const {error} = createSchema.validate(baseLocale)
+  const {error} = await validSchema(baseLocale, createSchema)
 
-  t.true(error.message.includes('must be a valid email'))
+  t.deepEqual(error, {
+    emails: ['L’adresse email invalid-mail est invalide']
+  })
 })
 
-test('not valid payload: not allowed extra param', t => {
+test('not valid payload: not allowed extra param', async t => {
   const baseLocale = {
     nom: 'nom',
     emails: ['mail@domain.net'],
@@ -85,80 +98,79 @@ test('not valid payload: not allowed extra param', t => {
     commune: '27115'
   }
 
-  const {error} = createSchema.validate(baseLocale)
+  const {error} = await validSchema(baseLocale, createSchema)
 
-  t.is(error.message, '"extra" is not allowed')
+  t.deepEqual(error, {
+    extra: ['Le champ extra n’est pas autorisé']
+  })
 })
 
-test('not valid payload: invalid status', t => {
+test('not valid payload: invalid status', async t => {
   const baseLocale = {
     status: 'invalid-status'
   }
 
-  const {error} = updateSchema.validate(baseLocale)
+  const {error} = await validSchema(baseLocale, updateSchema)
 
-  t.true(error.message.includes('"status" must be one of [draft, ready-to-publish]'))
+  t.deepEqual(error, {
+    status: ['La valeur du champ status est incorrecte, seules "draft" et "ready-to-publish" sont autorisées']
+  })
 })
 
-test('valid demo payload / create', t => {
+test('valid demo payload / create', async t => {
   const baseLocale = {
     commune: '27115',
     populate: false
   }
 
-  const {error} = createDemoSchema.validate(baseLocale)
+  const {value, error} = await validSchema(baseLocale, createDemoSchema)
 
-  t.is(error, undefined)
+  t.deepEqual(value, baseLocale)
+  t.deepEqual(error, {})
 })
 
-test('not valid demo payload / no commune', t => {
-  const baseLocale = {
-    populate: false
-  }
+test('not valid demo payload / missing required fields', async t => {
+  const {error} = await validSchema({}, createDemoSchema)
 
-  const {error} = createDemoSchema.validate(baseLocale)
-
-  t.is(error.message, '"commune" is required')
+  t.deepEqual(error, {
+    commune: ['Le champ commune est obligatoire'],
+    populate: ['Le champ populate est obligatoire']
+  })
 })
 
-test('not valid demo payload / invalid commune', t => {
+test('not valid demo payload / invalid commune', async t => {
   const baseLocale = {
     commune: '000000',
     populate: false
   }
 
-  const {error} = createDemoSchema.validate(baseLocale)
+  const {error} = await validSchema(baseLocale, createDemoSchema)
 
-  t.is(error.message, 'Code commune inconnu')
+  t.deepEqual(error, {
+    commune: ['Code commune inconnu']
+  })
 })
 
-test('not valid demo payload / no populate', t => {
-  const baseLocale = {
-    commune: '27115'
-  }
-
-  const {error} = createDemoSchema.validate(baseLocale)
-
-  t.true(error.message.includes('"populate" is required'))
-})
-
-test('valid payload : transform demo to draft', t => {
+test('valid payload : transform demo to draft', async t => {
   const baseLocale = {
     nom: 'foo',
     email: 'mail@test.fr'
   }
 
-  const {error} = transformToDraftSchema.validate(baseLocale)
+  const {value, error} = await validSchema(baseLocale, transformToDraftSchema)
 
-  t.is(error, undefined)
+  t.deepEqual(value, baseLocale)
+  t.deepEqual(error, {})
 })
 
-test('invalid payload : no email', t => {
+test('invalid payload : no email', async t => {
   const baseLocale = {
     nom: 'foo'
   }
 
-  const {error} = transformToDraftSchema.validate(baseLocale)
+  const {error} = await validSchema(baseLocale, transformToDraftSchema)
 
-  t.true(error.message.includes('"email" is required'))
+  t.deepEqual(error, {
+    email: ['Le champ email est obligatoire']
+  })
 })

--- a/lib/models/__tests__/nom-alt.schema.js
+++ b/lib/models/__tests__/nom-alt.schema.js
@@ -43,7 +43,7 @@ test('not valid payload: empty', async t => {
 
   const {error} = await validSchema({nomAlt}, {nomAlt: createSchema})
 
-  t.deepEqual(error, {nomAlt: [`breton : ${getLabel('voie_nom.valeur_manquante')}`]})
+  t.deepEqual(error, {nomAlt: [`bre : ${getLabel('voie_nom.valeur_manquante')}`]})
 })
 
 test('not valid payload: nomAlt over 200 caracters', async t => {
@@ -53,5 +53,5 @@ test('not valid payload: nomAlt over 200 caracters', async t => {
 
   const {error} = await validSchema({nomAlt}, {nomAlt: createSchema})
 
-  t.deepEqual(error, {nomAlt: [`breton : ${getLabel('voie_nom.trop_long')}`]})
+  t.deepEqual(error, {nomAlt: [`bre : ${getLabel('voie_nom.trop_long')}`]})
 })

--- a/lib/models/__tests__/nom-alt.schema.js
+++ b/lib/models/__tests__/nom-alt.schema.js
@@ -1,73 +1,57 @@
+const {getLabel} = require('@ban-team/validateur-bal')
 const test = require('ava')
+const {validSchema} = require('../../util/payload')
 const {createSchema} = require('../nom-alt')
 
-test('valid payload', t => {
+test('valid payload', async t => {
   const nomAlt = {
     bre: 'Kemper'
   }
 
-  const {error} = createSchema.validate(nomAlt)
+  const {value, error} = await validSchema({nomAlt}, {nomAlt: createSchema})
 
-  t.is(error, undefined)
+  t.deepEqual(value, {nomAlt})
+  t.deepEqual(error, {})
 })
 
-test('valid payload: 2 nomAlt', t => {
+test('valid payload: 2 nomAlt', async t => {
   const nomAlt = {
     bre: 'Kemper',
     fra: 'Quimper'
   }
 
-  const {error} = createSchema.validate(nomAlt)
+  const {value, error} = await validSchema({nomAlt}, {nomAlt: createSchema})
 
-  t.is(error, undefined)
+  t.deepEqual(value, {nomAlt})
+  t.deepEqual(error, {})
 })
 
-test('not valid payload: too many nomAlt', t => {
-  const nomAlt = {
-    bre: 'nomAlt bre',
-    fra: 'nomAlt fra',
-    eus: 'nomAlt eus',
-    gsw: 'nomAlt gsw',
-    gcf: 'nomAlt gcf',
-    cos: 'nomAlt cos',
-    gyn: 'nomAlt gyn',
-    rcf: 'nomAlt rcf',
-    oci: 'nomAlt oci',
-    guy: 'nomAlt guy',
-    gla: 'nomAlt gla'
-  }
-
-  const {error} = createSchema.validate(nomAlt)
-
-  t.is(error.message, '"value" failed custom validation because Trop de nom (10 maximum)')
-})
-
-test('not valid payload: disallowed nomAlt', t => {
+test('not valid payload: disallowed nomAlt', async t => {
   const nomAlt = {
     bra: 'Kemper'
   }
 
-  const {error} = createSchema.validate(nomAlt)
+  const {error} = await validSchema({nomAlt}, {nomAlt: createSchema})
 
-  t.is(error.message, '"value" failed custom validation because Valeurs "nomAlt" inattendues : bra. Valeurs attendues : fra, bre, eus, gsw, cos, gcr, gcf, rcf, swb ou oci')
+  t.deepEqual(error, {nomAlt: ['Le code langue régionale bra n’est pas supporté']})
 })
 
-test('not valid payload: empty', t => {
+test('not valid payload: empty', async t => {
   const nomAlt = {
     bre: ''
   }
 
-  const {error} = createSchema.validate(nomAlt)
+  const {error} = await validSchema({nomAlt}, {nomAlt: createSchema})
 
-  t.is(error.message, '"value" failed custom validation because Ce champ ne peut être vide')
+  t.deepEqual(error, {nomAlt: [`breton : ${getLabel('voie_nom.valeur_manquante')}`]})
 })
 
-test('not valid payload: nomAlt over 200 caracters', t => {
+test('not valid payload: nomAlt over 200 caracters', async t => {
   const nomAlt = {
     bre: ''.padStart(201, 'a')
   }
 
-  const {error} = createSchema.validate(nomAlt)
+  const {error} = await validSchema({nomAlt}, {nomAlt: createSchema})
 
-  t.is(error.message, '"value" failed custom validation because Le nom est trop long (200 caractères maximum)')
+  t.deepEqual(error, {nomAlt: [`breton : ${getLabel('voie_nom.trop_long')}`]})
 })

--- a/lib/models/__tests__/numero.mongo.js
+++ b/lib/models/__tests__/numero.mongo.js
@@ -1,3 +1,4 @@
+const {getLabel} = require('@etalab/bal')
 const test = require('ava')
 const {MongoMemoryServer} = require('mongodb-memory-server')
 const mongo = require('../../util/mongo')
@@ -105,13 +106,7 @@ test('create a numero with parcelles', async t => {
 test('create a numero with parcelles / lowercase', async t => {
   const _id = new mongo.ObjectId()
   await mongo.db.collection('voies').insertOne({_id})
-  const error = await t.throwsAsync(() => Numero.create(_id, {numero: 42, parcelles: ['12345000aa0001']}))
-
-  t.deepEqual(error.validation, {
-    parcelles: ['Le numéro de parcelle "12345000aa0001" est invalide']
-  })
-
-  t.is(error.message, 'Invalid payload')
+  await t.notThrowsAsync(() => Numero.create(_id, {numero: 42, parcelles: ['12345000aa0001']}))
 })
 
 test('create a numero with parcelles / less than 14 characters', async t => {
@@ -121,7 +116,7 @@ test('create a numero with parcelles / less than 14 characters', async t => {
   const error = await t.throwsAsync(() => Numero.create(_id, {numero: 42, parcelles}))
 
   t.deepEqual(error.validation, {
-    parcelles: ['Le numéro de parcelle "12345000AA" est invalide']
+    parcelles: [getLabel('cad_parcelles.valeur_invalide')]
   })
 
   t.is(error.message, 'Invalid payload')

--- a/lib/models/__tests__/numero.mongo.js
+++ b/lib/models/__tests__/numero.mongo.js
@@ -108,7 +108,7 @@ test('create a numero with parcelles / lowercase', async t => {
   const error = await t.throwsAsync(() => Numero.create(_id, {numero: 42, parcelles: ['12345000aa0001']}))
 
   t.deepEqual(error.validation, {
-    parcelles: ['"parcelles[0]" with value "12345000aa0001" fails to match the required pattern: /^[A-Z\\d]+$/']
+    parcelles: ['Le numéro de parcelle "12345000aa0001" est invalide']
   })
 
   t.is(error.message, 'Invalid payload')
@@ -121,7 +121,7 @@ test('create a numero with parcelles / less than 14 characters', async t => {
   const error = await t.throwsAsync(() => Numero.create(_id, {numero: 42, parcelles}))
 
   t.deepEqual(error.validation, {
-    parcelles: ['"parcelles[0]" length must be 14 characters long']
+    parcelles: ['Le numéro de parcelle "12345000AA" est invalide']
   })
 
   t.is(error.message, 'Invalid payload')
@@ -216,6 +216,7 @@ test('update a numero', async t => {
     numero: 42,
     suffixe: 'foo',
     positions: [],
+    parcelles: [],
     _created: referenceDate,
     _updated: referenceDate
   })
@@ -366,6 +367,7 @@ test('update a numero / change voie', async t => {
     numero: 42,
     suffixe: 'foo',
     positions: [],
+    parcelles: [],
     _created: referenceDate,
     _updated: referenceDate
   })
@@ -422,6 +424,7 @@ test('update a numero / add toponyme', async t => {
     voie: idVoie,
     numero: 42,
     positions: [],
+    parcelles: [],
     _created: referenceDate,
     _updated: referenceDate
   })
@@ -490,6 +493,7 @@ test('update a numero / change toponyme', async t => {
     numero: 42,
     voie: idVoie.toString(),
     toponyme: idToponymeB.toString(),
+    parcelles: [],
     positions: [{
       point: {type: 'Point', coordinates: [0, 0]},
       source: 'source',
@@ -630,6 +634,6 @@ test('batch numeros / invalid certifie value', async t => {
   }))
 
   t.deepEqual(error.validation, {
-    certifie: ['"certifie" must be a boolean']
+    certifie: ['Le champ certifie doit être de type "boolean"']
   })
 })

--- a/lib/models/__tests__/numero.mongo.js
+++ b/lib/models/__tests__/numero.mongo.js
@@ -1,4 +1,4 @@
-const {getLabel} = require('@etalab/bal')
+const {getLabel} = require('@ban-team/validateur-bal')
 const test = require('ava')
 const {MongoMemoryServer} = require('mongodb-memory-server')
 const mongo = require('../../util/mongo')

--- a/lib/models/__tests__/numero.schema.js
+++ b/lib/models/__tests__/numero.schema.js
@@ -1,19 +1,21 @@
 const {getLabel} = require('@ban-team/validateur-bal')
 const test = require('ava')
 const mongo = require('../../util/mongo')
+const {validSchema} = require('../../util/payload')
 const {createSchema, updateSchema, expandModel, normalizeSuffixe} = require('../numero')
 
-test('valid payload: minimalist', t => {
+test('valid payload: minimalist', async t => {
   const numero = {
     numero: 42
   }
 
-  const {error} = createSchema.validate(numero)
+  const {value, error} = await validSchema(numero, createSchema)
 
-  t.is(error, undefined)
+  t.deepEqual(value, numero)
+  t.deepEqual(error, {})
 })
 
-test('valid payload', t => {
+test('valid payload', async t => {
   const numero = {
     numero: 42,
     suffixe: 'bis',
@@ -22,97 +24,85 @@ test('valid payload', t => {
     certifie: false
   }
 
-  const {error} = createSchema.validate(numero)
+  const {value, error} = await validSchema(numero, createSchema)
 
-  t.is(error, undefined)
+  t.deepEqual(value, numero)
+  t.deepEqual(error, {})
 })
 
-test('valid payload / uppercase suffixe', t => {
+test('valid payload / uppercase suffixe', async t => {
   const numero = {
     numero: 41,
     suffixe: 'BIS'
   }
 
-  const {error} = createSchema.validate(numero)
+  const {value, error} = await validSchema(numero, createSchema)
 
-  t.is(error, undefined)
+  t.deepEqual(value, numero)
+  t.deepEqual(error, {})
 })
 
-test('valid payload / certifie true', t => {
+test('valid payload / certifie true', async t => {
   const numero = {
     numero: 41,
     certifie: true
   }
 
-  const {error} = createSchema.validate(numero)
+  const {value, error} = await validSchema(numero, createSchema)
 
-  t.is(error, undefined)
+  t.deepEqual(value, numero)
+  t.deepEqual(error, {})
 })
 
-test('valid payload: with toponyme', t => {
+test('valid payload: with toponyme', async t => {
   const _idToponyme = new mongo.ObjectId()
   const numero = {
     numero: 41,
     toponyme: _idToponyme.toString()
   }
 
-  const {error} = createSchema.validate(numero)
+  const {value, error} = await validSchema(numero, createSchema)
 
-  t.is(error, undefined)
+  t.deepEqual(value, numero)
+  t.deepEqual(error, {})
 })
 
-test('not valid payload: numero missing', t => {
-  const {error} = createSchema.validate({})
+test('not valid payload: numero missing', async t => {
+  const {error} = await validSchema({}, createSchema)
 
-  t.true(error.message.includes('"numero" is required'))
+  t.deepEqual(error, {numero: ['Le champ numero est obligatoire']})
 })
 
-test('not valid payload: numero invalid', t => {
-  const zero = createSchema.validate({numero: 0})
-  const negative = createSchema.validate({numero: -1})
-  const tenTousand = createSchema.validate({numero: 10000})
-  const string = createSchema.validate({numero: '42'})
+test('not valid payload: numero invalid', async t => {
+  const zero = await validSchema({numero: 0}, createSchema)
+  const negative = await validSchema({numero: -1}, createSchema)
+  const tenTousand = await validSchema({numero: 10000}, createSchema)
+  const string = await validSchema({numero: '42'}, createSchema)
 
-  t.is(zero.error, undefined)
-  t.is(negative.error.message, getLabel('numero.trop_grand'))
-  t.is(tenTousand.error.message, getLabel('numero.trop_grand'))
-  t.is(string.value.numero, 42)
+  t.deepEqual(zero.error, {})
+  t.deepEqual(negative.error, {numero: [getLabel('numero.type_invalide')]})
+  t.deepEqual(tenTousand.error, {numero: [getLabel('numero.trop_grand')]})
+  t.deepEqual(string.error, {numero: ['Le champ numero doit être de type "number"']})
 })
 
-test('not valid payload: invalid toponyme', t => {
+test('not valid payload: invalid fields', async t => {
   const numero = {
     numero: 42,
-    toponyme: 'invalid'
-  }
-
-  const {error} = createSchema.validate(numero)
-
-  t.truthy(error)
-})
-
-test('not valid payload: invalid parcelle', t => {
-  const numero = {
-    numero: 42,
-    parcelles: ['invalid']
-  }
-
-  const {error} = createSchema.validate(numero)
-
-  t.truthy(error)
-})
-
-test('not valid payload: invalid certifie', t => {
-  const numero = {
-    numero: 42,
+    toponyme: 'invalid',
+    parcelles: ['invalid'],
     certifie: 'invalid'
   }
 
-  const {error} = createSchema.validate(numero)
+  const {error} = await validSchema(numero, createSchema)
 
-  t.truthy(error)
+  t.deepEqual(error, {
+    toponyme: ['La valeur du champ toponyme est incorrecte'],
+    parcelles: ['Le numéro de parcelle "invalid" est invalide'],
+    certifie: ['Le champ certifie doit être de type "boolean"']
+  })
 })
 
-test('valid payload update', t => {
+test('valid payload update', async t => {
   const _idVoie = new mongo.ObjectId()
 
   const numero = {
@@ -124,12 +114,13 @@ test('valid payload update', t => {
     parcelles: []
   }
 
-  const {error} = updateSchema.validate(numero)
+  const {value, error} = await validSchema(numero, updateSchema)
 
-  t.is(error, undefined)
+  t.deepEqual(value, numero)
+  t.deepEqual(error, {})
 })
 
-test('invalid payload update', t => {
+test('invalid payload update', async t => {
   const numero = {
     numero: 42,
     voie: 'invalid',
@@ -138,11 +129,12 @@ test('invalid payload update', t => {
     positions: []
   }
 
-  const {error} = updateSchema.validate(numero)
-  t.true(error.message.includes('"voie" failed custom validation'))
+  const {error} = await validSchema(numero, updateSchema)
+
+  t.deepEqual(error, {voie: ['La valeur du champ voie est incorrecte']})
 })
 
-test('invalid payload update / invalid toponyme', t => {
+test('invalid payload update / invalid fields', async t => {
   const _idVoie = new mongo.ObjectId()
 
   const numero = {
@@ -151,27 +143,16 @@ test('invalid payload update / invalid toponyme', t => {
     suffixe: 'bis',
     comment: 'Hello world',
     positions: [],
-    toponyme: 'invalid'
+    toponyme: 'invalid',
+    parcelles: ['invalid-parcelle']
   }
 
-  const {error} = updateSchema.validate(numero)
-  t.truthy(error)
-})
+  const {error} = await validSchema(numero, updateSchema)
 
-test('invalid payload update / invalid parcelles', t => {
-  const _idVoie = new mongo.ObjectId()
-
-  const numero = {
-    numero: 42,
-    voie: _idVoie.toString(),
-    suffixe: 'bis',
-    comment: 'Hello world',
-    positions: [],
-    parcelles: ['invalid']
-  }
-
-  const {error} = updateSchema.validate(numero)
-  t.truthy(error)
+  t.deepEqual(error, {
+    toponyme: ['La valeur du champ toponyme est incorrecte'],
+    parcelles: ['Le numéro de parcelle "invalid-parcelle" est invalide']
+  })
 })
 
 test('expandModel', t => {

--- a/lib/models/__tests__/numero.schema.js
+++ b/lib/models/__tests__/numero.schema.js
@@ -97,7 +97,7 @@ test('not valid payload: invalid fields', async t => {
 
   t.deepEqual(error, {
     toponyme: ['La valeur du champ toponyme est incorrecte'],
-    parcelles: ['Le numéro de parcelle "invalid" est invalide'],
+    parcelles: [getLabel('cad_parcelles.valeur_invalide')],
     certifie: ['Le champ certifie doit être de type "boolean"']
   })
 })
@@ -151,7 +151,7 @@ test('invalid payload update / invalid fields', async t => {
 
   t.deepEqual(error, {
     toponyme: ['La valeur du champ toponyme est incorrecte'],
-    parcelles: ['Le numéro de parcelle "invalid-parcelle" est invalide']
+    parcelles: [getLabel('cad_parcelles.valeur_invalide')]
   })
 })
 

--- a/lib/models/__tests__/numero.schema.js
+++ b/lib/models/__tests__/numero.schema.js
@@ -63,7 +63,10 @@ test('valid payload: with toponyme', async t => {
 
   const {value, error} = await validSchema(numero, createSchema)
 
-  t.deepEqual(value, numero)
+  t.deepEqual(value, {
+    ...numero,
+    toponyme: _idToponyme
+  })
   t.deepEqual(error, {})
 })
 
@@ -116,7 +119,10 @@ test('valid payload update', async t => {
 
   const {value, error} = await validSchema(numero, updateSchema)
 
-  t.deepEqual(value, numero)
+  t.deepEqual(value, {
+    ...numero,
+    voie: _idVoie
+  })
   t.deepEqual(error, {})
 })
 

--- a/lib/models/__tests__/position.schema.js
+++ b/lib/models/__tests__/position.schema.js
@@ -73,8 +73,8 @@ test('not valid payload: point.coordinates invalid', async t => {
   position.point.coordinates = [1, 1, 1]
   const tooMuchItems = await validSchema(position, createSchema)
 
-  t.deepEqual(empty.error, {positions: ['le champ point.coordinates est incorrecte']})
-  t.deepEqual(tooMuchItems.error, {positions: ['le champ point.coordinates est incorrecte']})
+  t.deepEqual(empty.error, {positions: ['la valeur du champ point.coordinates est incorrecte']})
+  t.deepEqual(tooMuchItems.error, {positions: ['la valeur du champ point.coordinates est incorrecte']})
 })
 
 test('valid payload: source missing', async t => {

--- a/lib/models/__tests__/position.schema.js
+++ b/lib/models/__tests__/position.schema.js
@@ -1,66 +1,67 @@
+const {getLabel} = require('@etalab/bal')
 const test = require('ava')
+const {validSchema} = require('../../util/payload')
 const {createSchema} = require('../position')
 
-test('valid payload', t => {
+test('valid payload', async t => {
   const position = {
     point: {type: 'Point', coordinates: [1, 1]},
     source: 'source',
     type: 'entrée'
   }
 
-  const {error} = createSchema.validate(position)
-
-  t.is(error, undefined)
+  const {value, error} = await validSchema(position, createSchema)
+  t.deepEqual(value, position)
+  t.deepEqual(error, {})
 })
 
-test('not valid payload: point missing', t => {
+test('not valid payload: point missing', async t => {
   const position = {
     source: 'source',
     type: 'entrée'
   }
 
-  const {error} = createSchema.validate(position)
-
-  t.true(error.message.includes('"point" is required'))
+  const {error} = await validSchema(position, createSchema)
+  t.deepEqual(error, {point: ['Le champ point est obligatoire']})
 })
 
-test('not valid payload: point.type missing', t => {
+test('not valid payload: point.type missing', async t => {
   const position = {
     point: {coordinates: [1, 1]},
     source: 'source',
     type: 'entrée'
   }
 
-  const {error} = createSchema.validate(position)
+  const {error} = await validSchema(position, createSchema)
 
-  t.true(error.message.includes('"point.type" is required'))
+  t.deepEqual(error, {positions: ['Le champ point est invalide']})
 })
 
-test('not valid payload: point.type not valid', t => {
+test('not valid payload: point.type not valid', async t => {
   const position = {
     point: {type: 'invalid-type', coordinates: [1, 1]},
     source: 'source',
     type: 'entrée'
   }
 
-  const {error} = createSchema.validate(position)
+  const {error} = await validSchema(position, createSchema)
 
-  t.true(error.message.includes('"point.type" must be [Point]'))
+  t.deepEqual(error, {point: ['Le champ point.type doit avoir pour valeur "Point"']})
 })
 
-test('not valid payload: point.coordinates missing', t => {
+test('not valid payload: point.coordinates missing', async t => {
   const position = {
     point: {type: 'Point'},
     source: 'source',
     type: 'entrée'
   }
 
-  const {error} = createSchema.validate(position)
+  const {error} = await validSchema(position, createSchema)
 
-  t.true(error.message.includes('"point.coordinates" is required'))
+  t.deepEqual(error, {positions: ['Le champ point est invalide']})
 })
 
-test('not valid payload: point.coordinates invalid', t => {
+test('not valid payload: point.coordinates invalid', async t => {
   const position = {
     point: {type: 'Point', coordinates: null},
     source: 'source',
@@ -68,44 +69,45 @@ test('not valid payload: point.coordinates invalid', t => {
   }
 
   position.point.coordinates = []
-  const empty = createSchema.validate(position)
+  const empty = await validSchema(position, createSchema)
   position.point.coordinates = [1, 1, 1]
-  const tooMuchItems = createSchema.validate(position)
+  const tooMuchItems = await validSchema(position, createSchema)
 
-  t.true(empty.error.message.includes('"point.coordinates" must contain at least 2 items'))
-  t.true(tooMuchItems.error.message.includes(''))
+  t.deepEqual(empty.error, {positions: ['le champ point.coordinates est incorrecte']})
+  t.deepEqual(tooMuchItems.error, {positions: ['le champ point.coordinates est incorrecte']})
 })
 
-test('valid payload: source missing', t => {
+test('valid payload: source missing', async t => {
   const position = {
     point: {type: 'Point', coordinates: [1, 1]},
     type: 'entrée'
   }
 
-  const {error} = createSchema.validate(position)
+  const {value, error} = await validSchema(position, createSchema)
 
-  t.is(error, undefined)
+  t.deepEqual(value, position)
+  t.deepEqual(error, {})
 })
 
-test('not valid payload: type missing', t => {
+test('not valid payload: type missing', async t => {
   const position = {
     point: {type: 'Point', coordinates: [1, 1]},
     source: 'source'
   }
 
-  const {error} = createSchema.validate(position)
+  const {error} = await validSchema(position, createSchema)
 
-  t.true(error.message.includes('"type" is required'))
+  t.deepEqual(error, {type: ['Le champ type est obligatoire']})
 })
 
-test('not valid payload: type not valid', t => {
+test('not valid payload: type not valid', async t => {
   const position = {
     point: {type: 'Point', coordinates: [1, 1]},
     source: 'source',
     type: 'invalid-type'
   }
 
-  const {error} = createSchema.validate(position)
+  const {error} = await validSchema(position, createSchema)
 
-  t.true(error.message.includes('"type" must be one of'))
+  t.deepEqual(error, {positions: [getLabel('position.valeur_invalide')]})
 })

--- a/lib/models/__tests__/position.schema.js
+++ b/lib/models/__tests__/position.schema.js
@@ -1,4 +1,4 @@
-const {getLabel} = require('@etalab/bal')
+const {getLabel} = require('@ban-team/validateur-bal')
 const test = require('ava')
 const {validSchema} = require('../../util/payload')
 const {createSchema} = require('../position')

--- a/lib/models/__tests__/toponyme.mongo.js
+++ b/lib/models/__tests__/toponyme.mongo.js
@@ -45,7 +45,10 @@ test('create a Toponyme / with unsupported nomAlt', async t => {
   const error = await t.throwsAsync(() => Toponyme.create(_id, {nom: 'foo', nomAlt: {gua: 'Lapwent', gyn: 'Lapwent'}}))
 
   t.deepEqual(error.validation, {
-    nomAlt: ['"nomAlt" failed custom validation because Valeurs "nomAlt" inattendues : gua et gyn. Valeurs attendues : fra, bre, eus, gsw, cos, gcr, gcf, rcf, swb ou oci']
+    nomAlt: [
+      'Le code langue régionale gua n’est pas supporté',
+      'Le code langue régionale gyn n’est pas supporté'
+    ]
   })
 })
 
@@ -200,7 +203,7 @@ test('update a Toponyme / with unsupported nomAlt', async t => {
   }))
 
   t.deepEqual(error.validation, {
-    nomAlt: ['"nomAlt" failed custom validation because Valeurs "nomAlt" inattendues : gua. Valeurs attendues : fra, bre, eus, gsw, cos, gcr, gcf, rcf, swb ou oci']
+    nomAlt: ['Le code langue régionale gua n’est pas supporté']
   })
 })
 

--- a/lib/models/__tests__/toponyme.mongo.js
+++ b/lib/models/__tests__/toponyme.mongo.js
@@ -126,7 +126,7 @@ test('importMany / keeping ids', async t => {
     positions: []
   }
 
-  Toponyme.importMany(_idBal, [toponyme1, toponyme2], {validate: false, keepIds: true})
+  await Toponyme.importMany(_idBal, [toponyme1, toponyme2], {validate: false, keepIds: true})
   const toponymes = await mongo.db.collection('toponymes').find({_bal: _idBal}).toArray()
   t.is(toponymes.length, 2)
 

--- a/lib/models/__tests__/toponyme.mongo.js
+++ b/lib/models/__tests__/toponyme.mongo.js
@@ -127,14 +127,14 @@ test('importMany / keeping ids', async t => {
   }
 
   Toponyme.importMany(_idBal, [toponyme1, toponyme2], {validate: false, keepIds: true})
-  const voies = await mongo.db.collection('toponymes').find({_bal: _idBal}).toArray()
-  t.is(voies.length, 2)
+  const toponymes = await mongo.db.collection('toponymes').find({_bal: _idBal}).toArray()
+  t.is(toponymes.length, 2)
 
-  const v1 = voies.find(v => v.nom === 'foo')
+  const v1 = toponymes.find(v => v.nom === 'foo')
   t.deepEqual(pick(v1, 'nom', 'commune', 'positions'), pick(toponyme1, 'nom', 'commune', 'positions'))
   t.true(v1._id.equals(_idToponyme1))
 
-  const v2 = voies.find(v => v.nom === 'bar')
+  const v2 = toponymes.find(v => v.nom === 'bar')
   t.deepEqual(pick(v2, 'nom', 'commune', 'positions'), pick(toponyme2, 'nom', 'commune', 'positions'))
   t.true(v2._id.equals(_idToponyme2))
 })

--- a/lib/models/__tests__/toponyme.schema.js
+++ b/lib/models/__tests__/toponyme.schema.js
@@ -1,4 +1,4 @@
-const {getLabel} = require('@etalab/bal')
+const {getLabel} = require('@ban-team/validateur-bal')
 const test = require('ava')
 const {validSchema} = require('../../util/payload')
 const {createSchema} = require('../toponyme')

--- a/lib/models/__tests__/toponyme.schema.js
+++ b/lib/models/__tests__/toponyme.schema.js
@@ -1,15 +1,17 @@
 const test = require('ava')
+const {validSchema} = require('../../util/payload')
 const {createSchema} = require('../toponyme')
 
-test('valid payload', t => {
+test('valid payload', async t => {
   const toponyme = {nom: 'toponyme'}
 
-  const {error} = createSchema.validate(toponyme)
+  const {value, error} = await validSchema(toponyme, createSchema)
 
-  t.is(error, undefined)
+  t.deepEqual(value, toponyme)
+  t.deepEqual(error, {})
 })
 
-test('valid payload: with positions', t => {
+test('valid payload: with positions', async t => {
   const toponyme = {
     nom: 'toponyme',
     positions: [
@@ -22,53 +24,58 @@ test('valid payload: with positions', t => {
     parcelles: ['64284000BI0459', '64284000BI0450']
   }
 
-  const {error} = createSchema.validate(toponyme)
+  const {value, error} = await validSchema(toponyme, createSchema)
 
-  t.is(error, undefined)
+  t.deepEqual(value, toponyme)
+  t.deepEqual(error, {})
 })
 
-test('not valid payload: nom over 200 caracters', t => {
+test('not valid payload: nom over 200 caracters', async t => {
   const toponyme = {
     nom: ''.padStart(201, 'a')
   }
 
-  const {error} = createSchema.validate(toponyme)
+  const {error} = await validSchema(toponyme, createSchema)
 
-  t.is(error.message, 'Le nom est trop long (200 caractères maximum)')
+  t.deepEqual(error, {nom: ['Le nom est trop long (200 caractères maximum)']})
 })
 
-test('not valid payload: nom missing', t => {
-  const {error} = createSchema.validate({positions: [
+test('not valid payload: nom missing', async t => {
+  const toponyme = {positions: [
     {
       point: {type: 'Point', coordinates: [1, 1]},
       type: 'entrée',
       source: 'ban'
     }
-  ]})
+  ]}
+  const {error} = await validSchema(toponyme, createSchema)
 
-  t.true(error.message.includes('"nom" is required'))
+  t.deepEqual(error, {nom: ['Le champ nom est obligatoire']})
 })
 
-test('not valid payload: position invalid in positions', t => {
+test('not valid payload: position invalid in positions', async t => {
   const toponyme = {
     nom: 'toponyme',
     positions: [{}],
     parcelles: []
   }
 
-  const {error} = createSchema.validate(toponyme)
+  const {error} = await validSchema(toponyme, createSchema)
 
-  t.truthy(error)
+  t.deepEqual(error, {
+    point: ['Le champ point est obligatoire'],
+    type: ['Le champ type est obligatoire']
+  })
 })
 
-test('not valid payload: invalid parcelles', t => {
+test('not valid payload: invalid parcelles', async t => {
   const toponyme = {
     nom: 'toponyme',
     positions: [],
-    parcelles: ['PARCELLE', 'CC55DATA']
+    parcelles: ['PARCELLE123456', 'CC55DATA']
   }
 
-  const {error} = createSchema.validate(toponyme)
+  const {error} = await validSchema(toponyme, createSchema)
 
-  t.truthy(error)
+  t.deepEqual(error, {parcelles: ['Le numéro de parcelle "CC55DATA" est invalide']})
 })

--- a/lib/models/__tests__/toponyme.schema.js
+++ b/lib/models/__tests__/toponyme.schema.js
@@ -1,3 +1,4 @@
+const {getLabel} = require('@etalab/bal')
 const test = require('ava')
 const {validSchema} = require('../../util/payload')
 const {createSchema} = require('../toponyme')
@@ -77,5 +78,5 @@ test('not valid payload: invalid parcelles', async t => {
 
   const {error} = await validSchema(toponyme, createSchema)
 
-  t.deepEqual(error, {parcelles: ['Le numéro de parcelle "CC55DATA" est invalide']})
+  t.deepEqual(error, {parcelles: [getLabel('cad_parcelles.valeur_invalide')]})
 })

--- a/lib/models/__tests__/voie.mongo.js
+++ b/lib/models/__tests__/voie.mongo.js
@@ -56,7 +56,10 @@ test('create a Voie / with unsupported nomAlt', async t => {
   const error = await t.throwsAsync(() => Voie.create(baseLocale, {nom: 'foo  oo', nomAlt: {gua: 'Lapwent', gyn: 'Lapwent'}}))
 
   t.deepEqual(error.validation, {
-    nomAlt: ['"nomAlt" failed custom validation because Valeurs "nomAlt" inattendues : gua et gyn. Valeurs attendues : fra, bre, eus, gsw, cos, gcr, gcf, rcf, swb ou oci']
+    nomAlt: [
+      'Le code langue régionale gua n’est pas supporté',
+      'Le code langue régionale gyn n’est pas supporté'
+    ]
   })
 })
 
@@ -170,7 +173,7 @@ test('update a Voie / with unsupported nomAlt', async t => {
   }))
 
   t.deepEqual(error.validation, {
-    nomAlt: ['"nomAlt" failed custom validation because Valeurs "nomAlt" inattendues : gua. Valeurs attendues : fra, bre, eus, gsw, cos, gcr, gcf, rcf, swb ou oci']
+    nomAlt: ['Le code langue régionale gua n’est pas supporté']
   })
 })
 

--- a/lib/models/__tests__/voie.mongo.js
+++ b/lib/models/__tests__/voie.mongo.js
@@ -282,6 +282,6 @@ test('batch voie numeros / invalid certifie', async t => {
   const error = await t.throwsAsync(() => Voie.batchUpdateNumeros(idVoie, {certifie: 'foo'}))
 
   t.deepEqual(error.validation, {
-    certifie: ['"certifie" must be a boolean']
+    certifie: ['Le champ certifie doit être de type "boolean"']
   })
 })

--- a/lib/models/__tests__/voie.mongo.js
+++ b/lib/models/__tests__/voie.mongo.js
@@ -76,7 +76,8 @@ test('importMany', async t => {
     commune: '23456',
     nomAlt: {bre: 'bar bre'}
   }
-  Voie.importMany(_idBal, [voie1, voie2], {validate: false})
+
+  await Voie.importMany(_idBal, [voie1, voie2], {validate: false})
   const voies = await mongo.db.collection('voies').find({_bal: _idBal}).toArray()
   t.is(voies.length, 2)
   const v1 = voies.find(v => v.nom === 'foo')

--- a/lib/models/__tests__/voie.schema.js
+++ b/lib/models/__tests__/voie.schema.js
@@ -1,15 +1,17 @@
 const test = require('ava')
-const {createSchema, cleanNom} = require('../voie')
+const {getLabel} = require('@etalab/bal')
+const {createSchema, cleanNom, updateSchema} = require('../voie')
+const {validSchema} = require('../../util/payload')
 
-test('valid payload', t => {
+test('valid payload', async t => {
   const voie = {nom: 'voie'}
 
-  const {error} = createSchema.validate(voie)
-
-  t.is(error, undefined)
+  const {value, error} = await validSchema(voie, createSchema)
+  t.deepEqual(value, voie)
+  t.deepEqual(error, {})
 })
 
-test('valid payload: with trace', t => {
+test('valid payload: with trace', async t => {
   const voie = {
     nom: 'voie',
     trace: {
@@ -18,29 +20,43 @@ test('valid payload: with trace', t => {
     }
   }
 
-  const {error} = createSchema.validate(voie)
-
-  t.is(error, undefined)
+  const {value, error} = await validSchema(voie, createSchema)
+  t.deepEqual(value, voie)
+  t.deepEqual(error, {})
 })
 
-test('not valid payload: nom missing', t => {
-  const {error} = createSchema.validate({})
+test('not valid payload: nom missing', async t => {
+  const {error} = await validSchema({}, createSchema)
 
-  t.true(error.message.includes('"nom" is required'))
+  t.deepEqual(error, {
+    nom: ['Le champ nom est obligatoire']
+  })
 })
 
-test('not valid payload: invalid typeNumerotation', t => {
+test('not valid payload: invalid nom', async t => {
+  const {error} = await validSchema({nom: 'Fo'}, createSchema)
+
+  t.deepEqual(error, {
+    nom: [getLabel('voie_nom.trop_court')]
+  })
+})
+
+test('not valid payload: invalid typeNumerotation', async t => {
   const voie = {
     nom: 'voie',
     typeNumerotation: 'invalid type'
   }
 
-  const {error} = createSchema.validate(voie)
+  const {error} = await validSchema(voie, createSchema)
 
-  t.truthy(error)
+  t.deepEqual(error, {
+    typeNumerotation: [
+      'La valeur du champ typeNumerotation est incorrecte, seules "numerique" et "metrique" sont autorisées'
+    ]
+  })
 })
 
-test('not valid payload: invalid trace', t => {
+test('not valid payload: invalid trace', async t => {
   const voie = {
     nom: 'voie',
     trace: {
@@ -49,9 +65,53 @@ test('not valid payload: invalid trace', t => {
     }
   }
 
-  const {error} = createSchema.validate(voie)
+  const {error} = await validSchema(voie, createSchema)
 
-  t.truthy(error)
+  t.deepEqual(error, {
+    trace: [
+      'Le champ "trace.type" doit avoir pour valeur : "LineString"',
+      'Le valeur du champ "type.coordinates" est incorrecte'
+    ]
+  })
+})
+
+test('update valid payload', async t => {
+  const voie = {
+    nom: 'foo',
+    code: '0000',
+    typeNumerotation: 'metrique',
+  }
+
+  const {value, error} = await validSchema(voie, updateSchema)
+  t.deepEqual(value, voie)
+  t.deepEqual(error, {})
+})
+
+test('update invalid payload', async t => {
+  const voie = {
+    nom: 'fo',
+    code: '42',
+    typeNumerotation: null
+  }
+
+  const {error} = await validSchema(voie, updateSchema)
+
+  t.deepEqual(error, {
+    nom: [getLabel('voie_nom.trop_court')],
+    code: ['Le code voie est invalide'],
+    typeNumerotation: ['Le champ typeNumerotation ne peut pas être nul']
+  })
+})
+
+test('update invalid payload null allowed', async t => {
+  const voie = {
+    code: null,
+    trace: null
+  }
+
+  const {value, error} = await validSchema(voie, updateSchema)
+  t.deepEqual(value, voie)
+  t.deepEqual(error, {})
 })
 
 test('cleanNom', t => {

--- a/lib/models/__tests__/voie.schema.js
+++ b/lib/models/__tests__/voie.schema.js
@@ -1,5 +1,5 @@
 const test = require('ava')
-const {getLabel} = require('@etalab/bal')
+const {getLabel} = require('@ban-team/validateur-bal')
 const {createSchema, cleanNom, updateSchema} = require('../voie')
 const {validSchema} = require('../../util/payload')
 

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -1,7 +1,6 @@
-const Joi = require('joi')
 const {omit, difference, uniq, keyBy} = require('lodash')
 const {generateBase62String} = require('../util/base62')
-const {validPayload} = require('../util/payload')
+const {validPayload, addError} = require('../util/payload')
 const mongo = require('../util/mongo')
 const {sendMail} = require('../util/sendmail')
 const {getContourCommune} = require('../util/contours-communes')
@@ -19,22 +18,66 @@ const Voie = require('./voie')
 const Numero = require('./numero')
 const Toponyme = require('./toponyme')
 
-const nomValidation = Joi.string()
-  .min(1).message('Le nom est trop court (1 caractère minimum)')
-  .max(200).message('Le nom est trop long (200 caractères maximum)')
-const emailsValidation = Joi.array().min(1).items(Joi.string().email())
+async function validNom(nom, error) {
+  if (nom.length === 0) {
+    addError(error, 'nom', 'Le nom est trop court (1 caractère minimum)')
+  } else if (nom.length >= 200) {
+    addError(error, 'nom', 'Le nom est trop long (200 caractères maximum)')
+  }
+}
 
-const createSchema = Joi.object().keys({
-  nom: nomValidation.required(),
-  emails: emailsValidation.required(),
-  commune: Joi.string()
-    .valid(...getCodesCommunes())
-    .required()
-    .messages({'any.only': 'Code commune inconnu'})
-})
+async function validEmail(email, error) {
+  if (!(/^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/.test(email))) {
+    addError(error, 'emails', `L’adresse email ${email} est invalide`)
+  }
+}
+
+async function validEmails(emails, error) {
+  if (emails.length === 0) {
+    addError(error, 'emails', 'Le champ emails doit contenir au moins une adresse email')
+  } else {
+    emails.forEach(email => {
+      validEmail(email, error)
+    })
+  }
+}
+
+async function validCommune(commune, error) {
+  if (!getCodesCommunes().includes(commune)) {
+    addError(error, 'commune', 'Code commune inconnu')
+  }
+}
+
+async function validStatus(status, error) {
+  if (!['draft', 'ready-to-publish'].includes(status)) {
+    addError(error, 'status', 'La valeur du champ status est incorrecte, seules "draft" et "ready-to-publish" sont autorisées')
+  }
+}
+
+const createSchema = {
+  nom: {valid: validNom, isRequired: true, nullAllowed: false, type: 'string'},
+  emails: {valid: validEmails, isRequired: true, nullAllowed: false, type: 'array'},
+  commune: {valid: validCommune, isRequired: true, nullAllowed: false, type: 'string'}
+}
+
+const createDemoSchema = {
+  commune: {valid: validCommune, isRequired: true, nullAllowed: false, type: 'string'},
+  populate: {valid: null, isRequired: true, nullAllowed: false, type: 'boolean'}
+}
+
+const updateSchema = {
+  nom: {valid: validNom, isRequired: false, nullAllowed: false, type: 'string'},
+  status: {valid: validStatus, isRequired: false, nullAllowed: false, type: 'string'},
+  emails: {valid: validEmails, isRequired: false, nullAllowed: false, type: 'array'}
+}
+
+const transformToDraftSchema = {
+  nom: {valid: validNom, isRequired: false, nullAllowed: true, type: 'string'},
+  email: {valid: validEmail, isRequired: true, nullAllowed: false, type: 'string'}
+}
 
 async function create(payload) {
-  const {nom, emails, commune} = validPayload(payload, createSchema)
+  const {nom, emails, commune} = await validPayload(payload, createSchema)
 
   const baseLocale = {
     _id: new mongo.ObjectId(),
@@ -55,16 +98,8 @@ async function create(payload) {
   return baseLocale
 }
 
-const createDemoSchema = Joi.object().keys({
-  commune: Joi.string()
-    .valid(...getCodesCommunes())
-    .required()
-    .messages({'any.only': 'Code commune inconnu'}),
-  populate: Joi.boolean().required()
-})
-
 async function createDemo(payload) {
-  const {commune, populate} = validPayload(payload, createDemoSchema)
+  const {commune, populate} = await validPayload(payload, createDemoSchema)
 
   const baseLocale = {
     _id: new mongo.ObjectId(),
@@ -85,15 +120,9 @@ async function createDemo(payload) {
   return baseLocale
 }
 
-const updateSchema = Joi.object().keys({
-  nom: nomValidation,
-  status: Joi.string().valid('draft', 'ready-to-publish'),
-  emails: emailsValidation
-})
-
 async function update(id, payload) {
   // Validate and decorate changes
-  const baseLocaleChanges = validPayload(payload, updateSchema)
+  const baseLocaleChanges = await validPayload(payload, updateSchema)
   mongo.decorateModification(baseLocaleChanges)
 
   // Fetch current BaseLocale
@@ -124,11 +153,6 @@ async function update(id, payload) {
   return value
 }
 
-const transformToDraftSchema = Joi.object().keys({
-  nom: Joi.string().max(200).allow(null),
-  email: Joi.string().email().required()
-})
-
 async function transformToDraft(currentBaseLocale, payload) {
   if (!currentBaseLocale) {
     throw new Error('A BaseLocale must be provided as first param')
@@ -138,7 +162,7 @@ async function transformToDraft(currentBaseLocale, payload) {
     throw new Error(`Cannot transform BaseLocale into draft. Expected status demo. Found: ${currentBaseLocale.status}`)
   }
 
-  const {nom, email} = validPayload(payload, transformToDraftSchema)
+  const {nom, email} = await validPayload(payload, transformToDraftSchema)
 
   const changes = {
     nom: nom ? nom : `Adresses de ${getCommuneCOG(currentBaseLocale.commune).nom}`,
@@ -419,7 +443,7 @@ async function getExpandedBAL(baseLocale) {
 
 async function batchUpdateNumeros(idBal, changes) {
   const now = new Date()
-  const {certifie} = validPayload(changes, Numero.updateSchema)
+  const {certifie} = await validPayload(changes, Numero.updateSchema)
 
   const {modifiedCount} = await mongo.db.collection('numeros').updateMany({
     $and: [

--- a/lib/models/nom-alt.js
+++ b/lib/models/nom-alt.js
@@ -1,37 +1,23 @@
 const languesRegionales = require('@ban-team/shared-data/langues-regionales.json')
-const {assign} = require('lodash')
 const {addError} = require('../util/payload')
 const {validateurBAL} = require('../validateur-bal')
 
-const allowedNomAlt = languesRegionales.map(l => l.code)
+const supportedNomAlt = new Set(languesRegionales.map(l => l.code))
 
-function validNomAlt(nomAlt, error) {
-  if (nomAlt) {
-    if (Object.keys(nomAlt).length > allowedNomAlt.length) {
-      addError(error, 'nomAlt', `Trop de noms alternatifs (${allowedNomAlt.length} maximum)`)
+async function validNomAlt(nomAlt, error) {
+  Object.keys(nomAlt).forEach(async codeISO => {
+    if (supportedNomAlt.has(codeISO)) {
+      const nomVoie = nomAlt[codeISO]
+      const {errors} = await validateurBAL(nomVoie, 'voie_nom')
+
+      errors.forEach(err => {
+        const {label} = languesRegionales.find(({code}) => code === codeISO)
+        addError(error, 'nomAlt', `${label} : ${err}`)
+      })
+    } else {
+      addError(error, 'nomAlt', `Le code langue régionale ${codeISO} n’est pas supporté`)
     }
-
-    const disallowedNomAlt = Object.keys(nomAlt).filter(nom => !allowedNomAlt.includes(nom))
-
-    if (disallowedNomAlt.length > 0) {
-      const allowedList = new Intl.ListFormat('fr', {type: 'disjunction'}).format(allowedNomAlt)
-      const disallowedList = new Intl.ListFormat('fr').format(disallowedNomAlt)
-
-      addError(error, 'nomAlt', `Valeurs "nomAlt" inattendues : ${disallowedList}. Valeurs attendues : ${allowedList}`)
-    }
-
-    const parsedValue = {}
-    Object.keys(nomAlt).forEach(async nom => {
-      const result = await validateurBAL(nom, 'voie_nom')
-      if (result.value) {
-        parsedValue[nom] = result.value
-      }
-
-      assign(error, result.error)
-    })
-
-    return Object.keys(parsedValue).length === Object.keys(nomAlt).length ? parsedValue : nomAlt
-  }
+  })
 }
 
 function getNomAltDefault(nomAlt) {

--- a/lib/models/nom-alt.js
+++ b/lib/models/nom-alt.js
@@ -11,8 +11,7 @@ async function validNomAlt(nomAlt, error) {
       const {errors} = await validateurBAL(nomVoie, 'voie_nom')
 
       errors.forEach(err => {
-        const {label} = languesRegionales.find(({code}) => code === codeISO)
-        addError(error, 'nomAlt', `${label} : ${err}`)
+        addError(error, 'nomAlt', `${codeISO} : ${err}`)
       })
     } else {
       addError(error, 'nomAlt', `Le code langue régionale ${codeISO} n’est pas supporté`)

--- a/lib/models/nom-alt.js
+++ b/lib/models/nom-alt.js
@@ -1,12 +1,14 @@
-const Joi = require('joi')
 const languesRegionales = require('@ban-team/shared-data/langues-regionales.json')
+const {assign} = require('lodash')
+const {addError} = require('../util/payload')
+const {validateurBAL} = require('../validateur-bal')
 
 const allowedNomAlt = languesRegionales.map(l => l.code)
 
-function nomAltValidation(nomAlt) {
+function validNomAlt(nomAlt, error) {
   if (nomAlt) {
     if (Object.keys(nomAlt).length > allowedNomAlt.length) {
-      throw new Error(`Trop de nom (${allowedNomAlt.length} maximum)`)
+      addError(error, 'nomAlt', `Trop de noms alternatifs (${allowedNomAlt.length} maximum)`)
     }
 
     const disallowedNomAlt = Object.keys(nomAlt).filter(nom => !allowedNomAlt.includes(nom))
@@ -15,20 +17,20 @@ function nomAltValidation(nomAlt) {
       const allowedList = new Intl.ListFormat('fr', {type: 'disjunction'}).format(allowedNomAlt)
       const disallowedList = new Intl.ListFormat('fr').format(disallowedNomAlt)
 
-      throw new Error(`Valeurs "nomAlt" inattendues : ${disallowedList}. Valeurs attendues : ${allowedList}`)
+      addError(error, 'nomAlt', `Valeurs "nomAlt" inattendues : ${disallowedList}. Valeurs attendues : ${allowedList}`)
     }
 
-    Object.keys(nomAlt).forEach(nom => {
-      if (nomAlt[nom].trim().length === 0) {
-        throw new Error('Ce champ ne peut être vide')
+    const parsedValue = {}
+    Object.keys(nomAlt).forEach(async nom => {
+      const result = await validateurBAL(nom, 'voie_nom')
+      if (result.value) {
+        parsedValue[nom] = result.value
       }
 
-      if (nomAlt[nom].length > 200) {
-        throw new Error('Le nom est trop long (200 caractères maximum)')
-      }
+      assign(error, result.error)
     })
 
-    return nomAlt
+    return Object.keys(parsedValue).length === Object.keys(nomAlt).length ? parsedValue : nomAlt
   }
 }
 
@@ -44,7 +46,7 @@ function cleanNomAlt(nomAlt) {
   return nomAlt
 }
 
-const createSchema = Joi.object().custom(nomAltValidation)
+const createSchema = {valid: validNomAlt, isRequired: false, nullAllowed: true, type: 'object'}
 const updateSchema = createSchema
 
 module.exports = {

--- a/lib/models/numero.js
+++ b/lib/models/numero.js
@@ -15,19 +15,23 @@ function validObjectID(id) {
 }
 
 async function validNumero(numero, error) {
-  const {errors} = await validateurBAL(numero.toString(), 'numero')
+  const {value, errors} = await validateurBAL(numero.toString(), 'numero')
 
   errors.forEach(err => {
     addError(error, 'numero', err)
   })
+
+  return value || numero
 }
 
 async function validSuffixe(suffixe, error) {
-  const {errors} = await validateurBAL(suffixe.toString(), 'suffixe')
+  const {value, errors} = await validateurBAL(suffixe.toString(), 'suffixe')
 
   errors.forEach(err => {
     addError(error, 'suffixe', err)
   })
+
+  return value || suffixe
 }
 
 async function validComment(comment, error) {
@@ -44,24 +48,32 @@ async function validPositions(positions, error) {
 }
 
 async function validVoie(voie, error) {
-  if (!validObjectID(voie)) {
-    addError(error, 'voie', 'La valeur du champ voie est incorrecte')
+  const objectID = validObjectID(voie)
+  if (objectID) {
+    return objectID
   }
+
+  addError(error, 'voie', 'La valeur du champ voie est incorrecte')
 }
 
 async function validToponyme(toponyme, error) {
-  if (!validObjectID(toponyme)) {
-    addError(error, 'toponyme', 'La valeur du champ toponyme est incorrecte')
+  const objectID = validObjectID(toponyme)
+  if (objectID) {
+    return objectID
   }
+
+  addError(error, 'toponyme', 'La valeur du champ toponyme est incorrecte')
 }
 
 async function validParcelles(parcelles, error) {
   if (parcelles.length > 0) {
-    const {errors} = await validateurBAL(parcelles.join('|'), 'cad_parcelles')
+    const {value, errors} = await validateurBAL(parcelles.join('|'), 'cad_parcelles')
 
     errors.forEach(err => {
       addError(error, 'parcelles', err)
     })
+
+    return value
   }
 }
 

--- a/lib/models/numero.js
+++ b/lib/models/numero.js
@@ -1,50 +1,100 @@
-const Joi = require('joi')
-const {uniqBy, omit} = require('lodash')
+const {uniqBy, omit, assign} = require('lodash')
 const createError = require('http-errors')
-const {getLabel} = require('@ban-team/validateur-bal')
-const {getFilteredPayload} = require('../util/payload')
+const {getFilteredPayload, addError, validSchema} = require('../util/payload')
 const mongo = require('../util/mongo')
 const {validPayload} = require('../util/payload')
-const position = require('./position')
+const {validateurBAL} = require('../validateur-bal')
+const positionModel = require('./position')
 
 function validObjectID(id) {
-  if (id) {
-    const objectID = mongo.ObjectId.createFromHexString(id)
-    if (mongo.ObjectId.isValid(id)) {
-      return objectID
-    }
+  if (id && mongo.ObjectId.isValid(id)) {
+    return mongo.ObjectId.createFromHexString(id)
+  }
 
-    throw new Error('ObjectId is invalid')
+  return false
+}
+
+async function validNumero(numero, error) {
+  const {errors} = await validateurBAL(numero.toString(), 'numero')
+
+  errors.forEach(err => {
+    addError(error, 'numero', err)
+  })
+}
+
+async function validSuffixe(suffixe, error) {
+  const {errors} = await validateurBAL(suffixe.toString(), 'suffixe')
+
+  errors.forEach(err => {
+    addError(error, 'suffixe', err)
+  })
+}
+
+async function validComment(comment, error) {
+  if (comment.length > 5000) {
+    addError(error, 'comment', 'Le commentaire est trop long (5000 caractères maximum)')
   }
 }
 
-const numeroValidation = Joi.number()
-  .min(0).message(getLabel('numero.trop_grand'))
-  .max(9999).message(getLabel('numero.trop_grand'))
-  .integer().message(getLabel('numero.type_invalide'))
+async function validPositions(positions, error) {
+  positions.forEach(async position => {
+    const result = await validSchema(position, positionModel.createSchema)
+    assign(error, result.error)
+  })
+}
 
-const suffixeValidation = Joi.string()
-  .regex(/^[a-z\d]+$/i).message(getLabel('suffixe.debut_invalide'))
-  .max(9).message(getLabel('suffixe.trop_long'))
+async function validVoie(voie, error) {
+  if (!validObjectID(voie)) {
+    addError(error, 'voie', 'La valeur du champ voie est incorrecte')
+  }
+}
 
-const commentValidation = Joi.string().max(5000).message('Le commentiare est trop long (5000 caractères maximum)')
-const positionsValidation = Joi.array().items(position.createSchema)
-const toponymeValidation = Joi.string().custom(validObjectID)
-const parcellesValidation = Joi.array().items(Joi.string().regex(/^[A-Z\d]+$/).length(14)).default([])
-const certifieValidation = Joi.boolean()
+async function validToponyme(toponyme, error) {
+  if (!validObjectID(toponyme)) {
+    addError(error, 'toponyme', 'La valeur du champ toponyme est incorrecte')
+  }
+}
 
-const createSchema = Joi.object().keys({
-  numero: numeroValidation.required(),
-  suffixe: suffixeValidation.allow(null),
-  comment: commentValidation.allow(null),
-  positions: positionsValidation,
-  toponyme: toponymeValidation.allow(null),
-  parcelles: parcellesValidation,
-  certifie: certifieValidation.default(false)
-})
+async function validParcelles(parcelles, error) {
+  parcelles.forEach(parcelle => {
+    const match = parcelle.match(/^[A-Z\d]+$/)
+    if (parcelle.length !== 14 || !match) {
+      addError(error, 'parcelles', `Le numéro de parcelle "${parcelle}" est invalide`)
+    }
+  })
+}
+
+const createSchema = {
+  numero: {valid: validNumero, isRequired: true, nullAllowed: false, type: 'number'},
+  suffixe: {valid: validSuffixe, isRequired: false, nullAllowed: true, type: 'string'},
+  comment: {valid: validComment, isRequired: false, nullAllowed: true, type: 'string'},
+  positions: {valid: validPositions, isRequired: false, nullAllowed: false, type: 'array'},
+  toponyme: {valid: validToponyme, isRequired: false, nullAllowed: true, type: 'string'},
+  parcelles: {valid: validParcelles, isRequired: false, nullAllowed: false, type: 'array'},
+  certifie: {valid: null, isRequired: false, nullAllowed: false, type: 'boolean'}
+}
+
+const updateSchema = {
+  voie: {valid: validVoie, isRequired: false, nullAllowed: false, type: 'string'},
+  numero: {valid: validNumero, isRequired: false, nullAllowed: false, type: 'number'},
+  suffixe: {valid: validSuffixe, isRequired: false, nullAllowed: true, type: 'string'},
+  comment: {valid: validComment, isRequired: false, nullAllowed: true, type: 'string'},
+  positions: {valid: validPositions, isRequired: false, nullAllowed: false, type: 'array'},
+  toponyme: {valid: validToponyme, isRequired: false, nullAllowed: true, type: 'string'},
+  parcelles: {valid: validParcelles, isRequired: false, nullAllowed: false, type: 'array'},
+  certifie: {valid: null, isRequired: false, nullAllowed: false, type: 'boolean'}
+}
+
+const batchUpdateSchema = {
+  voie: {valid: validVoie, isRequired: false, nullAllowed: true, type: 'string'},
+  positionType: {valid: positionModel.validPositionType, isRequired: false, nullAllowed: true, type: 'string'},
+  comment: {valid: validComment, isRequired: false, nullAllowed: true, type: 'string'},
+  toponyme: {valid: validToponyme, isRequired: false, nullAllowed: true, type: 'string'},
+  certifie: {valid: null, isRequired: false, nullAllowed: false, type: 'boolean'}
+}
 
 async function create(idVoie, payload) {
-  const numero = validPayload(payload, createSchema)
+  const numero = await validPayload(payload, createSchema)
 
   const voie = await mongo.db.collection('voies').findOne({_id: mongo.parseObjectID(idVoie)})
 
@@ -143,37 +193,8 @@ function filterSensitiveFields(numero) {
   return omit(numero, 'comment')
 }
 
-const updateSchema = Joi.object().keys({
-  numero: Joi.number().min(0).max(9999).integer(),
-  voie: Joi.string().custom(validObjectID),
-  suffixe: suffixeValidation.allow(null),
-  comment: commentValidation.allow(null),
-  positions: positionsValidation,
-  toponyme: toponymeValidation.allow(null),
-  parcelles: parcellesValidation,
-  certifie: certifieValidation
-})
-
-const batchUpdateSchema = Joi.object().keys({
-  voie: Joi.string().custom(validObjectID).allow(null),
-  positionType: Joi.string().valid(
-    'entrée',
-    'délivrance postale',
-    'bâtiment',
-    'cage d’escalier',
-    'logement',
-    'parcelle',
-    'segment',
-    'service technique',
-    'inconnue'
-  ).allow(null),
-  comment: Joi.string().max(5000).allow(null),
-  toponyme: Joi.string().custom(validObjectID).allow(null),
-  certifie: Joi.boolean()
-})
-
 async function update(id, payload) {
-  const numeroChanges = validPayload(payload, updateSchema)
+  const numeroChanges = await validPayload(payload, updateSchema)
 
   if (numeroChanges.voie) {
     const voie = await mongo.db.collection('voies').findOne({
@@ -289,7 +310,7 @@ function normalizeSuffixe(suffixe) {
 
 async function batchUpdateNumeros(idBal, body) {
   const {numerosIds, changes} = body
-  const {voie, certifie, positionType, toponyme, comment} = validPayload(changes, batchUpdateSchema)
+  const {voie, certifie, positionType, toponyme, comment} = await validPayload(changes, batchUpdateSchema)
 
   if (voie) {
     const voieRequested = await mongo.db.collection('voies').findOne({
@@ -423,6 +444,8 @@ async function batchRemoveNumeros(idBal, body) {
 module.exports = {
   create,
   createSchema,
+  validPositions,
+  validParcelles,
   importMany,
   filterSensitiveFields,
   update,

--- a/lib/models/numero.js
+++ b/lib/models/numero.js
@@ -56,12 +56,13 @@ async function validToponyme(toponyme, error) {
 }
 
 async function validParcelles(parcelles, error) {
-  parcelles.forEach(parcelle => {
-    const match = parcelle.match(/^[A-Z\d]+$/)
-    if (parcelle.length !== 14 || !match) {
-      addError(error, 'parcelles', `Le numéro de parcelle "${parcelle}" est invalide`)
-    }
-  })
+  if (parcelles.length > 0) {
+    const {errors} = await validateurBAL(parcelles.join('|'), 'cad_parcelles')
+
+    errors.forEach(err => {
+      addError(error, 'parcelles', err)
+    })
+  }
 }
 
 const createSchema = {

--- a/lib/models/position.js
+++ b/lib/models/position.js
@@ -11,7 +11,7 @@ async function validPoint(point, error) {
       const [lat, long] = point.coordinates
 
       if (typeof lat !== 'number' || typeof long !== 'number') {
-        addError(error, 'positions', 'le champ point.coordinates est incorrecte')
+        addError(error, 'positions', 'la valeur du champ point.coordinates est incorrecte')
         return
       }
 
@@ -26,7 +26,7 @@ async function validPoint(point, error) {
         addError(error, 'positions', err)
       })
     } else {
-      addError(error, 'positions', 'le champ point.coordinates est incorrecte')
+      addError(error, 'positions', 'la valeur du champ point.coordinates est incorrecte')
     }
   } else {
     addError(error, 'positions', 'Le champ point est invalide')

--- a/lib/models/position.js
+++ b/lib/models/position.js
@@ -1,23 +1,57 @@
-const Joi = require('joi')
+const {addError} = require('../util/payload')
+const {validateurBAL} = require('../validateur-bal')
 
-const createSchema = Joi.object().keys({
-  point: Joi.object({
-    type: Joi.string().strict().valid('Point').required(),
-    coordinates: Joi.array().items(Joi.number()).min(2).max(2).required()
-  }).required(),
-  source: Joi.string().allow(null),
-  type: Joi.string().valid(
-    'entrée',
-    'délivrance postale',
-    'bâtiment',
-    'cage d’escalier',
-    'logement',
-    'parcelle',
-    'segment',
-    'service technique',
-    'inconnue'
-  ).required()
-})
+async function validPoint(point, error) {
+  if (point.type && point.coordinates) {
+    if (point.type !== 'Point') {
+      addError(error, 'point', 'Le champ point.type doit avoir pour valeur "Point"')
+    }
+
+    if (Array.isArray(point.coordinates) && point.coordinates.length === 2) {
+      const [lat, long] = point.coordinates
+
+      if (typeof lat !== 'number' || typeof long !== 'number') {
+        addError(error, 'positions', 'le champ point.coordinates est incorrecte')
+        return
+      }
+
+      const latResults = await validateurBAL(lat.toString(), 'lat')
+
+      latResults.errors.forEach(err => {
+        addError(error, 'positions', err)
+      })
+
+      const longResults = await validateurBAL(long.toString(), 'long')
+      longResults.errors.forEach(err => {
+        addError(error, 'positions', err)
+      })
+    } else {
+      addError(error, 'positions', 'le champ point.coordinates est incorrecte')
+    }
+  } else {
+    addError(error, 'positions', 'Le champ point est invalide')
+  }
+}
+
+async function validSource(source, error) {
+  const {errors} = await validateurBAL(source, 'source')
+  errors.forEach(err => {
+    addError(error, 'positions', err)
+  })
+}
+
+async function validPositionType(type, error) {
+  const {errors} = await validateurBAL(type, 'position')
+  errors.forEach(err => {
+    addError(error, 'positions', err)
+  })
+}
+
+const createSchema = {
+  point: {valid: validPoint, isRequired: true, nullAllowed: false, type: 'object'},
+  source: {valid: validSource, isRequired: false, nullAllowed: true, type: 'string'},
+  type: {valid: validPositionType, isRequired: true, nullAllowed: false, type: 'string'}
+}
 
 const updateSchema = createSchema
 

--- a/lib/models/position.js
+++ b/lib/models/position.js
@@ -34,17 +34,21 @@ async function validPoint(point, error) {
 }
 
 async function validSource(source, error) {
-  const {errors} = await validateurBAL(source, 'source')
+  const {value, errors} = await validateurBAL(source, 'source')
   errors.forEach(err => {
     addError(error, 'positions', err)
   })
+
+  return value
 }
 
 async function validPositionType(type, error) {
-  const {errors} = await validateurBAL(type, 'position')
+  const {value, errors} = await validateurBAL(type, 'position')
   errors.forEach(err => {
     addError(error, 'positions', err)
   })
+
+  return value
 }
 
 const createSchema = {

--- a/lib/models/toponyme.js
+++ b/lib/models/toponyme.js
@@ -1,24 +1,31 @@
-const Joi = require('joi')
 const mongo = require('../util/mongo')
-const {validPayload} = require('../util/payload')
+const {validPayload, addError} = require('../util/payload')
 const {getFilteredPayload} = require('../util/payload')
-const position = require('./position')
 const {cleanNom} = require('./voie')
 const nomAltSchema = require('./nom-alt')
+const {validPositions, validParcelles} = require('./numero')
 
-const nomValidation = Joi.string()
-  .min(1).message('Le nom est trop court (1 caractère minimum)')
-  .max(200).message('Le nom est trop long (200 caractères maximum)')
+function validNom(nom, error) {
+  if (nom.length === 0) {
+    addError(error, 'nom', 'Le nom est trop court (1 caractère minimum)')
+  } else if (nom.length > 200) {
+    addError(error, 'nom', 'Le nom est trop long (200 caractères maximum)')
+  }
+}
 
-const positionsValidation = Joi.array().items(position.createSchema)
-const parcellesValidation = Joi.array().items(Joi.string().regex(/^[A-Z\d]+$/).length(14)).default([])
+const createSchema = {
+  nom: {valid: validNom, isRequired: true, nullAllowed: false, type: 'string'},
+  nomAlt: nomAltSchema.createSchema,
+  positions: {valid: validPositions, isRequired: false, nullAllowed: false, type: 'array'},
+  parcelles: {valid: validParcelles, isRequired: false, nullAllowed: true, type: 'array'}
+}
 
-const createSchema = Joi.object().keys({
-  nom: nomValidation.required(),
-  positions: positionsValidation,
-  parcelles: parcellesValidation,
-  nomAlt: nomAltSchema.createSchema.allow(null)
-})
+const updateSchema = {
+  nom: {valid: validNom, isRequired: false, nullAllowed: false, type: 'string'},
+  nomAlt: nomAltSchema.updateSchema,
+  positions: {valid: validPositions, isRequired: false, nullAllowed: false, type: 'array'},
+  parcelles: {valid: validParcelles, isRequired: false, nullAllowed: true, type: 'array'}
+}
 
 async function create(idBal, payload) {
   if (payload.nom) {
@@ -29,7 +36,7 @@ async function create(idBal, payload) {
     payload.nomAlt = nomAltSchema.cleanNomAlt(payload.nomAlt)
   }
 
-  const toponyme = validPayload(payload, createSchema)
+  const toponyme = await validPayload(payload, createSchema)
   const baseLocale = await mongo.db.collection('bases_locales').findOne({_id: mongo.parseObjectID(idBal)})
 
   if (!baseLocale) {
@@ -51,13 +58,6 @@ async function create(idBal, payload) {
   return toponyme
 }
 
-const updateSchema = Joi.object().keys({
-  nom: nomValidation,
-  positions: positionsValidation,
-  parcelles: parcellesValidation,
-  nomAlt: nomAltSchema.updateSchema.allow(null)
-})
-
 async function update(id, payload) {
   if (payload.nom) {
     payload.nom = cleanNom(payload.nom)
@@ -67,7 +67,7 @@ async function update(id, payload) {
     payload.nomAlt = nomAltSchema.cleanNomAlt(payload.nomAlt)
   }
 
-  const toponymeChanges = validPayload(payload, updateSchema)
+  const toponymeChanges = await validPayload(payload, updateSchema)
 
   if (toponymeChanges.nomAlt) {
     toponymeChanges.nomAlt = nomAltSchema.getNomAltDefault(toponymeChanges.nomAlt)

--- a/lib/models/voie.js
+++ b/lib/models/voie.js
@@ -10,11 +10,13 @@ function cleanNom(nom) {
 }
 
 async function validNom(nom, error) {
-  const {errors} = await validateurBAL(nom, 'voie_nom')
+  const {value, errors} = await validateurBAL(nom, 'voie_nom')
 
   errors.forEach(err => {
     addError(error, 'nom', err)
   })
+
+  return value
 }
 
 async function validCode(code, error) {

--- a/lib/models/voie.js
+++ b/lib/models/voie.js
@@ -20,8 +20,7 @@ async function validNom(nom, error) {
 }
 
 async function validCode(code, error) {
-  const match = code.match(/^[\dA-Z]\d{3}$/)
-  if (code.length !== 4 || !match) {
+  if (!code.match(/^[\dA-Z]\d{3}$/)) {
     addError(error, 'code', 'Le code voie est invalide')
   }
 }

--- a/lib/models/voie.js
+++ b/lib/models/voie.js
@@ -1,8 +1,7 @@
-const Joi = require('joi')
-const {getLabel} = require('@ban-team/validateur-bal')
-const {getFilteredPayload} = require('../util/payload')
+const {getFilteredPayload, addError} = require('../util/payload')
 const mongo = require('../util/mongo')
 const {validPayload} = require('../util/payload')
+const {validateurBAL} = require('../validateur-bal')
 const Numero = require('./numero')
 const nomAltSchema = require('./nom-alt')
 
@@ -10,19 +9,55 @@ function cleanNom(nom) {
   return nom.replace(/^\s+/g, '').replace(/\s+$/g, '').replace(/\s\s+/g, ' ')
 }
 
-const nomValidation = Joi.string()
-  .min(3).message(getLabel('voie_nom.trop_court'))
-  .max(200).message(getLabel('voie_nom.trop_long'))
+async function validNom(nom, error) {
+  const {errors} = await validateurBAL(nom, 'voie_nom')
 
-const createSchema = Joi.object().keys({
-  nom: nomValidation.required(),
-  typeNumerotation: Joi.string().valid('numerique', 'metrique'),
-  trace: Joi.object({
-    type: Joi.string().valid('LineString').required(),
-    coordinates: Joi.array().required()
-  }).allow(null),
-  nomAlt: nomAltSchema.createSchema.allow(null)
-})
+  errors.forEach(err => {
+    addError(error, 'nom', err)
+  })
+}
+
+async function validCode(code, error) {
+  const match = code.match(/^[\dA-Z]\d{3}$/)
+  if (code.length !== 4 || !match) {
+    addError(error, 'code', 'Le code voie est invalide')
+  }
+}
+
+async function validTrace(trace, error) {
+  if (trace.type && trace.coordinates) {
+    if (trace.type !== 'LineString') {
+      addError(error, 'trace', 'Le champ "trace.type" doit avoir pour valeur : "LineString"')
+    }
+
+    if (!Array.isArray(trace.coordinates)) {
+      addError(error, 'trace', 'Le valeur du champ "type.coordinates" est incorrecte')
+    }
+  } else {
+    addError(error, 'trace', 'Le champ "trace" est invalide, "type" et "coordinates" sont obligatoires')
+  }
+}
+
+async function validTypeNumerotation(typeNumerotation, error) {
+  if (!['numerique', 'metrique'].includes(typeNumerotation)) {
+    addError(error, 'typeNumerotation', 'La valeur du champ typeNumerotation est incorrecte, seules "numerique" et "metrique" sont autorisées')
+  }
+}
+
+const createSchema = {
+  nom: {valid: validNom, isRequired: true, nullAllowed: false, type: 'string'},
+  nomAlt: nomAltSchema.createSchema,
+  typeNumerotation: {valid: validTypeNumerotation, isRequired: false, nullAllowed: false, type: 'string'},
+  trace: {valid: validTrace, isRequired: false, nullAllowed: true, type: 'object'},
+}
+
+const updateSchema = {
+  nom: {valid: validNom, isRequired: false, nullAllowed: false, type: 'string'},
+  nomAlt: nomAltSchema.updateSchema,
+  code: {valid: validCode, isRequired: false, nullAllowed: true, type: 'string'},
+  typeNumerotation: {valid: validTypeNumerotation, isRequired: false, nullAllowed: false, type: 'string'},
+  trace: {valid: validTrace, isRequired: false, nullAllowed: true, type: 'object'}
+}
 
 async function create(baseLocale, payload) {
   if (payload.nom) {
@@ -33,7 +68,7 @@ async function create(baseLocale, payload) {
     payload.nomAlt = nomAltSchema.cleanNomAlt(payload.nomAlt)
   }
 
-  const voie = validPayload(payload, createSchema)
+  const voie = await validPayload(payload, createSchema)
 
   voie._id = new mongo.ObjectId()
   voie._bal = baseLocale._id
@@ -99,17 +134,6 @@ async function importMany(idBal, rawVoies, options = {}) {
   await mongo.db.collection('voies').insertMany(voies)
 }
 
-const updateSchema = Joi.object().keys({
-  nom: nomValidation,
-  code: Joi.string().regex(/^[\dA-Z]\d{3}$/).allow(null),
-  typeNumerotation: Joi.string().valid('numerique', 'metrique'),
-  trace: Joi.object({
-    type: Joi.string().valid('LineString').required(),
-    coordinates: Joi.array().required()
-  }).allow(null),
-  nomAlt: nomAltSchema.updateSchema.allow(null)
-})
-
 async function update(id, payload) {
   if (payload.nom) {
     payload.nom = cleanNom(payload.nom)
@@ -119,7 +143,7 @@ async function update(id, payload) {
     payload.nomAlt = nomAltSchema.cleanNomAlt(payload.nomAlt)
   }
 
-  const voieChanges = validPayload(payload, updateSchema)
+  const voieChanges = await validPayload(payload, updateSchema)
 
   if (voieChanges.nomAlt) {
     voieChanges.nomAlt = nomAltSchema.getNomAltDefault(voieChanges.nomAlt)
@@ -173,7 +197,7 @@ async function getVoie(id) {
 
 async function batchUpdateNumeros(idVoie, changes) {
   const now = new Date()
-  const {certifie} = validPayload(changes, Numero.updateSchema)
+  const {certifie} = await validPayload(changes, Numero.updateSchema)
 
   const voie = mongo.db.collection('voies').findOne({_id: mongo.parseObjectID(idVoie)})
   const {modifiedCount} = await mongo.db.collection('numeros').updateMany({

--- a/lib/routes/__tests__/base-locale.js
+++ b/lib/routes/__tests__/base-locale.js
@@ -62,13 +62,13 @@ test.serial('create a BaseLocale / invalid payload', async t => {
     message: 'Invalid payload',
     validation: {
       nom: [
-        '"nom" is required'
+        'Le champ nom est obligatoire'
       ],
       emails: [
-        '"emails" is required'
+        'Le champ emails est obligatoire'
       ],
       commune: [
-        '"commune" is required'
+        'Le champ commune est obligatoire'
       ]
     }
   })
@@ -288,8 +288,8 @@ test.serial('modify a BaseLocal / invalid payload', async t => {
     code: 400,
     message: 'Invalid payload',
     validation: {
-      nom: ['"nom" is not allowed to be empty'],
-      emails: ['"emails" must contain at least 1 items']
+      nom: ['Le nom est trop court (1 caractère minimum)'],
+      emails: ['Le champ emails doit contenir au moins une adresse email']
     }
   })
 })

--- a/lib/routes/__tests__/numeros.js
+++ b/lib/routes/__tests__/numeros.js
@@ -110,7 +110,7 @@ test.serial('create a numero / invalid payload', async t => {
     code: 400,
     message: 'Invalid payload',
     validation: {
-      numero: ['"numero" must be a number']
+      numero: ['Le champ numero doit être de type "number"']
     }
   })
 })
@@ -157,8 +157,7 @@ test.serial('create a numero / invalid parcelles', async t => {
     message: 'Invalid payload',
     validation: {
       parcelles: [
-        '"parcelles[0]" with value "invalid" fails to match the required pattern: /^[A-Z\\d]+$/',
-        '"parcelles[0]" length must be 14 characters long'
+        'Le numéro de parcelle "invalid" est invalide'
       ]
     }
   })
@@ -821,7 +820,7 @@ test.serial('modify a numero / invalid payload', async t => {
     code: 400,
     message: 'Invalid payload',
     validation: {
-      numero: ['"numero" must be a number']
+      numero: ['Le champ numero doit être de type "number"']
     }
   })
 })

--- a/lib/routes/__tests__/numeros.js
+++ b/lib/routes/__tests__/numeros.js
@@ -3,7 +3,7 @@ const {MongoMemoryServer} = require('mongodb-memory-server')
 const express = require('express')
 const request = require('supertest')
 const {omit} = require('lodash')
-const {getLabel} = require('@etalab/bal')
+const {getLabel} = require('@ban-team/validateur-bal')
 const mongo = require('../../util/mongo')
 const routes = require('..')
 

--- a/lib/routes/__tests__/numeros.js
+++ b/lib/routes/__tests__/numeros.js
@@ -3,6 +3,7 @@ const {MongoMemoryServer} = require('mongodb-memory-server')
 const express = require('express')
 const request = require('supertest')
 const {omit} = require('lodash')
+const {getLabel} = require('@etalab/bal')
 const mongo = require('../../util/mongo')
 const routes = require('..')
 
@@ -157,7 +158,7 @@ test.serial('create a numero / invalid parcelles', async t => {
     message: 'Invalid payload',
     validation: {
       parcelles: [
-        'Le numéro de parcelle "invalid" est invalide'
+        getLabel('cad_parcelles.valeur_invalide')
       ]
     }
   })

--- a/lib/routes/__tests__/toponymes.js
+++ b/lib/routes/__tests__/toponymes.js
@@ -114,7 +114,10 @@ test.serial('create a toponyme / with unsupported nomAlt', async t => {
     code: 400,
     message: 'Invalid payload',
     validation: {
-      nomAlt: ['"nomAlt" failed custom validation because Valeurs "nomAlt" inattendues : gua et bri. Valeurs attendues : fra, bre, eus, gsw, cos, gcr, gcf, rcf, swb ou oci']
+      nomAlt: [
+        'Le code langue régionale gua n’est pas supporté',
+        'Le code langue régionale bri n’est pas supporté'
+      ]
     }
   })
 })

--- a/lib/routes/__tests__/toponymes.js
+++ b/lib/routes/__tests__/toponymes.js
@@ -134,12 +134,11 @@ test.serial('create a toponyme / without nom', async t => {
   const {status, body} = await request(getApp())
     .post(`/bases-locales/${_id}/toponymes`)
     .set({Authorization: 'Token coucou'})
-    .send({position:
-      {
-        point: {type: 'Point', coordinates: [1, 1]},
-        type: 'entrée',
-        source: 'ban'
-      }
+    .send({positions: [{
+      point: {type: 'Point', coordinates: [1, 1]},
+      type: 'entrée',
+      source: 'ban'
+    }]
     })
 
   t.is(status, 400)
@@ -147,7 +146,7 @@ test.serial('create a toponyme / without nom', async t => {
     code: 400,
     message: 'Invalid payload',
     validation: {
-      nom: ['"nom" is required']
+      nom: ['Le champ nom est obligatoire']
     }
   })
 })
@@ -354,7 +353,7 @@ test.serial('modify a toponyme / empty nom', async t => {
     code: 400,
     message: 'Invalid payload',
     validation: {
-      nom: ['"nom" is not allowed to be empty']
+      nom: ['Le nom est trop court (1 caractère minimum)']
     }
   })
 })

--- a/lib/routes/__tests__/voies.js
+++ b/lib/routes/__tests__/voies.js
@@ -116,7 +116,10 @@ test.serial('create a voie / with unsupported nomAlt', async t => {
     code: 400,
     message: 'Invalid payload',
     validation: {
-      nomAlt: ['"nomAlt" failed custom validation because Valeurs "nomAlt" inattendues : gua et bri. Valeurs attendues : fra, bre, eus, gsw, cos, gcr, gcf, rcf, swb ou oci']
+      nomAlt: [
+        'Le code langue régionale gua n’est pas supporté',
+        'Le code langue régionale bri n’est pas supporté'
+      ]
     }
   })
 })

--- a/lib/routes/__tests__/voies.js
+++ b/lib/routes/__tests__/voies.js
@@ -163,7 +163,7 @@ test.serial('create a voie / invalid voie', async t => {
     code: 400,
     message: 'Invalid payload',
     validation: {
-      nom: ['"nom" is required']
+      nom: ['Le champ nom est obligatoire']
     }
   })
 })
@@ -510,7 +510,7 @@ test.serial('modify a voie / invalid payload', async t => {
     code: 400,
     message: 'Invalid payload',
     validation: {
-      code: ['"code" with value "invalid code" fails to match the required pattern: /^[\\dA-Z]\\d{3}$/']
+      code: ['Le code voie est invalide']
     }
   })
   const voie = await mongo.db.collection('voies').findOne({_id})

--- a/lib/util/__tests__/payload.js
+++ b/lib/util/__tests__/payload.js
@@ -1,11 +1,10 @@
 const test = require('ava')
-const Joi = require('joi')
-const {getFilteredPayload, validPayload, ValidationError} = require('../payload')
+const {getFilteredPayload, validPayload, ValidationError, addError} = require('../payload')
 
 test('filter payload for create baselocal schema', t => {
-  const schema = Joi.object().keys({
-    foo: Joi.string()
-  })
+  const schema = {
+    foo: {valid: null, isRequired: false, nullAllowed: false, type: 'string'}
+  }
   const payload = {
     foo: 'bar',
     bar: 'bar'
@@ -16,32 +15,34 @@ test('filter payload for create baselocal schema', t => {
   t.deepEqual(filteredPayload, {foo: 'bar'})
 })
 
-test('check a valid payload', t => {
-  const schema = Joi.object().keys({
-    foo: Joi.string()
-  })
+test('check a valid payload', async t => {
+  const schema = {
+    foo: {valid: null, isRequired: false, nullAllowed: false, type: 'string'}
+  }
   const payload = {
     foo: 'foo'
   }
 
-  t.notThrows(() => validPayload(payload, schema))
+  await t.notThrowsAsync(validPayload(payload, schema))
 })
 
-test('check a invalid payload', t => {
+test('check a invalid payload', async t => {
   const payload = {bar: '', toto: '1'}
-  const schema = Joi.object().keys({
-    foo: Joi.string().required(),
-    bar: Joi.string().min(1),
-    toto: Joi.number().required()
-  })
+  const schema = {
+    foo: {valid: null, isRequired: true, nullAllowed: false, type: 'string'},
+    bar: {valid(p, err) {
+      if (p.length === 0) {
+        addError(err, 'bar', 'Le champ est trop court (1 caractère minimum)')
+      }
+    }, isRequired: false, nullAllowed: false, type: 'string'},
+    toto: {valid: null, isRequired: true, nullAllowed: false, type: 'number'}
+  }
 
-  const error = t.throws(() => {
-    validPayload(payload, schema)
-  }, {instanceOf: ValidationError})
+  const error = await t.throwsAsync(validPayload(payload, schema), {instanceOf: ValidationError})
 
   t.deepEqual(error.validation, {
-    foo: ['"foo" is required'],
-    bar: ['"bar" is not allowed to be empty'],
-    toto: ['"toto" must be a number']
+    foo: ['Le champ foo est obligatoire'],
+    bar: ['Le champ est trop court (1 caractère minimum)'],
+    toto: ['Le champ toto doit être de type "number"']
   })
 })

--- a/lib/util/__tests__/validateur-bal.js
+++ b/lib/util/__tests__/validateur-bal.js
@@ -1,0 +1,12 @@
+const test = require('ava')
+const {validateurBAL} = require('../../validateur-bal')
+
+test('validateur BAL valid nom voie', async t => {
+  const {value} = await validateurBAL('chemin du moulin', 'voie_nom')
+  t.is(value, 'chemin du moulin')
+})
+
+test('validateur BAL - autocorrect', async t => {
+  const {value} = await validateurBAL('chemin_du_moulin', 'voie_nom')
+  t.is(value, 'chemin du moulin')
+})

--- a/lib/util/payload.js
+++ b/lib/util/payload.js
@@ -1,40 +1,74 @@
-const {pick} = require('lodash')
+const {pick, assign, difference} = require('lodash')
 
 class ValidationError extends Error {
   constructor(validationDetails) {
     super('Invalid payload')
-    this.validation = validationDetails.reduce((acc, detail) => {
-      const key = detail.path[0]
-      if (!acc[key]) {
-        acc[key] = []
-      }
-
-      acc[key].push(detail.message)
-      return acc
-    }, {})
+    this.validation = validationDetails
   }
 }
 
+function addError(errors, name, label) {
+  if (errors[name]) {
+    return errors[name].push(label)
+  }
+
+  errors[name] = [label]
+  return errors
+}
+
+function isValidValueType(value, type) {
+  if (Array.isArray(value)) {
+    return type === 'array'
+  }
+
+  return typeof value === type
+}
+
 function getFilteredPayload(payload, schema) {
-  const acceptableKeys = Object.keys(schema.describe().keys)
+  const acceptableKeys = Object.keys(schema)
   return pick(payload, acceptableKeys)
 }
 
-function validPayload(payload, schema) {
-  const {error, value} = schema.validate(payload, {
-    abortEarly: false,
-    stripUnknown: true,
-    convert: false
+async function validSchema(payload, schema) {
+  const value = {}
+  const error = {}
+
+  difference(Object.keys(payload), Object.keys(schema)).forEach(key => {
+    addError(error, key, `Le champ ${key} n’est pas autorisé`)
   })
 
-  if (error) {
-    throw new ValidationError(error.details)
+  await Promise.all(Object.keys(schema).map(async key => {
+    if (schema[key].isRequired && payload[key] === undefined) {
+      addError(error, key, `Le champ ${key} est obligatoire`)
+    } else if (!schema[key].nullAllowed && payload[key] === null) {
+      addError(error, key, `Le champ ${key} ne peut pas être nul`)
+    } else if (payload[key] && !isValidValueType(payload[key], schema[key].type)) {
+      addError(error, key, `Le champ ${key} doit être de type "${schema[key].type}"`)
+    } else if (payload[key] !== undefined) {
+      if (payload[key] !== null && schema[key].valid) {
+        await schema[key].valid(payload[key], error)
+      }
+
+      assign(value, {[key]: payload[key]})
+    }
+  }))
+
+  return {value, error}
+}
+
+async function validPayload(payload, schema) {
+  const {error, value} = await validSchema(payload, schema)
+
+  if (Object.keys(error).length > 0) {
+    throw new ValidationError(error)
   }
 
   return value
 }
 
 module.exports = {
+  addError,
+  validSchema,
   getFilteredPayload,
   validPayload,
   ValidationError

--- a/lib/util/payload.js
+++ b/lib/util/payload.js
@@ -38,6 +38,7 @@ async function validSchema(payload, schema) {
   })
 
   await Promise.all(Object.keys(schema).map(async key => {
+    let parsedValue = null
     if (schema[key].isRequired && payload[key] === undefined) {
       addError(error, key, `Le champ ${key} est obligatoire`)
     } else if (!schema[key].nullAllowed && payload[key] === null) {
@@ -46,10 +47,10 @@ async function validSchema(payload, schema) {
       addError(error, key, `Le champ ${key} doit être de type "${schema[key].type}"`)
     } else if (payload[key] !== undefined) {
       if (payload[key] !== null && schema[key].valid) {
-        await schema[key].valid(payload[key], error)
+        parsedValue = await schema[key].valid(payload[key], error)
       }
 
-      assign(value, {[key]: payload[key]})
+      assign(value, {[key]: parsedValue || payload[key]})
     }
   }))
 

--- a/lib/util/payload.js
+++ b/lib/util/payload.js
@@ -1,4 +1,4 @@
-const {pick, assign, difference} = require('lodash')
+const {pick, assign} = require('lodash')
 
 class ValidationError extends Error {
   constructor(validationDetails) {
@@ -33,24 +33,22 @@ async function validSchema(payload, schema) {
   const value = {}
   const error = {}
 
-  difference(Object.keys(payload), Object.keys(schema)).forEach(key => {
-    addError(error, key, `Le champ ${key} n’est pas autorisé`)
-  })
+  const filteredPayload = pick(payload, Object.keys(schema))
 
   await Promise.all(Object.keys(schema).map(async key => {
     let parsedValue = null
-    if (schema[key].isRequired && payload[key] === undefined) {
+    if (schema[key].isRequired && filteredPayload[key] === undefined) {
       addError(error, key, `Le champ ${key} est obligatoire`)
-    } else if (!schema[key].nullAllowed && payload[key] === null) {
+    } else if (!schema[key].nullAllowed && filteredPayload[key] === null) {
       addError(error, key, `Le champ ${key} ne peut pas être nul`)
-    } else if (payload[key] && !isValidValueType(payload[key], schema[key].type)) {
+    } else if (filteredPayload[key] && !isValidValueType(filteredPayload[key], schema[key].type)) {
       addError(error, key, `Le champ ${key} doit être de type "${schema[key].type}"`)
-    } else if (payload[key] !== undefined) {
-      if (payload[key] !== null && schema[key].valid) {
-        parsedValue = await schema[key].valid(payload[key], error)
+    } else if (filteredPayload[key] !== undefined) {
+      if (filteredPayload[key] !== null && schema[key].valid) {
+        parsedValue = await schema[key].valid(filteredPayload[key], error)
       }
 
-      assign(value, {[key]: parsedValue || payload[key]})
+      assign(value, {[key]: parsedValue || filteredPayload[key]})
     }
   }))
 

--- a/lib/validateur-bal.js
+++ b/lib/validateur-bal.js
@@ -1,4 +1,4 @@
-const {getLabel, readValue} = require('@etalab/bal')
+const {getLabel, readValue} = require('@ban-team/validateur-bal')
 
 async function validateurBAL(value, label) {
   const {parsedValue, errors} = await readValue(label, value)

--- a/lib/validateur-bal.js
+++ b/lib/validateur-bal.js
@@ -1,0 +1,14 @@
+const {getLabel, readValue} = require('@etalab/bal')
+
+async function validateurBAL(value, label) {
+  const {parsedValue, errors} = await readValue(label, value)
+
+  return {
+    value: parsedValue,
+    errors: errors.map(error => getLabel(`${label}.${error}`))
+  }
+}
+
+module.exports = {
+  validateurBAL
+}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "hasha": "^5.2.2",
     "http-errors": "^2.0.0",
     "into-stream": "^6.0.0",
-    "joi": "^17.5.0",
     "lodash": "^4.17.21",
     "mongodb": "^4.6.0",
     "morgan": "^1.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -259,18 +259,6 @@
   dependencies:
     proj4 "^2.8.0"
 
-"@hapi/hoek@^9.0.0":
-  version "9.0.4"
-  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.0.4.tgz#e80ad4e8e8d2adc6c77d985f698447e8628b6010"
-  integrity sha512-EwaJS7RjoXUZ2cXXKZZxZqieGtc7RbvQhUy8FwDoMQtxWVi14tFjeFCYPZAM1mBCpOpiBpyaZbb9NeHc7eGKgw==
-
-"@hapi/topo@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-5.0.0.tgz#c19af8577fa393a06e9c77b60995af959be721e7"
-  integrity sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==
-  dependencies:
-    "@hapi/hoek" "^9.0.0"
-
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.2.tgz#68be55c737023009dfc5fe245d51181bb6476914"
@@ -333,23 +321,6 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
-
-"@sideway/address@^4.1.3":
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.3.tgz#d93cce5d45c5daec92ad76db492cc2ee3c64ab27"
-  integrity sha512-8ncEUtmnTsMmL7z1YPB47kPUq7LpKWJNFPsRzHiIajGC5uXlWGn+AmkYPcHNl8S4tcEGx+cnORnNYaw2wvL+LQ==
-  dependencies:
-    "@hapi/hoek" "^9.0.0"
-
-"@sideway/formula@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.0.tgz#fe158aee32e6bd5de85044be615bc08478a0a13c"
-  integrity sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==
-
-"@sideway/pinpoint@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
-  integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -3377,17 +3348,6 @@ istanbul-reports@^3.0.2:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
-
-joi@^17.5.0:
-  version "17.5.0"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-17.5.0.tgz#7e66d0004b5045d971cf416a55fb61d33ac6e011"
-  integrity sha512-R7hR50COp7StzLnDi4ywOXHrBrgNXuUUfJWIR5lPY5Bm/pOD3jZaTwpluUXVLRWcoWZxkrHBBJ5hLxgnlehbdw==
-  dependencies:
-    "@hapi/hoek" "^9.0.0"
-    "@hapi/topo" "^5.0.0"
-    "@sideway/address" "^4.1.3"
-    "@sideway/formula" "^3.0.0"
-    "@sideway/pinpoint" "^2.0.0"
 
 js-string-escape@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Contexte
Actuellement la validation des modèles est effectuée avec [joi](https://joi.dev). 
Cependant, la majorité des vérifications consiste à imiter le travaille que fait le [validateur-bal](https://github.com/BaseAdresseNationale/validateur-bal) afin que les BAL soient conformes au format.

Des différences de validation ont fini par voir le jour entre Mes Adresses et le Validateur, empêchant la publication de certaines BAL (ex : voie de moins de 3 caractères).

## Évolution
Cette PR propose de remplacer le `Joi` par une validation faite maison aidée par le `validateur-bal`. 

Les modèles de données seront donc toujours en accord avec la dernière version du `validateur-bal`. Et les messages d'erreur étant aussi ceux du validateur-bal, ils peuvent être directement renvoyés à l'utilisateur.

De plus, ne plus dépendre de `Joi` permet d'effectuer des validations asynchrones personnalisées avec des messages d'erreur en français. `Joi` s'est avéré ne pas être très adapté à ce besoin.

-----------------

## Nouveau système de validation de schéma
### Schémas
La validation est inspirée des schémas proposé par `Joi`. Le principe consiste à donner un objet où chaque clef est un champ à valider. À chacune de ces clefs est attachée un schéma de validation strictement formaté comme suit :

| clef         | valeur | description |
|--------------|-----|-----------|
| valid |  function |  Fonction de validation propre au champ. Elle prend en paramètre, la valeur de la clef à vérifier et un agrégateur d'erreur. Peut-être `null` si aucune validation spécifique n'est nécessaire   |
| isRequired      |  true/false |  `true` si le champ est obligatoire |
| nullAllowed      |  true/false |  `true` si le champ peut valoir `null` |
| type      |  `string`, `number`, `array`, `object` |  Permet de préciser le type de donnée attendu |

Exemple, le schéma de création d'un numéro : 
```
const createSchema = {
  numero: {valid: validNumero, isRequired: true, nullAllowed: false, type: 'number'},
  suffixe: {valid: validSuffixe, isRequired: false, nullAllowed: true, type: 'string'},
  positions: {valid: validPositions, isRequired: false, nullAllowed: false, type: 'array'},
  certifie: {valid: null, isRequired: false, nullAllowed: false, type: 'boolean'},
  …
}
```

### Validation des schémas
La validation des schémas est effectuée par la méthode `validSchema`. Celle-ci prend en paramètre le `payload` et le schéma (voir au dessus), et vérifie que le `payload` reçu respecte le schéma qui lui est imposé.

Elle s'assure tout d'abords que les pré-requis `isRequired`, `nullAllowed` et `type` du schéma sont respectés. En ensuite, si celle-ci est définie, elle appelle la fonction `valid` du schéma qui elle va s'assurer que les validations spécifiques à la clef sont respectées. C'est dans cette méthode `valid` qu'est appelé le Validateur BAL.

Tout au long du processus, un agrégateur `error` est alimenté avec les différentes erreurs qui auront été relevées.

Pour terminer, `validSchema` retourne `{value, error}`, `value` sera le `payload` qui aura été reconstitué et `error` est notre agrégateur d'erreur.

### Agrégateur d'erreur
Comportant toutes les erreurs qui auront été trouvée durant la validation du schéma, il est alimenté à l'aide la fonction helper `addError`. Elle permet d'ajouter la clef d'un champ si celle-ci n'a n'existe pas encore, mais aussi d'accumulé les erreurs sans les écraser.

Voici un exemple du contenu de l'agrégateur pour la validation d'un numéro :
```
 {
    toponyme: ['La valeur du champ toponyme est incorrecte'],
    parcelles: ['Le numéro de parcelle "KSUSH782" est invalide'],
    certifie: ['Le champ certifie doit être de type "boolean"']
  }
```
--------

## Fonctionnalité non répliquée
La fonctionnalité `Joi.default()`, permettant d'attribuer une valeur par défaut à un champ laissé à `null`, n'a pas d'équivalent dans le nouveau système de schéma.
Celle-ci n'était utilisée que pour attribuer `[]` aux parcelles d'un numéro et était de toute façon assurée par la méthode `Numero.create` qui attribue déjà des valeurs par défauts là où c'est nécessaire.