### PR TITLE
Ajout des langues régionales dans l’importation / exportation au format CSV

### DIFF
--- a/lib/export/__tests__/csv-bal.js
+++ b/lib/export/__tests__/csv-bal.js
@@ -142,9 +142,9 @@ test('exportAsCsv', async t => {
   ]
 
   const csv = await exportAsCsv({voies: [voie1, voie2], toponymes: [hameau, lieuDit], numeros})
-  const expected = `cle_interop;uid_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;certification_commune;commune_insee;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj;voie_nom_gsw;lieudit_complement_nom_gsw
-54084_6789_00006;;allée des acacias;La Varenne;6;;0;54084;Mont-Bonvillers;entrée;5.83315;49.324433;905967.72;6917567.98;12345000AA0001|12345000AA0002;Mairie;2019-02-05;Akazienallee;
-54084_xxxx_99999;;La Varenne;;99999;;;54084;Mont-Bonvillers;;;;;;;commune;2019-01-05;;
-54084_xxxx_99999;;Le Moulin;;99999;;;54084;Mont-Bonvillers;segment;5.83315;49.324433;905967.72;6917567.98;12345000AA0001|12345000AA0002;Mairie;2019-01-05;Die Mühle;`.replace(/\n/g, '\r\n') + '\r\n'
+  const expected = `cle_interop;uid_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;certification_commune;commune_insee;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj;voie_nom_gsw
+54084_6789_00006;;allée des acacias;La Varenne;6;;0;54084;Mont-Bonvillers;entrée;5.83315;49.324433;905967.72;6917567.98;12345000AA0001|12345000AA0002;Mairie;2019-02-05;Akazienallee
+54084_xxxx_99999;;La Varenne;;99999;;;54084;Mont-Bonvillers;;;;;;;commune;2019-01-05;
+54084_xxxx_99999;;Le Moulin;;99999;;;54084;Mont-Bonvillers;segment;5.83315;49.324433;905967.72;6917567.98;12345000AA0001|12345000AA0002;Mairie;2019-01-05;Die Mühle`.replace(/\n/g, '\r\n') + '\r\n'
   t.is(csv, expected)
 })

--- a/lib/export/__tests__/csv-bal.js
+++ b/lib/export/__tests__/csv-bal.js
@@ -28,6 +28,9 @@ test('createRow', t => {
     codeVoie: 'XXXX',
     nomVoie: 'rue des peupliers',
     nomToponyme: 'Le Moulin',
+    nomToponymeAlt: {
+      gsw: 'Die Mühle'
+    },
     numero: 12,
     suffixe: 'bis',
     certifie: true,
@@ -47,6 +50,7 @@ test('createRow', t => {
     uid_adresse: '',
     voie_nom: 'rue des peupliers',
     lieudit_complement_nom: 'Le Moulin',
+    lieudit_complement_nom_gsw: 'Die Mühle',
     numero: '12',
     suffixe: 'bis',
     certification_commune: '1',
@@ -67,6 +71,9 @@ test('exportAsCsv', async t => {
     _id: new ObjectId(),
     commune: '54084',
     nom: 'allée des acacias',
+    nomAlt: {
+      gsw: 'Akazienallee'
+    },
     code: '6789',
     _updated: new Date('2019-01-01')
   }
@@ -88,6 +95,9 @@ test('exportAsCsv', async t => {
   const lieuDit = {
     _id: new ObjectId(),
     nom: 'Le Moulin',
+    nomAlt: {
+      gsw: 'Die Mühle'
+    },
     commune: '54084',
     positions: [{
       type: 'segment',
@@ -132,9 +142,9 @@ test('exportAsCsv', async t => {
   ]
 
   const csv = await exportAsCsv({voies: [voie1, voie2], toponymes: [hameau, lieuDit], numeros})
-  const expected = `cle_interop;uid_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;certification_commune;commune_insee;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj
-54084_6789_00006;;allée des acacias;La Varenne;6;;0;54084;Mont-Bonvillers;entrée;5.83315;49.324433;905967.72;6917567.98;12345000AA0001|12345000AA0002;Mairie;2019-02-05
-54084_xxxx_99999;;La Varenne;;99999;;;54084;Mont-Bonvillers;;;;;;;commune;2019-01-05
-54084_xxxx_99999;;Le Moulin;;99999;;;54084;Mont-Bonvillers;segment;5.83315;49.324433;905967.72;6917567.98;12345000AA0001|12345000AA0002;Mairie;2019-01-05`.replace(/\n/g, '\r\n') + '\r\n'
+  const expected = `cle_interop;uid_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;certification_commune;commune_insee;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj;voie_nom_gsw;lieudit_complement_nom_gsw
+54084_6789_00006;;allée des acacias;La Varenne;6;;0;54084;Mont-Bonvillers;entrée;5.83315;49.324433;905967.72;6917567.98;12345000AA0001|12345000AA0002;Mairie;2019-02-05;Akazienallee;
+54084_xxxx_99999;;La Varenne;;99999;;;54084;Mont-Bonvillers;;;;;;;commune;2019-01-05;;
+54084_xxxx_99999;;Le Moulin;;99999;;;54084;Mont-Bonvillers;segment;5.83315;49.324433;905967.72;6917567.98;12345000AA0001|12345000AA0002;Mairie;2019-01-05;Die Mühle;`.replace(/\n/g, '\r\n') + '\r\n'
   t.is(csv, expected)
 })

--- a/lib/export/csv-bal.js
+++ b/lib/export/csv-bal.js
@@ -29,6 +29,20 @@ function toCsvBoolean(certifie) {
   return certifie ? '1' : '0'
 }
 
+function buildHeaders(altVoiesKeys, altToponymesKeys) {
+  const headers = new Set(['cle_interop', 'uid_adresse', 'voie_nom', 'lieudit_complement_nom', 'numero', 'suffixe', 'certification_commune', 'commune_insee', 'commune_nom', 'position', 'long', 'lat', 'x', 'y', 'cad_parcelles', 'source', 'date_der_maj'])
+
+  altVoiesKeys.forEach(v => {
+    headers.add('voie_nom_' + v)
+  })
+
+  altToponymesKeys.forEach(v => {
+    headers.add('lieudit_complement_nom_' + v)
+  })
+
+  return headers
+}
+
 /* eslint camelcase: off */
 function createRow(obj) {
   const row = {
@@ -84,6 +98,20 @@ function createRow(obj) {
 async function exportAsCsv({voies, toponymes, numeros}) {
   const voiesIndex = keyBy(voies, v => v._id.toHexString())
   const rows = []
+  const altVoiesKeys = new Set([])
+  const altToponymesKeys = new Set([])
+  const regionalVoiesKeys = voies.filter(v => v.nomAlt)
+  const regionalToponymesKeys = toponymes.filter(t => t.nomAlt)
+
+  regionalVoiesKeys.forEach(k => {
+    altVoiesKeys.add(...Object.keys(k.nomAlt))
+  })
+
+  regionalToponymesKeys.forEach(k => {
+    altToponymesKeys.add(...Object.keys(k.nomAlt))
+  })
+
+  altVoiesKeys.add(...altToponymesKeys)
 
   numeros.forEach(n => {
     const voieId = n.voie.toHexString()
@@ -140,15 +168,17 @@ async function exportAsCsv({voies, toponymes, numeros}) {
         numero: 99999,
         _updated: t._updated,
         nomVoie: t.nom,
-        nomVoieAlt: t.nomAlt,
+        nomVoieAlt: t.nomAlt || null,
         parcelles: t.parcelles
       })
     }
   })
 
+  const headers = [...buildHeaders(altVoiesKeys, altToponymesKeys)]
+
   return getStream(pumpify.obj(
     intoStream.object(rows.map(row => createRow(row))),
-    csvWriter({separator: ';', newline: '\r\n'})
+    csvWriter({separator: ';', newline: '\r\n', headers})
   ))
 }
 

--- a/lib/export/csv-bal.js
+++ b/lib/export/csv-bal.js
@@ -29,28 +29,14 @@ function toCsvBoolean(certifie) {
   return certifie ? '1' : '0'
 }
 
-function buildHeaders(altVoiesKeys, altToponymesKeys) {
-  return [
-    'cle_interop',
-    'uid_adresse',
-    'voie_nom',
-    'lieudit_complement_nom',
-    'numero',
-    'suffixe',
-    'certification_commune',
-    'commune_insee',
-    'commune_nom',
-    'position',
-    'long',
-    'lat',
-    'x',
-    'y',
-    'cad_parcelles',
-    'source',
-    'date_der_maj',
-    ...altVoiesKeys.map(v => `voie_nom_${v}`),
-    ...altToponymesKeys.map(v => `lieudit_complement_nom_${v}`)
-  ]
+function extractHeaders(csvRows) {
+  const headers = new Set()
+
+  for (const row of csvRows) {
+    for (const header of Object.keys(row)) {
+      headers.add(header)
+    }
+  }
 }
 
 /* eslint camelcase: off */
@@ -108,20 +94,6 @@ function createRow(obj) {
 async function exportAsCsv({voies, toponymes, numeros}) {
   const voiesIndex = keyBy(voies, v => v._id.toHexString())
   const rows = []
-  const altVoiesKeys = new Set([])
-  const altToponymesKeys = new Set([])
-  const regionalVoiesKeys = voies.filter(v => v.nomAlt)
-  const regionalToponymesKeys = toponymes.filter(t => t.nomAlt)
-
-  regionalVoiesKeys.forEach(k => {
-    altVoiesKeys.add(...Object.keys(k.nomAlt))
-  })
-
-  regionalToponymesKeys.forEach(k => {
-    altToponymesKeys.add(...Object.keys(k.nomAlt))
-  })
-
-  altVoiesKeys.add(...altToponymesKeys)
 
   numeros.forEach(n => {
     const voieId = n.voie.toHexString()
@@ -184,10 +156,11 @@ async function exportAsCsv({voies, toponymes, numeros}) {
     }
   })
 
-  const headers = [...buildHeaders(altVoiesKeys, altToponymesKeys)]
+  const csvRows = rows.map(row => createRow(row))
+  const headers = extractHeaders(csvRows)
 
   return getStream(pumpify.obj(
-    intoStream.object(rows.map(row => createRow(row))),
+    intoStream.object(csvRows),
     csvWriter({separator: ';', newline: '\r\n', headers})
   ))
 }

--- a/lib/export/csv-bal.js
+++ b/lib/export/csv-bal.js
@@ -30,21 +30,27 @@ function toCsvBoolean(certifie) {
 }
 
 function buildHeaders(altVoiesKeys, altToponymesKeys) {
-  const headers = new Set(['cle_interop', 'uid_adresse', 'voie_nom', 'lieudit_complement_nom', 'numero', 'suffixe', 'certification_commune', 'commune_insee', 'commune_nom', 'position', 'long', 'lat', 'x', 'y', 'cad_parcelles', 'source', 'date_der_maj'])
-
-  if (altVoiesKeys.size > 0) {
-    altVoiesKeys.forEach(v => {
-      headers.add('voie_nom_' + v)
-    })
-  }
-
-  if (altToponymesKeys.size > 0) {
-    altToponymesKeys.forEach(v => {
-      headers.add('lieudit_complement_nom_' + v)
-    })
-  }
-
-  return headers
+  return [
+    'cle_interop',
+    'uid_adresse',
+    'voie_nom',
+    'lieudit_complement_nom',
+    'numero',
+    'suffixe',
+    'certification_commune',
+    'commune_insee',
+    'commune_nom',
+    'position',
+    'long',
+    'lat',
+    'x',
+    'y',
+    'cad_parcelles',
+    'source',
+    'date_der_maj',
+    ...altVoiesKeys.map(v => `voie_nom_${v}`),
+    ...altToponymesKeys.map(v => `lieudit_complement_nom_${v}`)
+  ]
 }
 
 /* eslint camelcase: off */

--- a/lib/export/csv-bal.js
+++ b/lib/export/csv-bal.js
@@ -63,15 +63,13 @@ function createRow(obj) {
 
   if (obj.nomVoieAlt) {
     Object.keys(obj.nomVoieAlt).forEach(o => {
-      const newKey = 'voie_nom_' + o
-      row[newKey] = obj.nomVoieAlt[o]
+      row['voie_nom_' + o] = obj.nomVoieAlt[o]
     })
   }
 
   if (obj.nomToponymeAlt) {
     Object.keys(obj.nomToponymeAlt).forEach(o => {
-      const newKey = 'lieudit_complement_nom_' + o
-      row[newKey] = obj.nomToponymeAlt[o]
+      row['lieudit_complement_nom_' + o] = obj.nomToponymeAlt[o]
     })
   }
 

--- a/lib/export/csv-bal.js
+++ b/lib/export/csv-bal.js
@@ -32,13 +32,17 @@ function toCsvBoolean(certifie) {
 function buildHeaders(altVoiesKeys, altToponymesKeys) {
   const headers = new Set(['cle_interop', 'uid_adresse', 'voie_nom', 'lieudit_complement_nom', 'numero', 'suffixe', 'certification_commune', 'commune_insee', 'commune_nom', 'position', 'long', 'lat', 'x', 'y', 'cad_parcelles', 'source', 'date_der_maj'])
 
-  altVoiesKeys.forEach(v => {
-    headers.add('voie_nom_' + v)
-  })
+  if (altVoiesKeys.size > 0) {
+    altVoiesKeys.forEach(v => {
+      headers.add('voie_nom_' + v)
+    })
+  }
 
-  altToponymesKeys.forEach(v => {
-    headers.add('lieudit_complement_nom_' + v)
-  })
+  if (altToponymesKeys.size > 0) {
+    altToponymesKeys.forEach(v => {
+      headers.add('lieudit_complement_nom_' + v)
+    })
+  }
 
   return headers
 }

--- a/lib/export/csv-bal.js
+++ b/lib/export/csv-bal.js
@@ -37,6 +37,8 @@ function extractHeaders(csvRows) {
       headers.add(header)
     }
   }
+
+  return [...headers]
 }
 
 /* eslint camelcase: off */

--- a/lib/export/csv-bal.js
+++ b/lib/export/csv-bal.js
@@ -137,7 +137,7 @@ async function exportAsCsv({voies, toponymes, numeros}) {
           certifie: n.certifie || false,
           _updated: n._updated,
           nomVoie: v.nom,
-          nomVoieAlt: v.nomAlt,
+          nomVoieAlt: v.nomAlt || null,
           nomToponyme: n.toponyme ? n.toponyme.nom : null,
           nomToponymeAlt: n?.toponyme?.nomAlt || null,
           parcelles: n.parcelles,
@@ -156,7 +156,7 @@ async function exportAsCsv({voies, toponymes, numeros}) {
           numero: 99999,
           _updated: t._updated,
           nomVoie: t.nom,
-          nomVoieAlt: t.nomAlt,
+          nomVoieAlt: t.nomAlt || null,
           parcelles: t.parcelles,
           position: p
         })

--- a/lib/export/csv-bal.js
+++ b/lib/export/csv-bal.js
@@ -50,6 +50,21 @@ function createRow(obj) {
     source: obj.source || 'commune',
     date_der_maj: obj._updated ? obj._updated.toISOString().slice(0, 10) : ''
   }
+
+  if (obj.nomVoieAlt) {
+    Object.keys(obj.nomVoieAlt).forEach(o => {
+      const newKey = 'voie_nom_' + o
+      row[newKey] = obj.nomVoieAlt[o]
+    })
+  }
+
+  if (obj.nomToponymeAlt) {
+    Object.keys(obj.nomToponymeAlt).forEach(o => {
+      const newKey = 'lieudit_complement_nom_' + o
+      row[newKey] = obj.nomToponymeAlt[o]
+    })
+  }
+
   if (obj.position) {
     const coordsPosition = obj.position.point.coordinates
     const projectedCoords = proj(coordsPosition)
@@ -94,7 +109,9 @@ async function exportAsCsv({voies, toponymes, numeros}) {
           certifie: n.certifie || false,
           _updated: n._updated,
           nomVoie: v.nom,
+          nomVoieAlt: v.nomAlt,
           nomToponyme: n.toponyme ? n.toponyme.nom : null,
+          nomToponymeAlt: n?.toponyme?.nomAlt || null,
           parcelles: n.parcelles,
           position: p
         })
@@ -111,6 +128,7 @@ async function exportAsCsv({voies, toponymes, numeros}) {
           numero: 99999,
           _updated: t._updated,
           nomVoie: t.nom,
+          nomVoieAlt: t.nomAlt,
           parcelles: t.parcelles,
           position: p
         })
@@ -122,6 +140,7 @@ async function exportAsCsv({voies, toponymes, numeros}) {
         numero: 99999,
         _updated: t._updated,
         nomVoie: t.nom,
+        nomVoieAlt: t.nomAlt,
         parcelles: t.parcelles
       })
     }

--- a/lib/populate/__tests__/extract-csv.js
+++ b/lib/populate/__tests__/extract-csv.js
@@ -1,22 +1,22 @@
 const test = require('ava')
 const {extractFromCsv} = require('../extract-csv')
 
-const csvFile = `cle_interop;uid_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj
-55326_xxxx_00001;;Nouvelle Voie avec des numéros;;1;;Maulan;entrée;5.25237;48.668935;865837.51;6843339.94;64284000BI0459|64284000BI0450;;2021-04-27
-55326_xxxx_00001;;Nouvelle Voie avec des numéros;;1;;Maulan;délivrance postale;5.25237;48.669494;865835.73;6843402.13;;;2021-04-27
-55326_xxxx_00002;;Nouvelle Voie avec des numéros;;2;;Maulan;entrée;5.254912;48.667116;866030.41;6843143.15;;;2021-04-27
-55326_xxxx_00003;;Nouvelle Voie avec des numéros;;3;;Maulan;entrée;5.255336;48.669354;866054.49;6843392.82;;;2021-04-27
-55326_xxxx_00003;;Nouvelle Voie avec des numéros;;3;;Maulan;délivrance postale;5.256289;48.669914;866122.88;6843457.02;;;2021-04-27
-55326_xxxx_00003;;Nouvelle Voie avec des numéros;;3;;Maulan;bâtiment;5.25576;48.670264;866082.79;6843494.77;;;2021-04-27
-55326_xxxx_00003;;Nouvelle Voie avec des numéros;;3;;Maulan;logement;5.257137;48.670404;866183.7;6843513.22;;;2021-04-27
-55326_xxxx_00001;;voie dans un toponyme;Nouveau Toponyme;1;;Maulan;entrée;5.255501;48.662923;866087.07;6842678.39;;;2021-04-27
-55326_xxxx_00002;;voie dans un toponyme;Nouveau Toponyme;2;;Maulan;entrée;5.256137;48.663057;866133.48;6842694.64;;;2021-04-27
-55326_xxxx_00001;;Voie à moitié dans un toponyme;Nouveau Toponyme;1;;Maulan;entrée;5.255077;48.6631;866055.3;6842697.21;;;2021-04-27
-55326_xxxx_00002;;Voie à moitié dans un toponyme;Nouveau Toponyme;2;;Maulan;entrée;5.254396;48.663192;866004.84;6842706.03;;;2021-04-27
-55326_xxxx_00003;;Voie à moitié dans un toponyme;;3;;Maulan;entrée;5.253747;48.663252;865956.9;6842711.29;;;2021-04-27
-55326_xxxx_00004;;Voie à moitié dans un toponyme;;4;;Maulan;entrée;5.253197;48.663013;865917.16;6842683.62;;;2021-04-27
-55326_xxxx_99999;;Nouveau Toponyme;;99999;;Maulan;segment;5.25504;48.663112;866052.5;6842698.52;;;2021-04-27
-55326_xxxx_99999;;Toponyme Vide;;99999;;Maulan;segment;5.247276;48.664948;865475.13;6842886.26;;;2021-04-27`
+const csvFile = `cle_interop;uid_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj;voie_nom_gsw
+55326_xxxx_00001;;Nouvelle Voie avec des numéros;;1;;Maulan;entrée;5.25237;48.668935;865837.51;6843339.94;64284000BI0459|64284000BI0450;;2021-04-27;Neuer Weg mit Zahlen
+55326_xxxx_00001;;Nouvelle Voie avec des numéros;;1;;Maulan;délivrance postale;5.25237;48.669494;865835.73;6843402.13;;;2021-04-27;Neuer Weg mit Zahlen
+55326_xxxx_00002;;Nouvelle Voie avec des numéros;;2;;Maulan;entrée;5.254912;48.667116;866030.41;6843143.15;;;2021-04-27;Neuer Weg mit Zahlen
+55326_xxxx_00003;;Nouvelle Voie avec des numéros;;3;;Maulan;entrée;5.255336;48.669354;866054.49;6843392.82;;;2021-04-27;Neuer Weg mit Zahlen
+55326_xxxx_00003;;Nouvelle Voie avec des numéros;;3;;Maulan;délivrance postale;5.256289;48.669914;866122.88;6843457.02;;;2021-04-27;Neuer Weg mit Zahlen
+55326_xxxx_00003;;Nouvelle Voie avec des numéros;;3;;Maulan;bâtiment;5.25576;48.670264;866082.79;6843494.77;;;2021-04-27;Neuer Weg mit Zahlen
+55326_xxxx_00003;;Nouvelle Voie avec des numéros;;3;;Maulan;logement;5.257137;48.670404;866183.7;6843513.22;;;2021-04-27;Neuer Weg mit Zahlen
+55326_xxxx_00001;;voie dans un toponyme;Nouveau Toponyme;1;;Maulan;entrée;5.255501;48.662923;866087.07;6842678.39;;;2021-04-27;
+55326_xxxx_00002;;voie dans un toponyme;Nouveau Toponyme;2;;Maulan;entrée;5.256137;48.663057;866133.48;6842694.64;;;2021-04-27;
+55326_xxxx_00001;;Voie à moitié dans un toponyme;Nouveau Toponyme;1;;Maulan;entrée;5.255077;48.6631;866055.3;6842697.21;;;2021-04-27;
+55326_xxxx_00002;;Voie à moitié dans un toponyme;Nouveau Toponyme;2;;Maulan;entrée;5.254396;48.663192;866004.84;6842706.03;;;2021-04-27;
+55326_xxxx_00003;;Voie à moitié dans un toponyme;;3;;Maulan;entrée;5.253747;48.663252;865956.9;6842711.29;;;2021-04-27;
+55326_xxxx_00004;;Voie à moitié dans un toponyme;;4;;Maulan;entrée;5.253197;48.663013;865917.16;6842683.62;;;2021-04-27;
+55326_xxxx_99999;;Nouveau Toponyme;;99999;;Maulan;segment;5.25504;48.663112;866052.5;6842698.52;;;2021-04-27;
+55326_xxxx_99999;;Toponyme Vide;;99999;;Maulan;segment;5.247276;48.664948;865475.13;6842886.26;;;2021-04-27;leeres Toponym`
 
 test('import CSV file', async t => {
   const {isValid, accepted, numeros, voies, toponymes} = await extractFromCsv(Buffer.from(csvFile), '55326')

--- a/lib/populate/__tests__/extract-csv.js
+++ b/lib/populate/__tests__/extract-csv.js
@@ -28,4 +28,6 @@ test('import CSV file', async t => {
   t.is(toponymes.length, 2)
   t.deepEqual(numeros[0].parcelles, ['64284000BI0459', '64284000BI0450'])
   t.is(numeros[0].numero, 1)
+  t.is(voies[0].nomAlt.gsw, 'Neuer Weg mit Zahlen')
+  t.is(toponymes[1].nomAlt.gsw, 'leeres Toponym')
 })

--- a/lib/populate/__tests__/extract-csv.js
+++ b/lib/populate/__tests__/extract-csv.js
@@ -1,22 +1,22 @@
 const test = require('ava')
 const {extractFromCsv} = require('../extract-csv')
 
-const csvFile = `cle_interop;uid_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj;voie_nom_gsw
-55326_xxxx_00001;;Nouvelle Voie avec des numéros;;1;;Maulan;entrée;5.25237;48.668935;865837.51;6843339.94;64284000BI0459|64284000BI0450;;2021-04-27;Neuer Weg mit Zahlen
-55326_xxxx_00001;;Nouvelle Voie avec des numéros;;1;;Maulan;délivrance postale;5.25237;48.669494;865835.73;6843402.13;;;2021-04-27;Neuer Weg mit Zahlen
-55326_xxxx_00002;;Nouvelle Voie avec des numéros;;2;;Maulan;entrée;5.254912;48.667116;866030.41;6843143.15;;;2021-04-27;Neuer Weg mit Zahlen
-55326_xxxx_00003;;Nouvelle Voie avec des numéros;;3;;Maulan;entrée;5.255336;48.669354;866054.49;6843392.82;;;2021-04-27;Neuer Weg mit Zahlen
-55326_xxxx_00003;;Nouvelle Voie avec des numéros;;3;;Maulan;délivrance postale;5.256289;48.669914;866122.88;6843457.02;;;2021-04-27;Neuer Weg mit Zahlen
-55326_xxxx_00003;;Nouvelle Voie avec des numéros;;3;;Maulan;bâtiment;5.25576;48.670264;866082.79;6843494.77;;;2021-04-27;Neuer Weg mit Zahlen
-55326_xxxx_00003;;Nouvelle Voie avec des numéros;;3;;Maulan;logement;5.257137;48.670404;866183.7;6843513.22;;;2021-04-27;Neuer Weg mit Zahlen
-55326_xxxx_00001;;voie dans un toponyme;Nouveau Toponyme;1;;Maulan;entrée;5.255501;48.662923;866087.07;6842678.39;;;2021-04-27;
-55326_xxxx_00002;;voie dans un toponyme;Nouveau Toponyme;2;;Maulan;entrée;5.256137;48.663057;866133.48;6842694.64;;;2021-04-27;
-55326_xxxx_00001;;Voie à moitié dans un toponyme;Nouveau Toponyme;1;;Maulan;entrée;5.255077;48.6631;866055.3;6842697.21;;;2021-04-27;
-55326_xxxx_00002;;Voie à moitié dans un toponyme;Nouveau Toponyme;2;;Maulan;entrée;5.254396;48.663192;866004.84;6842706.03;;;2021-04-27;
-55326_xxxx_00003;;Voie à moitié dans un toponyme;;3;;Maulan;entrée;5.253747;48.663252;865956.9;6842711.29;;;2021-04-27;
-55326_xxxx_00004;;Voie à moitié dans un toponyme;;4;;Maulan;entrée;5.253197;48.663013;865917.16;6842683.62;;;2021-04-27;
-55326_xxxx_99999;;Nouveau Toponyme;;99999;;Maulan;segment;5.25504;48.663112;866052.5;6842698.52;;;2021-04-27;
-55326_xxxx_99999;;Toponyme Vide;;99999;;Maulan;segment;5.247276;48.664948;865475.13;6842886.26;;;2021-04-27;leeres Toponym`
+const csvFile = `cle_interop;uid_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj;voie_nom_gsw;lieudit_complement_nom_gsw
+55326_xxxx_00001;;Nouvelle Voie avec des numéros;;1;;Maulan;entrée;5.25237;48.668935;865837.51;6843339.94;64284000BI0459|64284000BI0450;;2021-04-27;Neuer Weg mit Zahlen;
+55326_xxxx_00001;;Nouvelle Voie avec des numéros;;1;;Maulan;délivrance postale;5.25237;48.669494;865835.73;6843402.13;;;2021-04-27;Neuer Weg mit Zahlen;
+55326_xxxx_00002;;Nouvelle Voie avec des numéros;;2;;Maulan;entrée;5.254912;48.667116;866030.41;6843143.15;;;2021-04-27;Neuer Weg mit Zahlen;
+55326_xxxx_00003;;Nouvelle Voie avec des numéros;;3;;Maulan;entrée;5.255336;48.669354;866054.49;6843392.82;;;2021-04-27;Neuer Weg mit Zahlen;
+55326_xxxx_00003;;Nouvelle Voie avec des numéros;;3;;Maulan;délivrance postale;5.256289;48.669914;866122.88;6843457.02;;;2021-04-27;Neuer Weg mit Zahlen;
+55326_xxxx_00003;;Nouvelle Voie avec des numéros;;3;;Maulan;bâtiment;5.25576;48.670264;866082.79;6843494.77;;;2021-04-27;Neuer Weg mit Zahlen;
+55326_xxxx_00003;;Nouvelle Voie avec des numéros;;3;;Maulan;logement;5.257137;48.670404;866183.7;6843513.22;;;2021-04-27;Neuer Weg mit Zahlen;
+55326_xxxx_00001;;voie dans un toponyme;Nouveau Toponyme;1;;Maulan;entrée;5.255501;48.662923;866087.07;6842678.39;;;2021-04-27;;leeres Toponym
+55326_xxxx_00002;;voie dans un toponyme;Nouveau Toponyme;2;;Maulan;entrée;5.256137;48.663057;866133.48;6842694.64;;;2021-04-27;;leeres Toponym
+55326_xxxx_00001;;Voie à moitié dans un toponyme;Nouveau Toponyme;1;;Maulan;entrée;5.255077;48.6631;866055.3;6842697.21;;;2021-04-27;;leeres Toponym
+55326_xxxx_00002;;Voie à moitié dans un toponyme;Toponyme implicite;2;;Maulan;entrée;5.254396;48.663192;866004.84;6842706.03;;;2021-04-27;;implizite Toponyme
+55326_xxxx_00003;;Voie à moitié dans un toponyme;;3;;Maulan;entrée;5.253747;48.663252;865956.9;6842711.29;;;2021-04-27;;
+55326_xxxx_00004;;Voie à moitié dans un toponyme;;4;;Maulan;entrée;5.253197;48.663013;865917.16;6842683.62;;;2021-04-27;;
+55326_xxxx_99999;;Nouveau Toponyme;;99999;;Maulan;segment;5.25504;48.663112;866052.5;6842698.52;;;2021-04-27;;
+55326_xxxx_99999;;Toponyme Vide;;99999;;Maulan;segment;5.247276;48.664948;865475.13;6842886.26;;;2021-04-27;leeres Toponym;`
 
 test('import CSV file', async t => {
   const {isValid, accepted, numeros, voies, toponymes} = await extractFromCsv(Buffer.from(csvFile), '55326')
@@ -25,9 +25,11 @@ test('import CSV file', async t => {
   t.is(accepted, 15)
   t.is(numeros.length, 9)
   t.is(voies.length, 3)
-  t.is(toponymes.length, 2)
+  t.is(toponymes.length, 3)
   t.deepEqual(numeros[0].parcelles, ['64284000BI0459', '64284000BI0450'])
   t.is(numeros[0].numero, 1)
   t.is(voies[0].nomAlt.gsw, 'Neuer Weg mit Zahlen')
   t.is(toponymes[1].nomAlt.gsw, 'leeres Toponym')
+  t.is(toponymes[2].nom, 'Toponyme implicite')
+  t.is(toponymes[2].nomAlt.gsw, 'implizite Toponyme')
 })

--- a/lib/populate/extract-csv.js
+++ b/lib/populate/extract-csv.js
@@ -33,11 +33,7 @@ function extractDate(row) {
 }
 
 function extractValidAltKeys(row) {
-  const altKeysArr = []
-  const altKeys = Object.keys(row).filter(r => validAltLang.has(r))
-  altKeys.forEach(k => altKeysArr.push(k))
-
-  return altKeysArr
+  return Object.keys(row).filter(r => validAltLang.has(r))
 }
 
 function addAltKeyValue(row) {

--- a/lib/populate/extract-csv.js
+++ b/lib/populate/extract-csv.js
@@ -2,7 +2,7 @@ const {validate} = require('@ban-team/validateur-bal')
 const {chain, compact, deburr, keyBy, min, max} = require('lodash')
 const {ObjectId} = require('../util/mongo')
 
-const validAltLang = new Set(['voie_nom_fra', 'voie_nom_bre', 'voie_nom_eus', 'voie_nom_asw', 'voie_nom_cos', 'voie_nom_gyn', 'voie_nom_rcf', 'voie_nom_oci'])
+const validAltLang = new Set(['voie_nom_fra', 'voie_nom_bre', 'voie_nom_eus', 'voie_nom_gsw', 'voie_nom_cos', 'voie_nom_gcr', 'voie_nom_gcf', 'voie_nom_rcf', 'voie_nom_swb', 'voie_nom_oci'])
 
 function extractCodeCommune({parsedValues, additionalValues}) {
   return parsedValues.commune_insee

--- a/lib/populate/extract-csv.js
+++ b/lib/populate/extract-csv.js
@@ -2,6 +2,8 @@ const {validate} = require('@ban-team/validateur-bal')
 const {chain, compact, deburr, keyBy, min, max} = require('lodash')
 const {ObjectId} = require('../util/mongo')
 
+const validAltLang = new Set(['voie_nom_fra', 'voie_nom_bre', 'voie_nom_eus', 'voie_nom_asw', 'voie_nom_cos', 'voie_nom_gyn', 'voie_nom_rcf', 'voie_nom_oci'])
+
 function extractCodeCommune({parsedValues, additionalValues}) {
   return parsedValues.commune_insee
   || additionalValues?.cle_interop?.codeCommune
@@ -29,8 +31,41 @@ function extractDate(row) {
   }
 }
 
+function extractValidAltKeys(row) {
+  const altKeysArr = []
+  const altKeys = Object.keys(row).filter(r => validAltLang.has(r))
+  altKeys.forEach(k => altKeysArr.push(k))
+
+  return altKeysArr
+}
+
+function addAltKeyValue(row) {
+  const keys = extractValidAltKeys(row)
+  const newObj = {}
+
+  keys.forEach(k => {
+    newObj[k.slice(-3)] = row[k]
+  })
+
+  return newObj
+}
+
+function addAltLang(rows) {
+  rows.forEach(row => {
+    const newRow = addAltKeyValue(row)
+
+    if (Object.keys(newRow).length > 0) {
+      row.nomAlt = newRow
+    }
+  })
+
+  return rows
+}
+
 function extractData(rows, codeCommune) {
-  const toponymes = chain(rows)
+  const rowsWithAltLang = addAltLang(rows)
+
+  const toponymes = chain(rowsWithAltLang)
     .filter(r => r.numero === 99999)
     .groupBy(r => normalizeString(r.voie_nom))
     .map(toponymeRows => {
@@ -40,6 +75,7 @@ function extractData(rows, codeCommune) {
         _id: new ObjectId(),
         commune: codeCommune,
         nom: toponymeRows[0].voie_nom,
+        nomAlt: toponymeRows[0].nomAlt || null,
         positions: extractPositions(toponymeRows),
         _created: date,
         _updated: date
@@ -49,7 +85,7 @@ function extractData(rows, codeCommune) {
 
   const toponymesIndex = keyBy(toponymes, t => normalizeString(t.nom))
 
-  const voies = chain(rows)
+  const voies = chain(rowsWithAltLang)
     .filter(r => r.numero !== 99999)
     .groupBy(r => normalizeString(r.voie_nom))
     .map(voieRows => {
@@ -59,6 +95,7 @@ function extractData(rows, codeCommune) {
         _id: new ObjectId(),
         commune: codeCommune,
         nom: voieRows[0].voie_nom,
+        nomAlt: voieRows[0].nomAlt || null,
         _created: dates.length > 0 ? new Date(min(dates)) : new Date(),
         _updated: dates.length > 0 ? new Date(max(dates)) : new Date()
       }

--- a/lib/populate/extract-csv.js
+++ b/lib/populate/extract-csv.js
@@ -1,8 +1,13 @@
 const {validate} = require('@ban-team/validateur-bal')
+const altLanguages = require('@ban-team/shared-data/langues-regionales.json')
 const {chain, compact, deburr, keyBy, min, max} = require('lodash')
 const {ObjectId} = require('../util/mongo')
 
-const validAltLang = new Set(['voie_nom_fra', 'voie_nom_bre', 'voie_nom_eus', 'voie_nom_gsw', 'voie_nom_cos', 'voie_nom_gcr', 'voie_nom_gcf', 'voie_nom_rcf', 'voie_nom_swb', 'voie_nom_oci'])
+const validAltLang = new Set([])
+
+altLanguages.forEach(al => {
+  validAltLang.add('voie_nom_' + al.code)
+})
 
 function extractCodeCommune({parsedValues, additionalValues}) {
   return parsedValues.commune_insee

--- a/lib/populate/extract-csv.js
+++ b/lib/populate/extract-csv.js
@@ -3,11 +3,7 @@ const altLanguages = require('@ban-team/shared-data/langues-regionales.json')
 const {chain, compact, deburr, keyBy, min, max} = require('lodash')
 const {ObjectId} = require('../util/mongo')
 
-const validAltLang = new Set([])
-
-altLanguages.forEach(al => {
-  validAltLang.add('voie_nom_' + al.code)
-})
+const validAltLang = new Set(altLanguages.map(({code}) => `voie_nom_${code}`))
 
 function extractCodeCommune({parsedValues, additionalValues}) {
   return parsedValues.commune_insee

--- a/lib/populate/extract-csv.js
+++ b/lib/populate/extract-csv.js
@@ -1,9 +1,6 @@
 const {validate} = require('@ban-team/validateur-bal')
-const altLanguages = require('@ban-team/shared-data/langues-regionales.json')
 const {chain, compact, deburr, keyBy, min, max} = require('lodash')
 const {ObjectId} = require('../util/mongo')
-
-const validAltLang = new Set(altLanguages.map(({code}) => `voie_nom_${code}`))
 
 function extractCodeCommune({parsedValues, additionalValues}) {
   return parsedValues.commune_insee
@@ -16,63 +13,34 @@ function normalizeString(string) {
 
 function extractPosition(row) {
   return {
-    source: row.source || null,
-    type: row.position || 'inconnue',
-    point: {type: 'Point', coordinates: [row.long, row.lat]}
+    source: row.parsedValues.source || null,
+    type: row.parsedValues.position || 'inconnue',
+    point: {type: 'Point', coordinates: [row.parsedValues.long, row.parsedValues.lat]}
   }
 }
 
 function extractPositions(rows) {
-  return rows.filter(r => r.long && r.lat).map(r => extractPosition(r))
+  return rows.filter(r => r.parsedValues.long && r.parsedValues.lat).map(r => extractPosition(r))
 }
 
 function extractDate(row) {
-  if (row.date_der_maj) {
-    return new Date(row.date_der_maj)
+  if (row.parsedValues.date_der_maj) {
+    return new Date(row.parsedValues.date_der_maj)
   }
 }
 
-function extractValidAltKeys(row) {
-  return Object.keys(row).filter(r => validAltLang.has(r))
-}
-
-function addAltKeyValue(row) {
-  const keys = extractValidAltKeys(row)
-  const newObj = {}
-
-  keys.forEach(k => {
-    newObj[k.slice(-3)] = row[k]
-  })
-
-  return newObj
-}
-
-function addAltLang(rows) {
-  rows.forEach(row => {
-    const newRow = addAltKeyValue(row)
-
-    if (Object.keys(newRow).length > 0) {
-      row.nomAlt = newRow
-    }
-  })
-
-  return rows
-}
-
 function extractData(rows, codeCommune) {
-  const rowsWithAltLang = addAltLang(rows)
-
-  const toponymes = chain(rowsWithAltLang)
-    .filter(r => r.numero === 99999)
-    .groupBy(r => normalizeString(r.voie_nom))
+  const toponymes = chain(rows)
+    .filter(r => r.parsedValues.numero === 99999)
+    .groupBy(r => normalizeString(r.parsedValues.voie_nom))
     .map(toponymeRows => {
       const date = extractDate(toponymeRows[0]) || new Date()
 
       return {
         _id: new ObjectId(),
         commune: codeCommune,
-        nom: toponymeRows[0].voie_nom,
-        nomAlt: toponymeRows[0].nomAlt || null,
+        nom: toponymeRows[0].parsedValues.voie_nom,
+        nomAlt: toponymeRows[0].localizedValues.voie_nom || null,
         positions: extractPositions(toponymeRows),
         _created: date,
         _updated: date
@@ -82,17 +50,17 @@ function extractData(rows, codeCommune) {
 
   const toponymesIndex = keyBy(toponymes, t => normalizeString(t.nom))
 
-  const voies = chain(rowsWithAltLang)
-    .filter(r => r.numero !== 99999)
-    .groupBy(r => normalizeString(r.voie_nom))
+  const voies = chain(rows)
+    .filter(r => r.parsedValues.numero !== 99999)
+    .groupBy(r => normalizeString(r.parsedValues.voie_nom))
     .map(voieRows => {
-      const dates = compact(voieRows.map(r => r.date_der_maj))
+      const dates = compact(voieRows.map(r => r.parsedValues.date_der_maj))
 
       return {
         _id: new ObjectId(),
         commune: codeCommune,
-        nom: voieRows[0].voie_nom,
-        nomAlt: voieRows[0].nomAlt || null,
+        nom: voieRows[0].parsedValues.voie_nom,
+        nomAlt: voieRows[0].localizedValues.voie_nom || null,
         _created: dates.length > 0 ? new Date(min(dates)) : new Date(),
         _updated: dates.length > 0 ? new Date(max(dates)) : new Date()
       }
@@ -102,21 +70,23 @@ function extractData(rows, codeCommune) {
   const voiesIndex = keyBy(voies, v => normalizeString(v.nom))
 
   const numeros = chain(rows)
-    .filter(r => r.numero !== 99999)
-    .groupBy(r => `${r.numero}@@@${r.suffixe}@@@${normalizeString(r.voie_nom)}`)
+    .filter(r => r.parsedValues.numero !== 99999)
+    .groupBy(r => `${r.parsedValues.numero}@@@${r.parsedValues.suffixe}@@@${normalizeString(r.parsedValues.voie_nom)}`)
     .map(numeroRows => {
       const date = extractDate(numeroRows[0]) || new Date()
 
-      const voieString = normalizeString(numeroRows[0].voie_nom)
-      const toponymeString = numeroRows[0].lieudit_complement_nom ? normalizeString(numeroRows[0].lieudit_complement_nom) : null
+      const voieString = normalizeString(numeroRows[0].parsedValues.voie_nom)
+      const toponymeString = numeroRows[0].parsedValues.lieudit_complement_nom ? normalizeString(numeroRows[0].parsedValues.lieudit_complement_nom) : null
+      const toponymeAlt = numeroRows[0].localizedValues.lieudit_complement_nom || null
 
       if (toponymeString && !(toponymeString in toponymesIndex)) {
         const toponyme = {
           _id: new ObjectId(),
           commune: codeCommune,
-          nom: numeroRows[0].lieudit_complement_nom,
+          nom: numeroRows[0].parsedValues.lieudit_complement_nom,
+          nomAlt: toponymeAlt,
           positions: [],
-          parcelles: numeroRows[0].cad_parcelles,
+          parcelles: numeroRows[0].parsedValues.cad_parcelles,
           _created: new Date(),
           _updated: new Date()
         }
@@ -130,11 +100,11 @@ function extractData(rows, codeCommune) {
         commune: codeCommune,
         voie: voiesIndex[voieString]._id,
         toponyme: toponymeString ? toponymesIndex[toponymeString]._id : null,
-        numero: numeroRows[0].numero,
-        suffixe: numeroRows[0].suffixe || null,
-        certifie: numeroRows[0].certification_commune,
+        numero: numeroRows[0].parsedValues.numero,
+        suffixe: numeroRows[0].parsedValues.suffixe || null,
+        certifie: numeroRows[0].parsedValues.certification_commune,
         positions: extractPositions(numeroRows),
-        parcelles: numeroRows[0].cad_parcelles,
+        parcelles: numeroRows[0].parsedValues.cad_parcelles,
         _created: date,
         _updated: date
       }
@@ -154,10 +124,11 @@ async function extractFromCsv(file, codeCommune) {
 
     const accepted = rows.filter(({isValid}) => isValid)
     const rejected = rows.filter(({isValid}) => !isValid)
-    const parsedValues = accepted.filter(r => extractCodeCommune(r) === codeCommune)
-      .map(({parsedValues}) => parsedValues)
 
-    const communesData = extractData(parsedValues, codeCommune)
+    const communesData = extractData(
+      accepted.filter(r => extractCodeCommune(r) === codeCommune),
+      codeCommune
+    )
 
     return {
       isValid: true,

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "update-cadastre": "node ./scripts/update-communes-cadastre.js"
   },
   "dependencies": {
-    "@ban-team/shared-data": "^1.0.0",
-    "@ban-team/validateur-bal": "^2.8.0",
+    "@ban-team/shared-data": "^1.0.1",
+    "@ban-team/validateur-bal": "^2.9.0",
     "@etalab/decoupage-administratif": "^2.0.0",
     "@etalab/project-legal": "^0.6.0",
     "bluebird": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "update-cadastre": "node ./scripts/update-communes-cadastre.js"
   },
   "dependencies": {
+    "@ban-team/shared-data": "^1.0.0",
     "@ban-team/validateur-bal": "^2.8.0",
     "@etalab/decoupage-administratif": "^2.0.0",
     "@etalab/project-legal": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "update-cadastre": "node ./scripts/update-communes-cadastre.js"
   },
   "dependencies": {
-    "@ban-team/shared-data": "^1.0.1",
     "@ban-team/validateur-bal": "^2.9.0",
     "@etalab/decoupage-administratif": "^2.0.0",
     "@etalab/project-legal": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "update-cadastre": "node ./scripts/update-communes-cadastre.js"
   },
   "dependencies": {
-    "@ban-team/validateur-bal": "^2.7.1",
+    "@ban-team/validateur-bal": "^2.8.0",
     "@etalab/decoupage-administratif": "^2.0.0",
     "@etalab/project-legal": "^0.6.0",
     "bluebird": "^3.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -197,6 +197,11 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
+"@ban-team/shared-data@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@ban-team/shared-data/-/shared-data-1.0.0.tgz#b45dc45a33ff0f9421ffa876f77f0f4671087e10"
+  integrity sha512-P5qTuSvRkLcDM2Rm6hriLbM4bC15SLTD6i9oquhSSnIbTkt235kmY+ThDTER5DcSircHeKOsQcD/5j0Mluv8SQ==
+
 "@ban-team/validateur-bal@^2.8.0":
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.8.0.tgz#09c8b5854ab6b96d8779287bc7430150dbaeccf7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -202,11 +202,6 @@
   resolved "https://registry.yarnpkg.com/@ban-team/shared-data/-/shared-data-1.0.0.tgz#b45dc45a33ff0f9421ffa876f77f0f4671087e10"
   integrity sha512-P5qTuSvRkLcDM2Rm6hriLbM4bC15SLTD6i9oquhSSnIbTkt235kmY+ThDTER5DcSircHeKOsQcD/5j0Mluv8SQ==
 
-"@ban-team/shared-data@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@ban-team/shared-data/-/shared-data-1.0.1.tgz#bc3f49beab5bf492ad5da4d2a3852a539e68416b"
-  integrity sha512-eRrAZ2QJRiYd3wiPQE1ejA8fwn18AWvKASaEn7ajGVxIjOD5ty3E2hKlLPDOjdrg/bsVrabzOvxnnUN0sxboIA==
-
 "@ban-team/validateur-bal@^2.9.0":
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.9.0.tgz#09fa914d42bedaf09c8369126ceed1b0a110945e"

--- a/yarn.lock
+++ b/yarn.lock
@@ -197,10 +197,10 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@ban-team/validateur-bal@^2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.7.1.tgz#ff9f530593d9fbca6592b980888eec37c6cdc739"
-  integrity sha512-Xa3QdKPgISKsmhFHurtUYu3S9OZR+LLuwG5xFk2pyEliFTfRkt/+DUnICa7z/492atH31h5+QRp5w2ujN9JDcQ==
+"@ban-team/validateur-bal@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.8.0.tgz#09c8b5854ab6b96d8779287bc7430150dbaeccf7"
+  integrity sha512-LusrzcHN9+0mjX0XIUjTjsrjiOD7158XPOucVtLxYEJ6I83ySdTg4MyW4QkJOxrsruf/ylEcdc+ZN2u0N5y3AQ==
   dependencies:
     "@etalab/project-legal" "^0.6.0"
     blob-to-buffer "^1.2.9"
@@ -378,11 +378,6 @@
     "@types/keyv" "*"
     "@types/node" "*"
     "@types/responselike" "*"
-
-"@types/color-name@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
-  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
 "@types/eslint@^7.2.13":
   version "7.28.0"
@@ -622,14 +617,9 @@ ansi-escapes@^4.2.1:
     type-fest "^0.11.0"
 
 ansi-regex@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
-  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
-
-ansi-regex@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
-  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
+  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
 
 ansi-regex@^5.0.1:
   version "5.0.1"
@@ -644,11 +634,10 @@ ansi-styles@^3.2.1:
     color-convert "^1.9.0"
 
 ansi-styles@^4.0.0, ansi-styles@^4.1.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
-  integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
-    "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
 
 ansi-styles@^5.0.0:
@@ -4807,7 +4796,7 @@ release-zalgo@^1.0.0:
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
-  integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
+  integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
 
 require-main-filename@^2.0.0:
   version "2.0.0"
@@ -5213,7 +5202,7 @@ string-width@^3.0.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.0.0"
 
-string-width@^4.0.0, string-width@^4.2.0:
+string-width@^4.0.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
   integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
@@ -5222,16 +5211,7 @@ string-width@^4.0.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
-string-width@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.1.0.tgz#ba846d1daa97c3c596155308063e075ed1c99aff"
-  integrity sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^5.2.0"
-
-string-width@^4.2.3:
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5270,21 +5250,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-strip-ansi@^5.0.0, strip-ansi@^5.2.0:
+strip-ansi@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
 
-strip-ansi@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
-  integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
-  dependencies:
-    ansi-regex "^5.0.0"
-
-strip-ansi@^6.0.1:
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5378,17 +5351,10 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7.0.0:
+supports-color@^7.0.0, supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
-  dependencies:
-    has-flag "^4.0.0"
-
-supports-color@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
-  integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
   dependencies:
     has-flag "^4.0.0"
 
@@ -5898,9 +5864,9 @@ y18n@^4.0.0:
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
 
 y18n@^5.0.5:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.5.tgz#8769ec08d03b1ea2df2500acef561743bbb9ab18"
-  integrity sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
 yallist@^4.0.0:
   version "4.0.0"
@@ -5931,9 +5897,9 @@ yargs-parser@^20.2.9:
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
 yargs-parser@^21.0.0:
-  version "21.0.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.0.tgz#a485d3966be4317426dd56bdb6a30131b281dc55"
-  integrity sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==
+  version "21.0.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.1.tgz#0267f286c877a4f0f728fceb6f8a3e4cb95c6e35"
+  integrity sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==
 
 yargs@^15.0.2:
   version "15.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -202,11 +202,17 @@
   resolved "https://registry.yarnpkg.com/@ban-team/shared-data/-/shared-data-1.0.0.tgz#b45dc45a33ff0f9421ffa876f77f0f4671087e10"
   integrity sha512-P5qTuSvRkLcDM2Rm6hriLbM4bC15SLTD6i9oquhSSnIbTkt235kmY+ThDTER5DcSircHeKOsQcD/5j0Mluv8SQ==
 
-"@ban-team/validateur-bal@^2.8.0":
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.8.0.tgz#09c8b5854ab6b96d8779287bc7430150dbaeccf7"
-  integrity sha512-LusrzcHN9+0mjX0XIUjTjsrjiOD7158XPOucVtLxYEJ6I83ySdTg4MyW4QkJOxrsruf/ylEcdc+ZN2u0N5y3AQ==
+"@ban-team/shared-data@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@ban-team/shared-data/-/shared-data-1.0.1.tgz#bc3f49beab5bf492ad5da4d2a3852a539e68416b"
+  integrity sha512-eRrAZ2QJRiYd3wiPQE1ejA8fwn18AWvKASaEn7ajGVxIjOD5ty3E2hKlLPDOjdrg/bsVrabzOvxnnUN0sxboIA==
+
+"@ban-team/validateur-bal@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.9.0.tgz#09fa914d42bedaf09c8369126ceed1b0a110945e"
+  integrity sha512-Qid9f/9bnYJyBdAt6vlrp43fDXcAl9bxvD9UTTUC7IMZsZXgIcnxyO8LUnjHz358MDraRmljRCb+U+pLAoA6bA==
   dependencies:
+    "@ban-team/shared-data" "^1.0.0"
     "@etalab/project-legal" "^0.6.0"
     blob-to-buffer "^1.2.9"
     bluebird "^3.7.2"


### PR DESCRIPTION
Cette PR propose d’ajouter la gestion des langues régionales lors de l’importation ou de l’exportation d’une Base Adresse Locale au format CSV.

- Prise en compte du champ `nomAlt` à l’exportation et importation d’une BAL en CSV
- Création d’une fonction pour créer le `header` du fichier CSV
- Mise à jour du validateur
- Mise à jour des tests



