### PR TITLE
Ajout de logs au démarrage du serveur

### DIFF
--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@ async function main() {
   const port = process.env.PORT || 5000
 
   await mongo.connect()
+  console.log('Prepare contours communes…')
   await prepareContoursCommunes()
 
   app.use(cors({origin: true}))
@@ -23,7 +24,9 @@ async function main() {
   app.use('/public', express.static('public'))
   app.use('/v1', routes)
 
-  app.listen(port)
+  app.listen(port, () => {
+    console.log(`Start listening on port ${port}`)
+  })
 }
 
 main().catch(error => {


### PR DESCRIPTION
## Contexte
Aucun log n'est actuellement affiché en console au démarrage du serveur. Or la préparation des contours des communes peut prendre un certain temps.

## Évolution
Affiche deux logs console:
- Début de la préparation des contours des communes
- Quand le serveur est prêt et indique sur quel port