### PR TITLE
Ajout des parcelles à l'extraction des données de la BAN

### DIFF
--- a/lib/populate/extract-ban.js
+++ b/lib/populate/extract-ban.js
@@ -20,12 +20,14 @@ async function extractFromBAN(codeCommune) {
       const numero = Number.parseInt(a.numero, 10)
       const suffixe = a.rep.toLowerCase() || null
       const nomVoie = a.nom_voie
+      const parcelles = a.cad_parcelles ? a.cad_parcelles.split('|') : null
 
       const adresse = {
         codeCommune,
         nomVoie,
         numero,
         suffixe,
+        parcelles,
         positions: []
       }
 
@@ -61,6 +63,7 @@ async function extractFromBAN(codeCommune) {
         commune: codeCommune,
         numero: a.numero,
         suffixe: a.suffixe,
+        parcelles: a.parcelles,
         positions: a.positions
       }))
       .forEach(n => numeros.push(n))


### PR DESCRIPTION
Lors de la création d’une Base Adresse Locale, les parcelles ne sont pas extraites par la fonction `extractBAN` .

Cette PR ajoute et remplit le champ "parcelles" et importe les données en provenance de la BAN.

Corrige l’issue mes-adresses [#621](https://github.com/BaseAdresseNationale/mes-adresses/issues/621).



