### PR TITLE
Supprime les espaces superflus pour les langues régionales

### DIFF
--- a/lib/models/__tests__/toponyme.mongo.js
+++ b/lib/models/__tests__/toponyme.mongo.js
@@ -24,7 +24,7 @@ test('create a Toponyme', async t => {
     _updated: new Date('2021-01-01')
   })
 
-  const toponyme = await Toponyme.create(_id, {nom: 'foo', nomAlt: {bre: 'ba  r'}})
+  const toponyme = await Toponyme.create(_id, {nom: 'foo', nomAlt: {bre: '  ba   r   '}})
 
   const keys = ['_id', '_bal', 'nom', 'positions', 'parcelles', 'commune', 'nomAlt', '_created', '_updated']
   t.true(keys.every(k => k in toponyme))

--- a/lib/models/__tests__/toponyme.mongo.js
+++ b/lib/models/__tests__/toponyme.mongo.js
@@ -24,12 +24,12 @@ test('create a Toponyme', async t => {
     _updated: new Date('2021-01-01')
   })
 
-  const toponyme = await Toponyme.create(_id, {nom: 'foo'})
+  const toponyme = await Toponyme.create(_id, {nom: 'foo', nomAlt: {bre: 'ba  r'}})
 
   const keys = ['_id', '_bal', 'nom', 'positions', 'parcelles', 'commune', 'nomAlt', '_created', '_updated']
   t.true(keys.every(k => k in toponyme))
   t.is(Object.keys(toponyme).length, keys.length)
-  t.is(toponyme.nomAlt, null)
+  t.deepEqual(toponyme.nomAlt, {bre: 'ba r'})
 
   const bal = await mongo.db.collection('bases_locales').findOne({_id})
   t.deepEqual(toponyme._created, bal._updated)

--- a/lib/models/__tests__/voie.mongo.js
+++ b/lib/models/__tests__/voie.mongo.js
@@ -26,7 +26,7 @@ test('create a Voie', async t => {
     _id,
     commune: '12345'
   }
-  const voie = await Voie.create(baseLocale, {nom: 'foo  oo'})
+  const voie = await Voie.create(baseLocale, {nom: 'foo  oo', nomAlt: {bre: 'ba  r'}})
 
   t.truthy(voie._id)
   t.is(voie._bal, baseLocale._id)
@@ -34,7 +34,7 @@ test('create a Voie', async t => {
   t.is(voie.nom, 'foo oo')
   t.is(voie.typeNumerotation, 'numerique')
   t.is(voie.trace, null)
-  t.is(voie.nomAlt, null)
+  t.deepEqual(voie.nomAlt, {bre: 'ba r'})
   t.truthy(voie._created)
   t.truthy(voie._updated)
 

--- a/lib/models/__tests__/voie.mongo.js
+++ b/lib/models/__tests__/voie.mongo.js
@@ -26,7 +26,7 @@ test('create a Voie', async t => {
     _id,
     commune: '12345'
   }
-  const voie = await Voie.create(baseLocale, {nom: 'foo  oo', nomAlt: {bre: 'ba  r'}})
+  const voie = await Voie.create(baseLocale, {nom: 'foo  oo', nomAlt: {bre: '  ba   r   '}})
 
   t.truthy(voie._id)
   t.is(voie._bal, baseLocale._id)

--- a/lib/models/nom-alt.js
+++ b/lib/models/nom-alt.js
@@ -36,11 +36,20 @@ function getNomAltDefault(nomAlt) {
   return nomAlt && Object.keys(nomAlt).length > 0 ? nomAlt : null
 }
 
+function cleanNomAlt(nomAlt) {
+  Object.keys(nomAlt).forEach(nom => {
+    nomAlt[nom] = nomAlt[nom].replace(/^\s+/g, '').replace(/\s+$/g, '').replace(/\s\s+/g, ' ')
+  })
+
+  return nomAlt
+}
+
 const createSchema = Joi.object().custom(nomAltValidation)
 const updateSchema = createSchema
 
 module.exports = {
   createSchema,
   updateSchema,
-  getNomAltDefault
+  getNomAltDefault,
+  cleanNomAlt
 }

--- a/lib/models/toponyme.js
+++ b/lib/models/toponyme.js
@@ -25,6 +25,10 @@ async function create(idBal, payload) {
     payload.nom = cleanNom(payload.nom)
   }
 
+  if (payload.nomAlt) {
+    payload.nomAlt = nomAltSchema.cleanNomAlt(payload.nomAlt)
+  }
+
   const toponyme = validPayload(payload, createSchema)
   const baseLocale = await mongo.db.collection('bases_locales').findOne({_id: mongo.parseObjectID(idBal)})
 
@@ -57,6 +61,10 @@ const updateSchema = Joi.object().keys({
 async function update(id, payload) {
   if (payload.nom) {
     payload.nom = cleanNom(payload.nom)
+  }
+
+  if (payload.nomAlt) {
+    payload.nomAlt = nomAltSchema.cleanNomAlt(payload.nomAlt)
   }
 
   const toponymeChanges = validPayload(payload, updateSchema)

--- a/lib/models/voie.js
+++ b/lib/models/voie.js
@@ -29,6 +29,10 @@ async function create(baseLocale, payload) {
     payload.nom = cleanNom(payload.nom)
   }
 
+  if (payload.nomAlt) {
+    payload.nomAlt = nomAltSchema.cleanNomAlt(payload.nomAlt)
+  }
+
   const voie = validPayload(payload, createSchema)
 
   voie._id = new mongo.ObjectId()
@@ -109,6 +113,10 @@ const updateSchema = Joi.object().keys({
 async function update(id, payload) {
   if (payload.nom) {
     payload.nom = cleanNom(payload.nom)
+  }
+
+  if (payload.nomAlt) {
+    payload.nomAlt = nomAltSchema.cleanNomAlt(payload.nomAlt)
   }
 
   const voieChanges = validPayload(payload, updateSchema)


### PR DESCRIPTION
resolves #348 

- Ajout de la méthode `cleanNomAlt` aux modèles `voie` et `toponyme`