### PR TITLE
Mise à jour du validateur bal

### DIFF
--- a/lib/models/__tests__/numero.schema.js
+++ b/lib/models/__tests__/numero.schema.js
@@ -1,4 +1,4 @@
-const {getLabel} = require('@etalab/bal')
+const {getLabel} = require('@ban-team/validateur-bal')
 const test = require('ava')
 const mongo = require('../../util/mongo')
 const {createSchema, updateSchema, expandModel, normalizeSuffixe} = require('../numero')

--- a/lib/models/numero.js
+++ b/lib/models/numero.js
@@ -1,7 +1,7 @@
 const Joi = require('joi')
 const {uniqBy, omit} = require('lodash')
 const createError = require('http-errors')
-const {getLabel} = require('@etalab/bal')
+const {getLabel} = require('@ban-team/validateur-bal')
 const {getFilteredPayload} = require('../util/payload')
 const mongo = require('../util/mongo')
 const {validPayload} = require('../util/payload')

--- a/lib/models/voie.js
+++ b/lib/models/voie.js
@@ -1,5 +1,5 @@
 const Joi = require('joi')
-const {getLabel} = require('@etalab/bal')
+const {getLabel} = require('@ban-team/validateur-bal')
 const {getFilteredPayload} = require('../util/payload')
 const mongo = require('../util/mongo')
 const {validPayload} = require('../util/payload')

--- a/lib/populate/extract-csv.js
+++ b/lib/populate/extract-csv.js
@@ -1,4 +1,4 @@
-const {validate} = require('@etalab/bal')
+const {validate} = require('@ban-team/validateur-bal')
 const {chain, compact, deburr, keyBy, min, max} = require('lodash')
 const {ObjectId} = require('../util/mongo')
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@ban-team/validateur-bal": "^2.7.1",
-    "@etalab/bal": "^2.6.0",
     "@etalab/decoupage-administratif": "^2.0.0",
     "@etalab/project-legal": "^0.6.0",
     "bluebird": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "update-cadastre": "node ./scripts/update-communes-cadastre.js"
   },
   "dependencies": {
+    "@ban-team/validateur-bal": "^2.7.1",
     "@etalab/bal": "^2.6.0",
     "@etalab/decoupage-administratif": "^2.0.0",
     "@etalab/project-legal": "^0.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -197,6 +197,23 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
+"@ban-team/validateur-bal@^2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.7.1.tgz#ff9f530593d9fbca6592b980888eec37c6cdc739"
+  integrity sha512-Xa3QdKPgISKsmhFHurtUYu3S9OZR+LLuwG5xFk2pyEliFTfRkt/+DUnICa7z/492atH31h5+QRp5w2ujN9JDcQ==
+  dependencies:
+    "@etalab/project-legal" "^0.6.0"
+    blob-to-buffer "^1.2.9"
+    bluebird "^3.7.2"
+    chalk "^4.1.2"
+    chardet "^1.4.0"
+    date-fns "^2.28.0"
+    file-type "^12.4.2"
+    iconv-lite "^0.6.3"
+    lodash "^4.17.21"
+    papaparse "^5.3.2"
+    yargs "^17.5.0"
+
 "@concordance/react@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@concordance/react/-/react-2.0.0.tgz#aef913f27474c53731f4fd79cc2f54897de90fde"

--- a/yarn.lock
+++ b/yarn.lock
@@ -236,22 +236,6 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@etalab/bal@^2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@etalab/bal/-/bal-2.6.0.tgz#8146a2d9c16e2825e9d5e8d1a29abbe1a3ce7644"
-  integrity sha512-LAiXIT0gKmjlr4rNPuzKjqxC2OezfG2PdatGKph0SyslyyawGpQNalSnUEPYCd3aZGpwqvEZJstbx9nQkZxv+Q==
-  dependencies:
-    blob-to-buffer "^1.2.9"
-    bluebird "^3.7.2"
-    chalk "^4.1.2"
-    chardet "^1.4.0"
-    date-fns "^2.28.0"
-    file-type "^12.4.2"
-    iconv-lite "^0.6.3"
-    lodash "^4.17.21"
-    papaparse "^5.3.2"
-    yargs "^17.5.0"
-
 "@etalab/decoupage-administratif@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@etalab/decoupage-administratif/-/decoupage-administratif-2.0.0.tgz#24ee640070c47e3c62883873c35450197fa5f78c"


### PR DESCRIPTION
@etalab/bal : `2.4.0` -> `2.7.1`

⚠️ @etalab/bal devient `@ban-team/validateur-bal`