### PR TITLE
Empêcher la publication de BAL sans adresse

### DIFF
--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -149,6 +149,7 @@ test('update a BaseLocale', async t => {
     _updated: new Date('2019-01-01'),
     _deleted: null
   })
+  await mongo.db.collection('numeros').insertOne({_bal: _id, numero: 1})
 
   const baseLocale = await BaseLocale.update(_id, {
     nom: 'foo2',
@@ -162,6 +163,28 @@ test('update a BaseLocale', async t => {
   t.is(baseLocale.token, 'coucou')
   t.is(baseLocale.status, 'ready-to-publish')
   t.is(Object.keys(baseLocale).length, 9)
+})
+
+test('update a BaseLocale / empty base local', async t => {
+  const _id = new mongo.ObjectId()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    nom: 'foo',
+    commune: '27115',
+    emails: ['me@domain.co', 'me2@domain.co'],
+    token: 'coucou',
+    status: 'draft',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01'),
+    _deleted: null
+  })
+
+  return t.throwsAsync(() => BaseLocale.update(_id, {
+    nom: 'foo2',
+    emails: ['me2@domain.co', 'me3@domain.co'],
+    status: 'ready-to-publish',
+    token: 'hack'
+  }), {message: 'La base locale ne possède aucune adresse'})
 })
 
 test('update a BaseLocale / not found', t => {

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -1,4 +1,5 @@
 const Joi = require('joi')
+const createHttpError = require('http-errors')
 const subMonths = require('date-fns/subMonths')
 const {omit, difference, uniq, keyBy} = require('lodash')
 const {generateBase62String} = require('../util/base62')
@@ -110,7 +111,7 @@ async function update(id, payload) {
 
   const numeroCount = await mongo.db.collection('numeros').countDocuments({_bal: mongo.parseObjectID(id)})
   if (numeroCount === 0 && baseLocaleChanges.status === 'ready-to-publish') {
-    throw new Error('La base locale ne possède aucune adresse')
+    throw createHttpError(412, 'La base locale ne possède aucune adresse')
   }
 
   // Apply changes to current BaseLocale and return modified one

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -108,6 +108,11 @@ async function update(id, payload) {
     throw new Error('La base locale a été publiée, son statut ne peut plus être changé')
   }
 
+  const numeroCount = await mongo.db.collection('numeros').countDocuments({_bal: mongo.parseObjectID(id)})
+  if (numeroCount === 0 && baseLocaleChanges.status === 'ready-to-publish') {
+    throw new Error('La base locale ne possède aucune adresse')
+  }
+
   // Apply changes to current BaseLocale and return modified one
   const {value} = await mongo.db.collection('bases_locales').findOneAndUpdate(
     {_id: mongo.parseObjectID(id)},

--- a/lib/sync/index.js
+++ b/lib/sync/index.js
@@ -124,6 +124,11 @@ async function exec(balId, options = {}) {
     throw createError(412, 'L’habilitation rattachée a expiré')
   }
 
+  const numeroCount = await mongo.db.collection('numeros').countDocuments({_bal: mongo.parseObjectID(balId)})
+  if (numeroCount === 0) {
+    throw createError(412, 'La base locale ne possède aucune adresse')
+  }
+
   /* On traite ensuite le cas de la première publication (status=ready-to-publish) */
 
   if (baseLocale.status === 'ready-to-publish') {


### PR DESCRIPTION
## Contexte
Il semblerait qu'un certain nombre d'utilisateurs publie des BAL sans adresses lorsqu'ils commencent leur adressage. 

## Correction
Cette PR empêche le change de status à `ready-to-publish` ou `published` si la BAL n'a aucune adresse.