### PR TITLE
Valide le nom des toponymes avec le validateur BAL

### DIFF
--- a/lib/models/__tests__/toponyme.schema.js
+++ b/lib/models/__tests__/toponyme.schema.js
@@ -38,7 +38,7 @@ test('not valid payload: nom over 200 caracters', async t => {
 
   const {error} = await validSchema(toponyme, createSchema)
 
-  t.deepEqual(error, {nom: ['Le nom est trop long (200 caractères maximum)']})
+  t.deepEqual(error, {nom: ['Le nom du toponyme est trop long (200 caractères maximum)']})
 })
 
 test('not valid payload: nom missing', async t => {

--- a/lib/models/toponyme.js
+++ b/lib/models/toponyme.js
@@ -1,16 +1,18 @@
 const mongo = require('../util/mongo')
-const {validPayload, addError} = require('../util/payload')
-const {getFilteredPayload} = require('../util/payload')
+const {validPayload, addError, getFilteredPayload} = require('../util/payload')
+const {validateurBAL} = require('../validateur-bal')
 const {cleanNom} = require('./voie')
 const nomAltSchema = require('./nom-alt')
 const {validPositions, validParcelles} = require('./numero')
 
-function validNom(nom, error) {
-  if (nom.length === 0) {
-    addError(error, 'nom', 'Le nom est trop court (1 caractère minimum)')
-  } else if (nom.length > 200) {
-    addError(error, 'nom', 'Le nom est trop long (200 caractères maximum)')
-  }
+async function validNom(nom, error) {
+  const {value, errors} = await validateurBAL(nom, 'voie_nom')
+
+  errors.forEach(err => {
+    addError(error, 'nom', err.replace('de la voie', 'du toponyme'))
+  })
+
+  return value
 }
 
 const createSchema = {

--- a/lib/routes/__tests__/toponymes.js
+++ b/lib/routes/__tests__/toponymes.js
@@ -336,7 +336,7 @@ test.serial('modify a toponyme', async t => {
   t.deepEqual(body.nomAlt, {gcf: 'Lapwent'})
 })
 
-test.serial('modify a toponyme / empty nom', async t => {
+test.serial('modify a toponyme / nom too short', async t => {
   const _idBal = new mongo.ObjectId()
   const _id = new mongo.ObjectId()
   await mongo.db.collection('bases_locales').insertOne({
@@ -361,14 +361,14 @@ test.serial('modify a toponyme / empty nom', async t => {
   const {status, body} = await request(getApp())
     .put(`/toponymes/${_id}`)
     .set({Authorization: 'Token coucou'})
-    .send({nom: ''})
+    .send({nom: 'fo'})
 
   t.is(status, 400)
   t.deepEqual(body, {
     code: 400,
     message: 'Invalid payload',
     validation: {
-      nom: ['Le nom est trop court (1 caractère minimum)']
+      nom: ['Le nom du toponyme est trop court (3 caractères minimum)']
     }
   })
 })


### PR DESCRIPTION
## Contexte
Seulement deux règles de validation sont appliquées aux noms des toponymes :
- Avoir plus d'un caractère
- Avoir moins de 200 caractères

Cependant, un certain nombre de toponymes avec des noms incorrecte remonte dans le support.

## Évolution
Le nom du toponyme est validé par le `validateur-bal` en utilisant le champ `voie_nom` qui utilise les mêmes critères de validation.
L'erreur renvoyée par le validateur est en revanche modifiée pour ne pas dire "_xxx de la voie_" mais bien "_xxx du toponyme".

Fix [BaseAdresseNationale/mes-adresses/721](https://github.com/BaseAdresseNationale/mes-adresses/issues/712)