### PR TITLE
Corrige le problème d’ajout d’emails

### DIFF
--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -29,7 +29,7 @@ async function validNom(nom, error) {
 }
 
 async function validEmail(email, error) {
-  if (!(/^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/.test(email))) {
+  if (!(/^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[(?:\d{1,3}\.){3}\d{1,3}])|(([a-zA-Z\-\d]+\.)+[a-zA-Z]{2,}))$/.test(email))) {
     addError(error, 'emails', `L’adresse email ${email} est invalide`)
   }
 }


### PR DESCRIPTION
## Contexte : 
Certains utilisateurs n’arrivent pas à valider leur adresse email, malgré qu’elle soit correcte.

## Solution : 

Modification du regex de validation d’adresse mail (utilisation de celui de mes-adresses)

Fix [#714](https://github.com/BaseAdresseNationale/mes-adresses/issues/714)