### PR TITLE
Intègre la récupération des BAL "supprimées"

### DIFF
--- a/lib/emails/__tests__/recovery-notification.js
+++ b/lib/emails/__tests__/recovery-notification.js
@@ -20,6 +20,20 @@ test('formatEmail - list of BAL', t => {
       token: '424242',
       status: 'published',
       nom: 'BAL C'
+    },
+    {
+      _id: '168',
+      _deleted: new Date('2022-02-02'),
+      token: '424242',
+      status: 'draft',
+      nom: 'BAL D'
+    },
+    {
+      _id: '336',
+      _deleted: new Date('2022-02-03'),
+      token: '424242',
+      status: 'draft',
+      nom: 'BAL E'
     }
   ]
 
@@ -116,6 +130,10 @@ test('formatEmail - list of BAL', t => {
     <h3>Liste des Bases Adresses Locales associées à votre adresse email :</h3>
     <ul>
       <li><span class="status draft">Brouillon</span> BAL A : <a href="http://editor.domain.tld/21/123456">http://editor.domain.tld/21/123456</a></li><li><span class="status ready-to-publish">Prête à être publiée</span> BAL B : <a href="http://editor.domain.tld/42/789100">http://editor.domain.tld/42/789100</a></li><li><span class="status published">Publiée</span> BAL C : <a href="http://editor.domain.tld/84/424242">http://editor.domain.tld/84/424242</a></li>
+    </ul>
+    <h3>Liste des Bases Adresses Locales supprimées, associées à votre adresse email :</h3>
+    <ul>
+      <li><span class="status draft">Supprimée le 02/02/2022</span> BAL D : <a href="http://api.domain.tld/v1/bases-locales/168/424242/recovery">http://api.domain.tld/v1/bases-locales/168/424242/recovery</a></li><li><span class="status draft">Supprimée le 03/02/2022</span> BAL E : <a href="http://api.domain.tld/v1/bases-locales/336/424242/recovery">http://api.domain.tld/v1/bases-locales/336/424242/recovery</a></li>
     </ul>
 
     <h5>Pourquoi ce courriel vous est envoyé ?</h5>
@@ -236,6 +254,127 @@ test('formatEmail - only one BAL', t => {
   <div class="container">
     <ul>
       <li><span class="status draft">Brouillon</span> BAL A : <a href="http://editor.domain.tld/21/123456">http://editor.domain.tld/21/123456</a></li>
+    </ul>
+
+    <h5>Pourquoi ce courriel vous est envoyé ?</h5>
+    <p class="explaination">
+      Une personne souhaite récupérer l’accès à sa Base Adresse Locale et a communiquée cette adresse de courrier électronique.
+      Si vous n'êtes pas à l'origine de cette demande, merci d'ignorer ce courriel.
+    </p>
+
+    <div class="signature"><i>L’équipe adresse.data.gouv.fr</i></div>
+  </div>
+</body>
+
+</html>
+`
+
+  t.is(formatEmail({basesLocales}).html, expectedTextBody)
+})
+
+test('formatEmail - only one BAL deleted', t => {
+  const basesLocales = [
+    {
+      _id: '21',
+      _deleted: new Date('2022-02-02'),
+      token: '123456',
+      status: 'draft',
+      nom: 'BAL A'
+    }
+  ]
+
+  const expectedTextBody = `
+<!DOCTYPE html>
+<html lang="fr">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Demande de récupération de vos Bases Adresses Locales</title>
+  <style>
+    body {
+      background-color: #F5F6F7;
+      color: #234361;
+      font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+      margin: auto;
+      padding: 25px;
+    }
+
+    li {
+      margin: 1em 0;
+    }
+
+    h5 {
+      margin: 40px 0 0;
+    }
+
+    img {
+      max-height: 45px;
+      background-color: #F5F6F7;
+    }
+
+    .container {
+      background-color: #ebeff3;
+      padding: 25px;
+    }
+
+    .title {
+      align-items: center;
+      border-bottom: 1px solid #E4E7EB;
+      justify-content: center;
+      margin-top: 35px;
+      min-height: 10em;
+      padding: 10px;
+      text-align: center;
+    }
+
+    .status {
+      padding: .4em;
+      border-radius: 4px;
+    }
+
+    .draft {
+      background-color: rgb(228, 231, 235);
+      color: rgb(66, 90, 112);
+    }
+
+    .ready-to-publish {
+      background-color: rgb(221, 235, 247);
+      color: rgb(8, 75, 138);
+    }
+
+    .published {
+      background-color: rgb(212, 238, 226);
+      color: rgb(0, 120, 62);
+    }
+
+    .replaced {
+      background-color: rgb(212, 238, 226);
+      color: rgb(120, 120, 62);
+    }
+
+    .explaination {
+      font-size: small;
+    }
+
+    .signature {
+      margin-top: 40px;
+    }
+  </style>
+</head>
+
+<body>
+  <div>
+    <img src="http://api.domain.tld/public/images/logo-adresse.png" alt="Logo République Française">
+  </div>
+  <div class="title">
+    <h2 style="margin:0; mso-line-height-rule:exactly;">Demande de récupération de votre Base Adresse Locale</h2><br>
+    <h3 style="margin:0; mso-line-height-rule:exactly;">Cliquez sur le lien associé pour récupérer votre Base Adresse Locale</h3>
+  </div>
+
+  <div class="container">
+    <ul>
+      <li><span class="status draft">Supprimée le 02/02/2022</span> BAL A : <a href="http://api.domain.tld/v1/bases-locales/21/123456/recovery">http://api.domain.tld/v1/bases-locales/21/123456/recovery</a></li>
     </ul>
 
     <h5>Pourquoi ce courriel vous est envoyé ?</h5>

--- a/lib/emails/recovery-notification.js
+++ b/lib/emails/recovery-notification.js
@@ -1,5 +1,7 @@
 const {template} = require('lodash')
-const {getEditorUrl, getApiUrl} = require('./util')
+const {format} = require('date-fns')
+const {fr} = require('date-fns/locale')
+const {getEditorUrl, getApiUrl, getApiRecoveryUrl} = require('./util')
 
 const head = `
 <!DOCTYPE html>
@@ -93,10 +95,18 @@ const bodyTemplateList = template(`${head}
   </div>
 
   <div class="container">
-    <h3>Liste des Bases Adresses Locales associées à votre adresse email :</h3>
+    <% if(basesLocalesRecovery.length > 0) { %><h3>Liste des Bases Adresses Locales associées à votre adresse email :</h3>
     <ul>
-      <% _.forEach(basesLocalesRevory, function(baseLocale) { %><li><span class="status <%- baseLocale.status %>"><%- baseLocale.statusFr %></span> <%- baseLocale.nom %> : <a href="<%- baseLocale.recoveryUrl %>"><%- baseLocale.recoveryUrl %></a></li><% }); %>
-    </ul>
+      <% _.forEach(basesLocalesRecovery, function(baseLocale) { %><li><span class="status <%- baseLocale.status %>"><%- baseLocale.statusFr %></span> <%- baseLocale.nom %> : <a href="<%- baseLocale.recoveryUrl %>"><%- baseLocale.recoveryUrl %></a></li><% }); %>
+    </ul><% } %><% if (basesLocalesDeleted.length === 1) { %>
+    <h3>Une Base Adresse Locale associée à votre adresse email a été supprimée, vous pouvez la récupérer via le lien ci-dessous :</h3>
+    <ul>
+      <li><span class="status <%- basesLocalesDeleted[0].status %>"><%- basesLocalesDeleted[0].statusFr %><% if (basesLocalesDeleted[0].deleted) { %> le <%= basesLocalesDeleted[0].deleted %><% } %></span> <%- basesLocalesDeleted[0].nom %> : <% if (basesLocalesDeleted[0].deleted) { %> <a href="<%- basesLocalesDeleted[0].deletedRecoveryUrl %>"><%- basesLocalesDeleted[0].deletedRecoveryUrl %></a></li> <% } else { %> <a href="<%- basesLocalesDeleted[0].recoveryUrl %>"><%- basesLocalesDeleted[0].recoveryUrl %></a></li> <% }; %>
+    </ul><% } %><% if (basesLocalesDeleted.length > 1) { %>
+    <h3>Liste des Bases Adresses Locales supprimées, associées à votre adresse email :</h3>
+    <ul>
+      <% _.forEach(basesLocalesDeleted, function(baseLocale) { %><li><span class="status <%- baseLocale.status %>"><%- baseLocale.statusFr %><% if (baseLocale.deleted) { %> le <%= baseLocale.deleted %><% } %></span> <%- baseLocale.nom %> : <% if (baseLocale.deleted) { %><a href="<%= apiUrl %>/v1/bases-locales/<%= baseLocale._id %>/<%= baseLocale.token %>/recovery"><%= apiUrl %>/v1/bases-locales/<%= baseLocale._id %>/<%= baseLocale.token %>/recovery</a></li><% } else { %> <a href="<%- baseLocale.recoveryUrl %>"><%- baseLocale.recoveryUrl %></a></li><% }}); %>
+    </ul><%}%>
 
     <h5>Pourquoi ce courriel vous est envoyé ?</h5>
     <p class="explaination">
@@ -123,7 +133,7 @@ const bodyTemplate = template(`${head}
 
   <div class="container">
     <ul>
-      <li><span class="status <%- baseLocale.status %>"><%- baseLocale.statusFr %></span> <%- baseLocale.nom %> : <a href="<%- baseLocale.recoveryUrl %>"><%- baseLocale.recoveryUrl %></a></li>
+      <li><span class="status <%- baseLocale.status %>"><%- baseLocale.statusFr %><% if (baseLocale.deleted) { %> le <%= baseLocale.deleted %><% } %></span> <%- baseLocale.nom %> : <% if (baseLocale.deleted) { %><a href="<%- baseLocale.deletedRecoveryUrl %>"><%- baseLocale.deletedRecoveryUrl %></a></li><% } else { %><a href="<%- baseLocale.recoveryUrl %>"><%- baseLocale.recoveryUrl %></a></li><% }; %>
     </ul>
 
     <h5>Pourquoi ce courriel vous est envoyé ?</h5>
@@ -149,24 +159,30 @@ const STATUS = {
 function formatEmail(data) {
   const {basesLocales} = data
   const apiUrl = getApiUrl()
-  const basesLocalesRevory = basesLocales.map(baseLocale => {
+  const basesLocalesRecovery = basesLocales.map(baseLocale => {
     return {
       ...baseLocale,
-      statusFr: STATUS[baseLocale.status],
-      recoveryUrl: getEditorUrl(baseLocale)
+      statusFr: baseLocale._deleted ? 'Supprimée' : STATUS[baseLocale.status],
+      recoveryUrl: getEditorUrl(baseLocale),
+      deletedRecoveryUrl: getApiRecoveryUrl(baseLocale),
+      deleted: baseLocale._deleted ? format(baseLocale._deleted, 'P', {locale: fr}) : null
     }
   })
 
-  if (basesLocalesRevory.length === 1) {
+  if (basesLocalesRecovery.length === 1) {
     return {
       subject: 'Demande de récupération de votre Base Adresse Locale',
-      html: bodyTemplate({baseLocale: basesLocalesRevory[0], apiUrl})
+      html: bodyTemplate({baseLocale: basesLocalesRecovery[0], apiUrl})
     }
   }
 
   return {
     subject: 'Demande de récupération de vos Bases Adresses Locales',
-    html: bodyTemplateList({basesLocalesRevory, apiUrl})
+    html: bodyTemplateList({
+      basesLocalesRecovery: basesLocalesRecovery.filter(({deleted}) => !deleted),
+      basesLocalesDeleted: basesLocalesRecovery.filter(({deleted}) => deleted),
+      apiUrl
+    })
   }
 }
 

--- a/lib/emails/recovery-notification.js
+++ b/lib/emails/recovery-notification.js
@@ -84,6 +84,10 @@ const head = `
 </head>
 `
 
+const recoveryBALList = '<% _.forEach(basesLocalesRecovery, function(baseLocale) { %><li><span class="status <%- baseLocale.status %>"><%- baseLocale.statusFr %></span> <%- baseLocale.nom %> : <a href="<%- baseLocale.recoveryUrl %>"><%- baseLocale.recoveryUrl %></a></li><% }); %>'
+
+const deletedBALList = '<% _.forEach(basesLocalesDeleted, function(baseLocale) { %><li><span class="status <%- baseLocale.status %>"><%- baseLocale.statusFr %> le <%= baseLocale.deleted %></span> <%- baseLocale.nom %> : <a href="<%= baseLocale.deletedRecoveryUrl %>"><%= baseLocale.deletedRecoveryUrl %></a></li><%})%>'
+
 const bodyTemplateList = template(`${head}
 <body>
   <div>
@@ -97,15 +101,15 @@ const bodyTemplateList = template(`${head}
   <div class="container">
     <% if(basesLocalesRecovery.length > 0) { %><h3>Liste des Bases Adresses Locales associées à votre adresse email :</h3>
     <ul>
-      <% _.forEach(basesLocalesRecovery, function(baseLocale) { %><li><span class="status <%- baseLocale.status %>"><%- baseLocale.statusFr %></span> <%- baseLocale.nom %> : <a href="<%- baseLocale.recoveryUrl %>"><%- baseLocale.recoveryUrl %></a></li><% }); %>
+      ${recoveryBALList}
     </ul><% } %><% if (basesLocalesDeleted.length === 1) { %>
     <h3>Une Base Adresse Locale associée à votre adresse email a été supprimée, vous pouvez la récupérer via le lien ci-dessous :</h3>
     <ul>
-      <li><span class="status <%- basesLocalesDeleted[0].status %>"><%- basesLocalesDeleted[0].statusFr %><% if (basesLocalesDeleted[0].deleted) { %> le <%= basesLocalesDeleted[0].deleted %><% } %></span> <%- basesLocalesDeleted[0].nom %> : <% if (basesLocalesDeleted[0].deleted) { %> <a href="<%- basesLocalesDeleted[0].deletedRecoveryUrl %>"><%- basesLocalesDeleted[0].deletedRecoveryUrl %></a></li> <% } else { %> <a href="<%- basesLocalesDeleted[0].recoveryUrl %>"><%- basesLocalesDeleted[0].recoveryUrl %></a></li> <% }; %>
+      <li><span class="status <%- basesLocalesDeleted[0].status %>"><%- basesLocalesDeleted[0].statusFr %> le <%= basesLocalesDeleted[0].deleted %></span> <%- basesLocalesDeleted[0].nom %> : <a href="<%- basesLocalesDeleted[0].deletedRecoveryUrl %>"><%- basesLocalesDeleted[0].deletedRecoveryUrl %></a></li>
     </ul><% } %><% if (basesLocalesDeleted.length > 1) { %>
     <h3>Liste des Bases Adresses Locales supprimées, associées à votre adresse email :</h3>
     <ul>
-      <% _.forEach(basesLocalesDeleted, function(baseLocale) { %><li><span class="status <%- baseLocale.status %>"><%- baseLocale.statusFr %><% if (baseLocale.deleted) { %> le <%= baseLocale.deleted %><% } %></span> <%- baseLocale.nom %> : <% if (baseLocale.deleted) { %><a href="<%= apiUrl %>/v1/bases-locales/<%= baseLocale._id %>/<%= baseLocale.token %>/recovery"><%= apiUrl %>/v1/bases-locales/<%= baseLocale._id %>/<%= baseLocale.token %>/recovery</a></li><% } else { %> <a href="<%- baseLocale.recoveryUrl %>"><%- baseLocale.recoveryUrl %></a></li><% }}); %>
+      ${deletedBALList}
     </ul><%}%>
 
     <h5>Pourquoi ce courriel vous est envoyé ?</h5>

--- a/lib/emails/util.js
+++ b/lib/emails/util.js
@@ -30,4 +30,10 @@ function getEditorUrl(baseLocale) {
     .replace('<token>', baseLocale.token)
 }
 
-module.exports = {getEditorUrl, getApiUrl}
+const apiUrl = getApiUrl()
+
+function getApiRecoveryUrl(baseLocale) {
+  return `${apiUrl}/v1/bases-locales/${baseLocale._id}/${baseLocale.token}/recovery`
+}
+
+module.exports = {getEditorUrl, getApiUrl, getApiRecoveryUrl}

--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -286,6 +286,27 @@ test('Soft delete a BaseLocale', async t => {
   t.deepEqual(baseLocale._deleted, baseLocale._updated)
 })
 
+test('Recover BAL', async t => {
+  const _id = new mongo.ObjectId()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    nom: 'foo',
+    emails: ['me@domain.co', 'me2@domain.co'],
+    token: 'coucou',
+    status: 'published',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01'),
+    _deleted: new Date('2019-01-01')
+  })
+
+  const recoveredBAL = await BaseLocale.recovery(_id)
+  const baseLocale = await mongo.db.collection('bases_locales').findOne({_id})
+
+  t.is(recoveredBAL._deleted, null)
+  t.is(baseLocale._deleted, null)
+  t.deepEqual(recoveredBAL, baseLocale)
+})
+
 test('cleanContent', async t => {
   const _id = new mongo.ObjectId()
   await mongo.db.collection('bases_locales').insertOne({_id, nom: 'foo'})

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -218,6 +218,21 @@ async function remove(id) {
   }
 }
 
+async function recovery(id) {
+  const now = new Date()
+  const {value} = await mongo.db.collection('bases_locales').findOneAndUpdate(
+    {_id: mongo.parseObjectID(id)},
+    {$set: {_deleted: null, _updated: now}},
+    {returnDocument: 'after'}
+  )
+
+  if (!value) {
+    throw new Error('BaseLocale not found')
+  }
+
+  return value
+}
+
 async function renewToken(id) {
   const {value} = await mongo.db.collection('bases_locales').findOneAndUpdate(
     {_id: mongo.parseObjectID(id)},
@@ -521,6 +536,7 @@ module.exports = {
   updateSchema,
   transformToDraft,
   transformToDraftSchema,
+  recovery,
   fetchOne,
   fetchAll,
   fetchByCommunes,

--- a/lib/routes/__tests__/base-locale.js
+++ b/lib/routes/__tests__/base-locale.js
@@ -404,6 +404,51 @@ test.serial('delete a BaseLocal / without admin token', async t => {
   })
 })
 
+test('Restore deleted BAL', async t => {
+  const _id = new mongo.ObjectId()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    nom: 'foo',
+    emails: ['me@domain.co'],
+    commune: '27115',
+    token: 'coucou',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-02-02'),
+    _deleted: new Date('2019-02-02')
+  })
+
+  await request(getApp())
+    .get(`/bases-locales/${_id}/coucou/recovery`)
+
+  const baseLocale = await mongo.db.collection('bases_locales').findOne({_id})
+
+  t.is(baseLocale._deleted, null)
+})
+
+test('Restore deleted BAL / invalid token', async t => {
+  const _id = new mongo.ObjectId()
+  const deletedDate = new Date('2019-02-02')
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    nom: 'foo',
+    emails: ['me@domain.co'],
+    commune: '27115',
+    token: 'coucou',
+    _created: new Date('2019-01-01'),
+    _updated: deletedDate,
+    _deleted: deletedDate
+  })
+
+  const {status} = await request(getApp())
+    .get(`/bases-locales/${_id}/cou/recovery`)
+
+  t.is(status, 403)
+
+  const baseLocale = await mongo.db.collection('bases_locales').findOne({_id})
+
+  t.deepEqual(baseLocale._deleted, deletedDate)
+})
+
 test('export as CSV', async t => {
   mockBan54084()
   const {_id} = await BaseLocale.create({nom: 'foo', commune: '54084', emails: ['toto@acme.co']},)

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -8,6 +8,7 @@ const Numero = require('../models/numero')
 const Toponyme = require('../models/toponyme')
 const errorHandler = require('../util/error-handler')
 const {getCommune} = require('../util/cog')
+const {getEditorUrl} = require('../emails/util')
 const sync = require('../sync')
 const {createHabilitation, sendPinCode, validatePinCode, fetchHabilitation} = require('../habilitations')
 const {checkHasCadastre} = require('../cadastre')
@@ -199,6 +200,18 @@ app.route('/bases-locales/:baseLocaleId/numeros/batch')
   .delete(ensureIsAdmin, w(async (req, res) => {
     const batchRemove = await Numero.batchRemoveNumeros(req.baseLocale._id, req.body)
     res.send(batchRemove)
+  }))
+
+app.route('/bases-locales/:baseLocaleId/:token/recovery')
+  .get(w(async (req, res) => {
+    if (req.baseLocale.token !== req.params.token) {
+      return res.sendStatus(403)
+    }
+
+    const restoredBaseLocale = await BaseLocale.recovery(req.baseLocale._id)
+    const editorUrl = getEditorUrl(restoredBaseLocale)
+
+    res.redirect(editorUrl)
   }))
 
 function loadHabilitation(allowEmpty = false) {


### PR DESCRIPTION
Resolves #341 

- Création de `getApiRecoveryUrl`
- Modification du template de l'e-mail de récupération des BAL
- Ajout de la route `/bases-locales/:baseLocaleId/:token/recovery` (GET)