### PR TITLE
Renvoi la position prioritaire en fonction de son type

### DIFF
--- a/lib/export/geojson.js
+++ b/lib/export/geojson.js
@@ -1,5 +1,6 @@
-const {keyBy} = require('lodash')
+const {keyBy, maxBy} = require('lodash')
 const pumpify = require('pumpify')
+const {getPositionPriorityByType} = require('@etalab/adresses-util')
 const {stringify} = require('../util/geojson-stream')
 
 function voieToLineFeature(v) {
@@ -16,9 +17,17 @@ function voieToLineFeature(v) {
   }
 }
 
+function getBestPosition(positions) {
+  if (positions.length === 0) {
+    return {}
+  }
+
+  return maxBy(positions, p => getPositionPriorityByType(p.type))
+}
+
 function numeroVoieToAdresseFeature(n, v, t) {
   const nomToponyme = t ? t.nom : null
-  const position = n.positions[0]
+  const position = getBestPosition(n.positions)
   const properties = {
     type: 'adresse',
     idNumero: n._id,

--- a/lib/export/geojson.js
+++ b/lib/export/geojson.js
@@ -17,7 +17,7 @@ function voieToLineFeature(v) {
   }
 }
 
-function getBestPosition(positions) {
+function getPriorityPosition(positions) {
   if (positions.length === 0) {
     return {}
   }
@@ -27,7 +27,8 @@ function getBestPosition(positions) {
 
 function numeroVoieToAdresseFeature(n, v, t) {
   const nomToponyme = t ? t.nom : null
-  const position = getBestPosition(n.positions)
+  const position = getPriorityPosition(n.positions)
+
   const properties = {
     type: 'adresse',
     idNumero: n._id,

--- a/lib/export/geojson.js
+++ b/lib/export/geojson.js
@@ -1,6 +1,6 @@
 const {keyBy, maxBy} = require('lodash')
 const pumpify = require('pumpify')
-const {getPositionPriorityByType} = require('@etalab/adresses-util')
+const {getPositionPriorityByType} = require('@ban-team/adresses-util')
 const {stringify} = require('../util/geojson-stream')
 
 function voieToLineFeature(v) {

--- a/lib/populate/extract-csv.js
+++ b/lib/populate/extract-csv.js
@@ -1,5 +1,5 @@
 const {validate} = require('@ban-team/validateur-bal')
-const {normalize} = require('@etalab/adresses-util/lib/voies')
+const {normalize} = require('@ban-team/adresses-util/lib/voies')
 const {chain, compact, keyBy, min, max} = require('lodash')
 const {ObjectId} = require('../util/mongo')
 const {beautifyUppercased, beautifyNomAlt} = require('../util/string')

--- a/lib/util/string.js
+++ b/lib/util/string.js
@@ -1,5 +1,5 @@
 const {mapValues} = require('lodash')
-const {beautify} = require('@etalab/adresses-util/lib/voies')
+const {beautify} = require('@ban-team/adresses-util/lib/voies')
 
 function beautifyUppercased(str) {
   return str === str.toUpperCase()

--- a/migrations/2021-04-20-new-toponyme.js
+++ b/migrations/2021-04-20-new-toponyme.js
@@ -2,7 +2,7 @@
 /* eslint no-await-in-loop: off */
 require('dotenv').config()
 const {keyBy} = require('lodash')
-const {normalize} = require('@etalab/adresses-util/lib/voies')
+const {normalize} = require('@ban-team/adresses-util/lib/voies')
 const mongo = require('../lib/util/mongo')
 const {ObjectId} = require('../lib/util/mongo')
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "update-cadastre": "node ./scripts/update-communes-cadastre.js"
   },
   "dependencies": {
-    "@etalab/adresses-util": "^0.8.2",
+    "@ban-team/adresses-util": "^0.9.0",
     "@ban-team/shared-data": "^1.1.0",
     "@ban-team/validateur-bal": "^2.10.0",
     "@etalab/decoupage-administratif": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -197,6 +197,17 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
+"@ban-team/adresses-util@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@ban-team/adresses-util/-/adresses-util-0.9.0.tgz#7b137c3507a1c543d0f91d60ceff478363a9d5ba"
+  integrity sha512-d64e1HRxuAcn5z7JDPHbavVg6nJrBoFBL0qSMUwIPX5Y1uAqT5AdFcCQ/TRGguR35BinVBMocQ0QAA3pFOCNGg==
+  dependencies:
+    "@turf/distance" "^6.3.0"
+    leven "^3.1.0"
+    lodash "^4.17.20"
+    talisman "^1.1.4"
+    written-number "^0.9.1"
+
 "@ban-team/shared-data@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@ban-team/shared-data/-/shared-data-1.1.0.tgz#5c1ee73fd98b86723ee9893a426cbfd9a6e5f6b6"
@@ -241,17 +252,6 @@
     js-yaml "^4.1.0"
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
-
-"@etalab/adresses-util@^0.8.2":
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/@etalab/adresses-util/-/adresses-util-0.8.2.tgz#697c3ca9ed2e6103650a8f3c43fa2ae9caec360f"
-  integrity sha512-PsZfyECOvW6y5WzPq3NqaBk53CMcq9bNdcG8IzoFkAIf03RbFCMtSYFrhfOkJXa7qAxHJbESYBuiEPbaxCzZYw==
-  dependencies:
-    "@turf/distance" "^6.3.0"
-    leven "^3.1.0"
-    lodash "^4.17.20"
-    talisman "^1.1.4"
-    written-number "^0.9.1"
 
 "@etalab/decoupage-administratif@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
~~## ⚠️ Ne pas merger avant [cette PR](https://github.com/BaseAdresseNationale/adresses-util/pull/15) ⚠️~~

Cette PR propose d’ajouter une fonction `getBestPosition` permettant de modifier l’ordre d’affichage des positions.

Jusqu’à présent, l’ordre des positions était choisi en fonction de l’ordre des positions et non du type.
Avec cette modification, l’ordre sera défini grâce à un algorithme renvoyant la position prioritaire. 

_**Les tests ne pourront fonctionner que lorsque `adresses-util` sera mis à jour, cf [cette PR](https://github.com/BaseAdresseNationale/adresses-util/pull/15)**_ -> OK !

Fix [#591 mes-adresses](https://github.com/BaseAdresseNationale/mes-adresses/issues/591)