### PR TITLE
Mise à jour du validateur de Base Adresse Locale

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@ban-team/adresses-util": "^0.9.0",
     "@ban-team/shared-data": "^1.1.0",
-    "@ban-team/validateur-bal": "^2.10.0",
+    "@ban-team/validateur-bal": "^2.11.0",
     "@etalab/decoupage-administratif": "^2.0.0",
     "@etalab/project-legal": "^0.6.0",
     "bluebird": "^3.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -213,10 +213,10 @@
   resolved "https://registry.yarnpkg.com/@ban-team/shared-data/-/shared-data-1.1.0.tgz#5c1ee73fd98b86723ee9893a426cbfd9a6e5f6b6"
   integrity sha512-+SnPGySf715hd2pvygtCN24uGZNBMAeY8mNvt1WC7a+sPtjz74HL7+S+ff7SiZIrSYioSJi+OZp5t8QHgk2X/A==
 
-"@ban-team/validateur-bal@^2.10.0":
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.10.0.tgz#47f5f58ce13f2f4ab4b3e490e687ab3bb1d8cdaf"
-  integrity sha512-DPi9hlgbs88exH6UAoJLJ63UyChdBpldD+kzvp0DdXRWYGh7oJwUwroSuw7ixqAB7iXPlSsIfIK3fe6EUle78Q==
+"@ban-team/validateur-bal@^2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.11.0.tgz#3707aab531f720614d9c842db41ff510d92918d8"
+  integrity sha512-jyixz2ZhvFic4TQKzRyUcZoWDCXoiGfxrxp637kVeG4Yt+BIJW65Ze02qWa9F4OCZJxGNwj8asNzP6HJlEnXcA==
   dependencies:
     "@ban-team/shared-data" "^1.1.0"
     "@etalab/project-legal" "^0.6.0"
@@ -224,7 +224,7 @@
     bluebird "^3.7.2"
     chalk "^4.1.2"
     chardet "^1.4.0"
-    date-fns "^2.28.0"
+    date-fns "^2.29.3"
     file-type "^12.4.2"
     iconv-lite "^0.6.3"
     lodash "^4.17.21"
@@ -1425,6 +1425,11 @@ date-fns@^2.28.0:
   version "2.28.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
   integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
+
+date-fns@^2.29.3:
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
+  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
 
 date-time@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
Mise à jour du validateur de Base Adresse Locale en version [2.11.0](https://github.com/BaseAdresseNationale/validateur-bal/releases/tag/v2.11.0)