### PR TITLE
Modification majeure de la route /bases-locales/search

### DIFF
--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -1,7 +1,6 @@
 const test = require('ava')
 const {MongoMemoryServer} = require('mongodb-memory-server')
 const subMonths = require('date-fns/subMonths')
-const {every} = require('lodash')
 const mongo = require('../../util/mongo')
 const BaseLocale = require('../base-locale')
 const {getAssignedParcelles} = require('../base-locale')
@@ -479,7 +478,7 @@ test('Fetch bases locales by status', async t => {
   const {basesLocales, count} = await BaseLocale.fetch({status: 'draft'})
 
   t.is(count, 2)
-  t.true(every(basesLocales, {status: 'draft'}))
+  t.true(basesLocales.every(({status}) => status === 'draft'))
 })
 
 test('Fetch bases locales / cross params', async t => {

--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -438,8 +438,8 @@ test('Fetch Base Locales by commune and email', async t => {
     commune: '55500'
   })
 
-  const foundedBasesLocales = await BaseLocale.fetch({commune: '55326', email: 'living@data.com'})
-  const notFoundedBasesLocales = await BaseLocale.fetch({commune: '55326', email: 'fetching@data.com'})
+  const foundedBasesLocales = await BaseLocale.fetchByQuery({commune: '55326', email: 'living@data.com'})
+  const notFoundedBasesLocales = await BaseLocale.fetchByQuery({commune: '55326', email: 'fetching@data.com'})
 
   t.deepEqual(foundedBasesLocales.basesLocales[0].emails, ['living@data.com'])
   t.is(foundedBasesLocales.basesLocales[0].commune, '55326')
@@ -475,7 +475,7 @@ test('Fetch bases locales by status', async t => {
     commune: '55500'
   })
 
-  const {basesLocales, count} = await BaseLocale.fetch({status: 'draft'})
+  const {basesLocales, count} = await BaseLocale.fetchByQuery({status: 'draft'})
 
   t.is(count, 2)
   t.true(basesLocales.every(({status}) => status === 'draft'))
@@ -513,7 +513,7 @@ test('Fetch bases locales / cross params', async t => {
     commune: '55500'
   })
 
-  const {basesLocales, count} = await BaseLocale.fetch({status: 'draft', commune: '55500'})
+  const {basesLocales, count} = await BaseLocale.fetchByQuery({status: 'draft', commune: '55500'})
 
   t.is(count, 1)
   t.deepEqual(basesLocales[0]._id, idBal2)

--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -388,13 +388,13 @@ test('find Bases Locales by codes commune', async t => {
   await mongo.db.collection('bases_locales').insertOne({
     _id: _idBalA,
     token: 'coucou1',
-    commune: '47192'
+    commune: '47178'
   })
 
   await mongo.db.collection('bases_locales').insertOne({
     _id: _idBalB,
     token: 'coucou2',
-    commune: '47178'
+    commune: '47192'
   })
 
   await mongo.db.collection('bases_locales').insertOne({

--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -514,7 +514,7 @@ test('Fetch bases locales / cross params', async t => {
     commune: '55500'
   })
 
-  const {basesLocales, count} = await BaseLocale.fetch({status: 'draft', commune: '55500', nom: 'bal-A'})
+  const {basesLocales, count} = await BaseLocale.fetch({status: 'draft', commune: '55500'})
 
   t.is(count, 1)
   t.deepEqual(basesLocales[0]._id, idBal2)

--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -416,6 +416,32 @@ test('find Bases Locales by code commune / no BAL found', async t => {
   t.is(basesLocales.length, 0)
 })
 
+test('Fetch Base Locales by commune and email', async t => {
+  const idBal1 = new mongo.ObjectId()
+  const idBal2 = new mongo.ObjectId()
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: idBal1,
+    token: 'coucou',
+    emails: ['living@data.com'],
+    commune: '55326'
+  })
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: idBal2,
+    token: 'coucou',
+    emails: ['fetching@data.com'],
+    commune: '55500'
+  })
+
+  const foundedBasesLocales = await BaseLocale.fetch({commune: '55326', email: 'living@data.com'})
+  const notFoundedBasesLocales = await BaseLocale.fetch({commune: '55326', email: 'fetching@data.com'})
+
+  t.deepEqual(foundedBasesLocales.basesLocales[0].emails, ['living@data.com'])
+  t.is(foundedBasesLocales.basesLocales[0].commune, '55326')
+  t.is(notFoundedBasesLocales.basesLocales.length, 0)
+})
+
 test('Get all assigned parcelles', async t => {
   const _id = new mongo.ObjectId()
   await mongo.db.collection('bases_locales').insertOne({

--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -416,33 +416,6 @@ test('find Bases Locales by code commune / no BAL found', async t => {
   t.is(basesLocales.length, 0)
 })
 
-test('Find Base Locales by commune and email', async t => {
-  const idBal1 = new mongo.ObjectId()
-  const idBal2 = new mongo.ObjectId()
-
-  await mongo.db.collection('bases_locales').insertOne({
-    _id: idBal1,
-    token: 'coucou',
-    emails: ['living@data.com'],
-    commune: '55326'
-  })
-
-  await mongo.db.collection('bases_locales').insertOne({
-    _id: idBal2,
-    token: 'coucou',
-    emails: ['fetching@data.com'],
-    commune: '55500'
-  })
-
-  const foundedBasesLocales = await BaseLocale.findByCommuneAndEmail('55326', 'living@data.com')
-  const notFoundedBasesLocales = await BaseLocale.findByCommuneAndEmail('55326', 'fetching@data.com')
-
-  t.is(foundedBasesLocales[0].emails, undefined)
-  t.is(foundedBasesLocales[0].token, undefined)
-  t.is(foundedBasesLocales[0].commune, '55326')
-  t.is(notFoundedBasesLocales.length, 0)
-})
-
 test('Get all assigned parcelles', async t => {
   const _id = new mongo.ObjectId()
   await mongo.db.collection('bases_locales').insertOne({

--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -1,6 +1,7 @@
 const test = require('ava')
 const {MongoMemoryServer} = require('mongodb-memory-server')
 const subMonths = require('date-fns/subMonths')
+const {every} = require('lodash')
 const mongo = require('../../util/mongo')
 const BaseLocale = require('../base-locale')
 const {getAssignedParcelles} = require('../base-locale')
@@ -16,6 +17,10 @@ test.before('start server', async () => {
 test.after.always('cleanup', async () => {
   await mongo.disconnect()
   await mongod.stop()
+})
+
+test.beforeEach('clean database', async () => {
+  await mongo.db.collection('bases_locales').deleteMany({})
 })
 
 test('create a BaseLocale', async t => {
@@ -440,6 +445,79 @@ test('Fetch Base Locales by commune and email', async t => {
   t.deepEqual(foundedBasesLocales.basesLocales[0].emails, ['living@data.com'])
   t.is(foundedBasesLocales.basesLocales[0].commune, '55326')
   t.is(notFoundedBasesLocales.basesLocales.length, 0)
+})
+
+test('Fetch bases locales by status', async t => {
+  const idBal1 = new mongo.ObjectId()
+  const idBal2 = new mongo.ObjectId()
+  const idBal3 = new mongo.ObjectId()
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: idBal1,
+    token: 'coucou',
+    status: 'draft',
+    emails: ['living@data.com'],
+    commune: '55326'
+  })
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: idBal2,
+    token: 'coucou',
+    status: 'draft',
+    emails: ['fetching@data.com'],
+    commune: '55500'
+  })
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: idBal3,
+    token: 'coucou',
+    status: 'ready-to-publish',
+    emails: ['fetching@data.com'],
+    commune: '55500'
+  })
+
+  const {basesLocales, count} = await BaseLocale.fetch({status: 'draft'})
+
+  t.is(count, 2)
+  t.true(every(basesLocales, {status: 'draft'}))
+})
+
+test('Fetch bases locales / cross params', async t => {
+  const idBal1 = new mongo.ObjectId()
+  const idBal2 = new mongo.ObjectId()
+  const idBal3 = new mongo.ObjectId()
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: idBal1,
+    nom: 'bal-A',
+    token: 'coucou',
+    status: 'draft',
+    emails: ['living@data.com'],
+    commune: '55326'
+  })
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: idBal2,
+    nom: 'bal-A',
+    token: 'coucou',
+    status: 'draft',
+    emails: ['fetching@data.com'],
+    commune: '55500'
+  })
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: idBal3,
+    nom: 'bal-A',
+    token: 'coucou',
+    status: 'ready-to-publish',
+    emails: ['fetching@data.com'],
+    commune: '55500'
+  })
+
+  const {basesLocales, count} = await BaseLocale.fetch({status: 'draft', commune: '55500', nom: 'bal-A'})
+
+  t.is(count, 1)
+  t.deepEqual(basesLocales[0]._id, idBal2)
 })
 
 test('Get all assigned parcelles', async t => {

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -78,6 +78,34 @@ const transformToDraftSchema = {
   email: {valid: validEmail, isRequired: true, nullAllowed: false, type: 'string'}
 }
 
+function parseQueryFilters(query) {
+  const limit = query.limit ? Number.parseInt(query.limit, 10) : 20
+  const offset = query.offset ? Number.parseInt(query.offset, 10) : 0
+  const filters = {}
+
+  if (query.deleted) {
+    if (query.deleted === '0') {
+      filters._deleted = {$eq: null}
+    } else if (query.deleted === '1') {
+      filters._deleted = {$ne: null}
+    }
+  }
+
+  if (query.nom) {
+    filters.$text = {$search: query.nom}
+  }
+
+  if (query.commune) {
+    filters.commune = {$eq: query.commune}
+  }
+
+  if (query.email) {
+    filters.emails = {$eq: query.email}
+  }
+
+  return {offset, limit, filters}
+}
+
 async function create(payload) {
   const {nom, emails, commune} = await validPayload(payload, createSchema)
 
@@ -200,10 +228,15 @@ async function fetchAll() {
 }
 
 async function fetch(query) {
-  const cursor = await mongo.db.collection('bases_locales').find(query)
-  const count = await mongo.db.collection('bases_locales').countDocuments(query)
+  const {limit, offset, filters} = parseQueryFilters(query)
+  const count = await mongo.db.collection('bases_locales').countDocuments({...filters})
+  const basesLocales = await mongo.db.collection('bases_locales')
+    .find({...filters})
+    .limit(limit)
+    .skip(offset)
+    .toArray()
 
-  return {cursor, count}
+  return {offset, limit, count, basesLocales}
 }
 
 async function fetchByCommunes(codesCommunes) {

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -92,7 +92,7 @@ function parseQueryFilters(query) {
   }
 
   if (query.nom) {
-    filters.$text = {$search: query.nom}
+    filters.nom = {$eq: query.nom}
   }
 
   if (query.commune) {

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -195,6 +195,10 @@ async function fetchOne(id) {
   return mongo.db.collection('bases_locales').findOne({_id: mongo.parseObjectID(id)})
 }
 
+async function fetchAll() {
+  return mongo.db.collection('bases_locales').find({}).toArray()
+}
+
 async function fetch(query) {
   const cursor = await mongo.db.collection('bases_locales').find(query)
   const count = await mongo.db.collection('bases_locales').countDocuments(query)
@@ -441,13 +445,6 @@ async function basesLocalesRecovery(userEmail, baseLocaleId) {
   }
 }
 
-async function findByCommuneAndEmail(codeCommune, userEmail) {
-  const foundBasesLocales = await mongo.db.collection('bases_locales')
-    .find({commune: codeCommune, emails: userEmail}).sort({_updated: -1}).toArray()
-
-  return foundBasesLocales.map(bal => filterSensitiveFields(bal))
-}
-
 async function getAssignedParcelles(balId) {
   const numeroWithParcelles = await mongo.db.collection('numeros').distinct('parcelles', {_bal: mongo.parseObjectID(balId)})
   const toponymesWithParcelles = await mongo.db.collection('toponymes').distinct('parcelles', {_bal: mongo.parseObjectID(balId)})
@@ -525,6 +522,7 @@ module.exports = {
   transformToDraftSchema,
   recovery,
   fetchOne,
+  fetchAll,
   fetch,
   fetchByCommunes,
   remove,
@@ -539,7 +537,6 @@ module.exports = {
   computeStats,
   publishedBasesLocalesStats,
   basesLocalesRecovery,
-  findByCommuneAndEmail,
   getAssignedParcelles,
   batchUpdateNumeros,
   updateHabilitation,

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -93,14 +93,6 @@ function parseQueryFilters(query) {
     }
   }
 
-  if (query.nom) {
-    if (typeof query.nom === 'string') {
-      filters.nom = {$eq: query.nom}
-    } else {
-      throw createHttpError(400, 'La valeur du champ "nom" est invalide')
-    }
-  }
-
   if (query.commune) {
     if (typeof query.commune === 'string' && getCommuneCOG(query.commune)) {
       filters.commune = {$eq: query.commune}

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -103,6 +103,10 @@ function parseQueryFilters(query) {
     filters.emails = {$eq: query.email}
   }
 
+  if (query.status) {
+    filters.status = {$eq: query.status}
+  }
+
   return {offset, limit, filters}
 }
 

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -196,7 +196,11 @@ async function fetchOne(id) {
 }
 
 async function fetchAll() {
-  return mongo.db.collection('bases_locales').find({}).toArray()
+  const query = {_deleted: {$eq: null}}
+  const cursor = await mongo.db.collection('bases_locales').find(query)
+  const count = await mongo.db.collection('bases_locales').countDocuments(query)
+
+  return {cursor, count}
 }
 
 async function fetchByCommunes(codesCommunes) {

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -195,8 +195,7 @@ async function fetchOne(id) {
   return mongo.db.collection('bases_locales').findOne({_id: mongo.parseObjectID(id)})
 }
 
-async function fetchAll() {
-  const query = {_deleted: {$eq: null}}
+async function fetch(query) {
   const cursor = await mongo.db.collection('bases_locales').find(query)
   const count = await mongo.db.collection('bases_locales').countDocuments(query)
 
@@ -526,7 +525,7 @@ module.exports = {
   transformToDraftSchema,
   recovery,
   fetchOne,
-  fetchAll,
+  fetch,
   fetchByCommunes,
   remove,
   renewToken,

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -123,8 +123,9 @@ function parseQueryFilters(query) {
     } else {
       throw createHttpError(400, 'La valeur du champ "email" est invalide')
     }
+  }
 
-  return {offset, limit, filters}
+    return {offset, limit, filters}
 }
 
 async function create(payload) {

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -88,24 +88,41 @@ function parseQueryFilters(query) {
       filters._deleted = {$eq: null}
     } else if (query.deleted === '1') {
       filters._deleted = {$ne: null}
+    } else {
+      throw createHttpError(400, 'La valeur du champ "deleted" est invalide')
     }
   }
 
   if (query.nom) {
-    filters.nom = {$eq: query.nom}
+    if (typeof query.nom === 'string') {
+      filters.nom = {$eq: query.nom}
+    } else {
+      throw createHttpError(400, 'La valeur du champ "nom" est invalide')
+    }
   }
 
   if (query.commune) {
-    filters.commune = {$eq: query.commune}
+    if (typeof query.nom === 'string' && getCodesCommunes().includes(query.commune)) {
+      filters.commune = {$eq: query.commune}
+    } else {
+      throw createHttpError(400, 'La valeur du champ "commune" est invalide')
+    }
   }
 
   if (query.email) {
-    filters.emails = {$eq: query.email}
+    if (typeof query.email === 'string') {
+      filters.emails = {$eq: query.email}
+    } else {
+      throw createHttpError(400, 'La valeur du champ "email" est invalide')
+    }
   }
 
   if (query.status) {
-    filters.status = {$eq: query.status}
-  }
+    if (typeof query.status === 'string' && ['demo', 'draft', 'ready-to-publish', 'published', 'replaced'].includes(query.status)) {
+      filters.status = {$eq: query.status}
+    } else {
+      throw createHttpError(400, 'La valeur du champ "email" est invalide')
+    }
 
   return {offset, limit, filters}
 }

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -79,8 +79,8 @@ const transformToDraftSchema = {
 }
 
 function parseQueryFilters(query) {
-  const limit = query.limit ? Number.parseInt(query.limit, 10) : 20
-  const offset = query.offset ? Number.parseInt(query.offset, 10) : 0
+  const limit = Math.min(Math.max(Number.parseInt(query.limit, 10) || 20, 1), 100) // Convert to integer or assign a default value if NaN. Min = 1, Max = 100, default = 20
+  const offset = Math.min(Number.parseInt(query.offset, 10) || 0, 0) // Convert to integer or assign a default value if NaN. Min = 0, default = 0
   const filters = {}
 
   if (query.deleted) {

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -249,7 +249,7 @@ async function fetchAll() {
   return mongo.db.collection('bases_locales').find({}).toArray()
 }
 
-async function fetch(query) {
+async function fetchByQuery(query) {
   const {limit, offset, filters} = parseQueryFilters(query)
   const count = await mongo.db.collection('bases_locales').countDocuments(filters)
   const basesLocales = await mongo.db.collection('bases_locales')
@@ -578,7 +578,7 @@ module.exports = {
   recovery,
   fetchOne,
   fetchAll,
-  fetch,
+  fetchByQuery,
   fetchByCommunes,
   remove,
   renewToken,

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -79,9 +79,17 @@ const transformToDraftSchema = {
 }
 
 function parseQueryFilters(query) {
-  const limit = query.limit ? Math.min(Math.max(Number.parseInt(query.limit, 10), 1), 100) : 20 // Convert to integer or assign a default value if NaN. Min = 1, Max = 100, default = 20
-  const offset = query.offset ? Math.min(Number.parseInt(query.offset, 10), 0) : 0 // Convert to integer or assign a default value if NaN. Min = 0, default = 0
+  const limit = query.limit ? Number.parseInt(query.limit, 10) : 20
+  const offset = query.offset ? Number.parseInt(query.offset, 10) : 0
   const filters = {}
+
+  if (!Number.isInteger(limit) || limit > 100 || limit <= 0) {
+    throw createHttpError(400, 'La valeur du champ "limit" doit un entier compris en 1 et 100 (défaut : 20)')
+  }
+
+  if (!Number.isInteger(offset) || offset < 0) {
+    throw createHttpError(400, 'La valeur du champ "offset" doit être un entier positif (défaut : 0)')
+  }
 
   if (query.deleted) {
     if (query.deleted === '0') {
@@ -243,7 +251,7 @@ async function fetchAll() {
 
 async function fetch(query) {
   const {limit, offset, filters} = parseQueryFilters(query)
-  const count = await mongo.db.collection('bases_locales').countDocuments({...filters})
+  const count = await mongo.db.collection('bases_locales').countDocuments(filters)
   const basesLocales = await mongo.db.collection('bases_locales')
     .find({...filters})
     .limit(limit)

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -14,7 +14,7 @@ const {extract} = require('../populate/extract-ban')
 const {extractFromCsv} = require('../populate/extract-csv')
 const adressesToCsv = require('../export/csv-bal').exportAsCsv
 const {transformToGeoJSON} = require('../export/geojson')
-const {getCommune: getCommuneCOG, getCodesCommunes} = require('../util/cog')
+const {getCommune: getCommuneCOG} = require('../util/cog')
 const {getCommunesSummary} = require('../util/api-ban')
 const Voie = require('./voie')
 const Numero = require('./numero')
@@ -45,7 +45,7 @@ async function validEmails(emails, error) {
 }
 
 async function validCommune(commune, error) {
-  if (!getCodesCommunes().includes(commune)) {
+  if (!getCommuneCOG(commune)) {
     addError(error, 'commune', 'Code commune inconnu')
   }
 }
@@ -79,8 +79,8 @@ const transformToDraftSchema = {
 }
 
 function parseQueryFilters(query) {
-  const limit = Math.min(Math.max(Number.parseInt(query.limit, 10) || 20, 1), 100) // Convert to integer or assign a default value if NaN. Min = 1, Max = 100, default = 20
-  const offset = Math.min(Number.parseInt(query.offset, 10) || 0, 0) // Convert to integer or assign a default value if NaN. Min = 0, default = 0
+  const limit = query.limit ? Math.min(Math.max(Number.parseInt(query.limit, 10), 1), 100) : 20 // Convert to integer or assign a default value if NaN. Min = 1, Max = 100, default = 20
+  const offset = query.offset ? Math.min(Number.parseInt(query.offset, 10), 0) : 0 // Convert to integer or assign a default value if NaN. Min = 0, default = 0
   const filters = {}
 
   if (query.deleted) {
@@ -102,7 +102,7 @@ function parseQueryFilters(query) {
   }
 
   if (query.commune) {
-    if (typeof query.nom === 'string' && getCodesCommunes().includes(query.commune)) {
+    if (typeof query.commune === 'string' && getCommuneCOG(query.commune)) {
       filters.commune = {$eq: query.commune}
     } else {
       throw createHttpError(400, 'La valeur du champ "commune" est invalide')
@@ -110,7 +110,7 @@ function parseQueryFilters(query) {
   }
 
   if (query.email) {
-    if (typeof query.email === 'string') {
+    if (typeof query.email === 'string' && validEmail(query.email)) {
       filters.emails = {$eq: query.email}
     } else {
       throw createHttpError(400, 'La valeur du champ "email" est invalide')
@@ -125,7 +125,7 @@ function parseQueryFilters(query) {
     }
   }
 
-    return {offset, limit, filters}
+  return {offset, limit, filters}
 }
 
 async function create(payload) {

--- a/lib/routes/__tests__/base-locale.js
+++ b/lib/routes/__tests__/base-locale.js
@@ -95,7 +95,7 @@ test.serial('create a BaseLocale / invalid commune', async t => {
   })
 })
 
-test.serial('get BaseLocales', async t => {
+test.serial('get all BaseLocales', async t => {
   const _idBalA = new mongo.ObjectId()
   const _idBalB = new mongo.ObjectId()
 
@@ -124,11 +124,10 @@ test.serial('get BaseLocales', async t => {
   const {body, status} = await request(getApp())
     .get('/bases-locales')
 
-  t.true(['page', 'limit', 'totalPages', 'basesLocales'].every(k => k in body))
   t.is(status, 200)
-  t.is(body.basesLocales.length, 2)
-  t.true(SAFE_FIELDS.every(k => k in body.basesLocales[0]))
-  t.is(Object.keys(body.basesLocales[0]).length, SAFE_FIELDS.length)
+  t.is(body.length, 2)
+  t.true(SAFE_FIELDS.every(k => k in body[0]))
+  t.is(Object.keys(body[0]).length, SAFE_FIELDS.length)
 })
 
 test.serial('get a BaseLocal / with admin token', async t => {
@@ -539,7 +538,7 @@ test.serial('renew token / without admin token', async t => {
   t.is(baseLocal.token, 'coucou')
 })
 
-test('Find Bases Locales by Commune and email', async t => {
+test('Find Bases Locales by commune and email', async t => {
   const _id = new mongo.ObjectId()
   await mongo.db.collection('bases_locales').insertOne({
     _id,
@@ -549,28 +548,12 @@ test('Find Bases Locales by Commune and email', async t => {
   })
 
   const response = await request(getApp())
-    .get('/bases-locales/search?codeCommune=55326&userEmail=living@data.com')
+    .get('/bases-locales/search?commune=55326&email=living@data.com')
 
   t.is(response.status, 200)
-  t.is(response.body.length, 1)
-  t.is(response.body[0].email, undefined)
-  t.is(response.body[0].commune, '55326')
-})
-
-test('Find Bases Locales by Commune and email, no email', async t => {
-  const response = await request(getApp())
-    .get('/bases-locales/search?codeCommune=55326')
-
-  t.is(response.status, 400)
-  t.is(response.body.message, 'codeCommune et userEmail sont des champs obligatoires')
-})
-
-test('Find Bases Locales by Commune and email, no commune', async t => {
-  const response = await request(getApp())
-    .get('/bases-locales/search')
-
-  t.is(response.status, 400)
-  t.is(response.body.message, 'codeCommune et userEmail sont des champs obligatoires')
+  t.is(response.body.basesLocales.length, 1)
+  t.is(response.body.basesLocales[0].email, undefined)
+  t.is(response.body.basesLocales[0].commune, '55326')
 })
 
 test('get all assigned parcelles', async t => {

--- a/lib/routes/__tests__/base-locale.js
+++ b/lib/routes/__tests__/base-locale.js
@@ -551,9 +551,9 @@ test('Find Bases Locales by commune and email', async t => {
     .get('/bases-locales/search?commune=55326&email=living@data.com')
 
   t.is(response.status, 200)
-  t.is(response.body.basesLocales.length, 1)
-  t.is(response.body.basesLocales[0].email, undefined)
-  t.is(response.body.basesLocales[0].commune, '55326')
+  t.is(response.body.results.length, 1)
+  t.is(response.body.results[0].email, undefined)
+  t.is(response.body.results[0].commune, '55326')
 })
 
 test('get all assigned parcelles', async t => {

--- a/lib/routes/__tests__/base-locale.js
+++ b/lib/routes/__tests__/base-locale.js
@@ -95,7 +95,7 @@ test.serial('create a BaseLocale / invalid commune', async t => {
   })
 })
 
-test.serial('get all BaseLocale', async t => {
+test.serial('get BaseLocales', async t => {
   const _idBalA = new mongo.ObjectId()
   const _idBalB = new mongo.ObjectId()
 
@@ -124,10 +124,11 @@ test.serial('get all BaseLocale', async t => {
   const {body, status} = await request(getApp())
     .get('/bases-locales')
 
+  t.true(['page', 'limit', 'totalPages', 'basesLocales'].every(k => k in body))
   t.is(status, 200)
-  t.is(body.length, 2)
-  t.true(SAFE_FIELDS.every(k => k in body[0]))
-  t.is(Object.keys(body[0]).length, SAFE_FIELDS.length)
+  t.is(body.basesLocales.length, 2)
+  t.true(SAFE_FIELDS.every(k => k in body.basesLocales[0]))
+  t.is(Object.keys(body.basesLocales[0]).length, SAFE_FIELDS.length)
 })
 
 test.serial('get a BaseLocal / with admin token', async t => {

--- a/lib/routes/__tests__/base-locale.js
+++ b/lib/routes/__tests__/base-locale.js
@@ -538,13 +538,22 @@ test.serial('renew token / without admin token', async t => {
   t.is(baseLocal.token, 'coucou')
 })
 
-test('Find Bases Locales by commune and email', async t => {
-  const _id = new mongo.ObjectId()
+test('Fetch Bases Locales by commune and email', async t => {
+  const idBal1 = new mongo.ObjectId()
+  const idBal2 = new mongo.ObjectId()
+
   await mongo.db.collection('bases_locales').insertOne({
-    _id,
+    _id: idBal1,
     token: 'coucou',
     emails: ['living@data.com'],
     commune: '55326'
+  })
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: idBal2,
+    token: 'coucou',
+    emails: ['fetching@data.com'],
+    commune: '55500'
   })
 
   const response = await request(getApp())

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -110,7 +110,7 @@ app.route('/bases-locales/create-demo')
 
 app.route('/bases-locales/search')
   .get(w(async (req, res) => {
-    const {offset, limit, count, basesLocales} = await BaseLocale.fetch(req.query)
+    const {offset, limit, count, basesLocales} = await BaseLocale.fetchByQuery(req.query)
     const basesLocalesExpanded = await Promise.all(
       basesLocales.map(baseLocale => expandModelWithNumeros(baseLocale, '_bal'))
     )

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -33,33 +33,6 @@ function checkIsAdmin(baseLocale, req) {
   return req.get('Authorization') === `Token ${baseLocale.token}`
 }
 
-function parseQueryFilters(req, res, next) {
-  const queryFilter = {}
-
-  if (req.query.deleted) {
-    if (req.query.deleted === '0') {
-      queryFilter._deleted = {$eq: null}
-    } else if (req.query.deleted === '1') {
-      queryFilter._deleted = {$ne: null}
-    }
-  }
-
-  if (req.query.nom) {
-    queryFilter.$text = {$search: req.query.nom}
-  }
-
-  if (req.query.commune) {
-    queryFilter.commune = {$eq: req.query.commune}
-  }
-
-  if (req.query.email) {
-    queryFilter.emails = {$eq: req.query.email}
-  }
-
-  req.queryFilter = queryFilter
-  next()
-}
-
 app.param('baseLocaleId', w(async (req, res, next) => {
   const id = req.params.baseLocaleId
   const baseLocale = await BaseLocale.fetchOne(id)
@@ -136,23 +109,18 @@ app.route('/bases-locales/create-demo')
   }))
 
 app.route('/bases-locales/search')
-  .get(parseQueryFilters, w(async (req, res) => {
-    const page = req.query.page ? Number.parseInt(req.query.page, 10) : 1
-    const limit = req.query.limit ? Number.parseInt(req.query.limit, 10) : 20
-    const skipIndex = (page - 1) * limit
-
-    const {cursor, count} = await BaseLocale.fetch(req.queryFilter)
-    const basesLocales = await cursor.limit(limit).skip(skipIndex).toArray()
+  .get(w(async (req, res) => {
+    const {offset, limit, count, basesLocales} = await BaseLocale.fetch(req.query)
     const basesLocalesExpanded = await Promise.all(
       basesLocales.map(baseLocale => expandModelWithNumeros(baseLocale, '_bal'))
     )
     const basesLocalesSensitivefields = basesLocalesExpanded.map(bal => BaseLocale.filterSensitiveFields(bal))
 
     res.send({
-      page,
+      offset,
       limit,
-      totalPages: Math.round(count / limit) || 1,
-      basesLocales: basesLocalesSensitivefields
+      count,
+      results: basesLocalesSensitivefields
     })
   }))
 

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -114,13 +114,12 @@ app.route('/bases-locales/search')
     const basesLocalesExpanded = await Promise.all(
       basesLocales.map(baseLocale => expandModelWithNumeros(baseLocale, '_bal'))
     )
-    const basesLocalesSensitivefields = basesLocalesExpanded.map(bal => BaseLocale.filterSensitiveFields(bal))
 
     res.send({
       offset,
       limit,
       count,
-      results: basesLocalesSensitivefields
+      results: basesLocalesExpanded.map(bal => BaseLocale.filterSensitiveFields(bal))
     })
   }))
 

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -48,6 +48,14 @@ function parseQueryFilters(req, res, next) {
     queryFilter.$text = {$search: req.query.nom}
   }
 
+  if (req.query.commune) {
+    queryFilter.commune = {$eq: req.query.commune}
+  }
+
+  if (req.query.email) {
+    queryFilter.emails = {$eq: req.query.email}
+  }
+
   req.queryFilter = queryFilter
   next()
 }
@@ -107,27 +115,13 @@ app.param('toponymeId', w(async (req, res, next) => {
 }))
 
 app.route('/bases-locales')
-  .get(parseQueryFilters, w(async (req, res) => {
-    const page = req.query.page ? Number.parseInt(req.query.page, 10) : 1
-    const limit = req.query.limit ? Number.parseInt(req.query.limit, 10) : 20
-    const skipIndex = (page - 1) * limit
-
-    const {cursor, count} = await BaseLocale.fetch(req.queryFilter)
-    const basesLocales = await cursor.limit(limit).skip(skipIndex).toArray()
-
+  .get(w(async (req, res) => {
+    const basesLocales = await BaseLocale.fetchAll()
     const basesLocalesExpanded = await Promise.all(
-      basesLocales.map(baseLocale => {
-        return expandModelWithNumeros(baseLocale, '_bal')
-      })
+      basesLocales.map(baseLocale => expandModelWithNumeros(baseLocale, '_bal'))
     )
-    const basesLocalesSensitivefields = basesLocalesExpanded.map(bal => BaseLocale.filterSensitiveFields(bal))
 
-    res.send({
-      page,
-      limit,
-      totalPages: Math.round(count / limit) || 1,
-      basesLocales: basesLocalesSensitivefields
-    })
+    res.send(basesLocalesExpanded.map(bal => BaseLocale.filterSensitiveFields(bal)))
   }))
   .post(w(async (req, res) => {
     const baseLocale = await BaseLocale.create(req.body)
@@ -142,13 +136,24 @@ app.route('/bases-locales/create-demo')
   }))
 
 app.route('/bases-locales/search')
-  .get(w(async (req, res) => {
-    if (!req.query.codeCommune || !req.query.userEmail) {
-      return res.status(400).send({code: 400, message: 'codeCommune et userEmail sont des champs obligatoires'})
-    }
+  .get(parseQueryFilters, w(async (req, res) => {
+    const page = req.query.page ? Number.parseInt(req.query.page, 10) : 1
+    const limit = req.query.limit ? Number.parseInt(req.query.limit, 10) : 20
+    const skipIndex = (page - 1) * limit
 
-    const basesLocales = await BaseLocale.findByCommuneAndEmail(req.query.codeCommune, req.query.userEmail)
-    res.send(basesLocales)
+    const {cursor, count} = await BaseLocale.fetch(req.queryFilter)
+    const basesLocales = await cursor.limit(limit).skip(skipIndex).toArray()
+    const basesLocalesExpanded = await Promise.all(
+      basesLocales.map(baseLocale => expandModelWithNumeros(baseLocale, '_bal'))
+    )
+    const basesLocalesSensitivefields = basesLocalesExpanded.map(bal => BaseLocale.filterSensitiveFields(bal))
+
+    res.send({
+      page,
+      limit,
+      totalPages: Math.round(count / limit) || 1,
+      basesLocales: basesLocalesSensitivefields
+    })
   }))
 
 app.route('/bases-locales/:baseLocaleId')

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -89,11 +89,32 @@ app.param('toponymeId', w(async (req, res, next) => {
 
 app.route('/bases-locales')
   .get(w(async (req, res) => {
-    const basesLocales = await BaseLocale.fetchAll()
+    const page = Number.parseInt(req.query.page, 10)
+    const limit = Number.parseInt(req.query.limit, 10)
+    const skipIndex = (page - 1) * limit
+
+    let basesLocales = []
+    const {cursor, count} = await BaseLocale.fetchAll()
+
+    basesLocales = await (page && limit ? cursor.limit(limit).skip(skipIndex).toArray() : cursor.toArray())
+
     const basesLocalesExpanded = await Promise.all(
-      basesLocales.map(baseLocale => expandModelWithNumeros(baseLocale, '_bal'))
+      basesLocales.map(baseLocale => {
+        return expandModelWithNumeros(baseLocale, '_bal')
+      })
     )
-    res.send(basesLocalesExpanded.map(bal => BaseLocale.filterSensitiveFields(bal)))
+    const basesLocalesSensitivefields = basesLocalesExpanded.map(bal => BaseLocale.filterSensitiveFields(bal))
+
+    if (page && limit) {
+      res.send({
+        page,
+        limit,
+        totalPages: Math.round(count / limit),
+        basesLocales: basesLocalesSensitivefields
+      })
+    } else {
+      res.send(basesLocalesSensitivefields)
+    }
   }))
   .post(w(async (req, res) => {
     const baseLocale = await BaseLocale.create(req.body)

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -33,6 +33,25 @@ function checkIsAdmin(baseLocale, req) {
   return req.get('Authorization') === `Token ${baseLocale.token}`
 }
 
+function parseQueryFilters(req, res, next) {
+  const queryFilter = {}
+
+  if (req.query.deleted) {
+    if (req.query.deleted === '0') {
+      queryFilter._deleted = {$eq: null}
+    } else if (req.query.deleted === '1') {
+      queryFilter._deleted = {$ne: null}
+    }
+  }
+
+  if (req.query.nom) {
+    queryFilter.$text = {$search: req.query.nom}
+  }
+
+  req.queryFilter = queryFilter
+  next()
+}
+
 app.param('baseLocaleId', w(async (req, res, next) => {
   const id = req.params.baseLocaleId
   const baseLocale = await BaseLocale.fetchOne(id)
@@ -88,15 +107,13 @@ app.param('toponymeId', w(async (req, res, next) => {
 }))
 
 app.route('/bases-locales')
-  .get(w(async (req, res) => {
-    const page = Number.parseInt(req.query.page, 10)
-    const limit = Number.parseInt(req.query.limit, 10)
+  .get(parseQueryFilters, w(async (req, res) => {
+    const page = req.query.page ? Number.parseInt(req.query.page, 10) : 1
+    const limit = req.query.limit ? Number.parseInt(req.query.limit, 10) : 20
     const skipIndex = (page - 1) * limit
 
-    let basesLocales = []
-    const {cursor, count} = await BaseLocale.fetchAll()
-
-    basesLocales = await (page && limit ? cursor.limit(limit).skip(skipIndex).toArray() : cursor.toArray())
+    const {cursor, count} = await BaseLocale.fetch(req.queryFilter)
+    const basesLocales = await cursor.limit(limit).skip(skipIndex).toArray()
 
     const basesLocalesExpanded = await Promise.all(
       basesLocales.map(baseLocale => {
@@ -105,16 +122,12 @@ app.route('/bases-locales')
     )
     const basesLocalesSensitivefields = basesLocalesExpanded.map(bal => BaseLocale.filterSensitiveFields(bal))
 
-    if (page && limit) {
-      res.send({
-        page,
-        limit,
-        totalPages: Math.round(count / limit),
-        basesLocales: basesLocalesSensitivefields
-      })
-    } else {
-      res.send(basesLocalesSensitivefields)
-    }
+    res.send({
+      page,
+      limit,
+      totalPages: Math.round(count / limit) || 1,
+      basesLocales: basesLocalesSensitivefields
+    })
   }))
   .post(w(async (req, res) => {
     const baseLocale = await BaseLocale.create(req.body)

--- a/lib/util/mongo.js
+++ b/lib/util/mongo.js
@@ -17,6 +17,7 @@ class Mongo {
   async createIndexes() {
     await this.db.collection('bases_locales').createIndex({'sync.status': 1}, {sparse: 1})
     await this.db.collection('bases_locales').createIndex({_updated: 1})
+    await this.db.collection('bases_locales').createIndex({nom: 'text'})
 
     await this.db.collection('voies').createIndex({_bal: 1})
     await this.db.collection('voies').createIndex({_bal: 1, commune: 1})

--- a/lib/util/mongo.js
+++ b/lib/util/mongo.js
@@ -17,6 +17,8 @@ class Mongo {
   async createIndexes() {
     await this.db.collection('bases_locales').createIndex({'sync.status': 1}, {sparse: 1})
     await this.db.collection('bases_locales').createIndex({_updated: 1})
+    await this.db.collection('bases_locales').createIndex({_deleted: 1})
+    await this.db.collection('bases_locales').createIndex({nom: 1})
     await this.db.collection('bases_locales').createIndex({status: 1})
     await this.db.collection('bases_locales').createIndex({commune: 1})
     await this.db.collection('bases_locales').createIndex({emails: 1})

--- a/lib/util/mongo.js
+++ b/lib/util/mongo.js
@@ -17,7 +17,6 @@ class Mongo {
   async createIndexes() {
     await this.db.collection('bases_locales').createIndex({'sync.status': 1}, {sparse: 1})
     await this.db.collection('bases_locales').createIndex({_updated: 1})
-    await this.db.collection('bases_locales').createIndex({nom: 'text'})
 
     await this.db.collection('voies').createIndex({_bal: 1})
     await this.db.collection('voies').createIndex({_bal: 1, commune: 1})

--- a/lib/util/mongo.js
+++ b/lib/util/mongo.js
@@ -17,6 +17,9 @@ class Mongo {
   async createIndexes() {
     await this.db.collection('bases_locales').createIndex({'sync.status': 1}, {sparse: 1})
     await this.db.collection('bases_locales').createIndex({_updated: 1})
+    await this.db.collection('bases_locales').createIndex({status: 1})
+    await this.db.collection('bases_locales').createIndex({commune: 1})
+    await this.db.collection('bases_locales').createIndex({emails: 1})
 
     await this.db.collection('voies').createIndex({_bal: 1})
     await this.db.collection('voies').createIndex({_bal: 1, commune: 1})

--- a/lib/util/mongo.js
+++ b/lib/util/mongo.js
@@ -18,7 +18,6 @@ class Mongo {
     await this.db.collection('bases_locales').createIndex({'sync.status': 1}, {sparse: 1})
     await this.db.collection('bases_locales').createIndex({_updated: 1})
     await this.db.collection('bases_locales').createIndex({_deleted: 1})
-    await this.db.collection('bases_locales').createIndex({nom: 1})
     await this.db.collection('bases_locales').createIndex({status: 1})
     await this.db.collection('bases_locales').createIndex({commune: 1})
     await this.db.collection('bases_locales').createIndex({emails: 1})


### PR DESCRIPTION
## Contexte
La route `GET /bases-locales/search` ne permet de récupérer que les bases locales correspondant à un couple email et code commune. Or cette route pourrait accepter d'autre filtre et proposer une réponse paginée afin d'alléger certaine page comme `/all`.

## Évolution
Cette PR propose de renvoyer une réponse paginée sur `GET /bases-locales/search` et ajoute de nouveau filtre à la recherche.

Le nombre de réponses est limité à 20 par défaut.

### Filtres possibles
~- `nom` : Recherche textuelle dans le nom de la base locale. Ce filtre a nécessité la création d'un index sur le champ `nom` des bases locales.~
- `deleted` : Valeur `0` ou `1`. Si `1` seule les bases locales supprimées sont renvoyées. Si `0` seules les bases locales non supprimées sont renvoyées.
- `email` : Recherche de l'email fourni dans les listes des emails de la base locale 
- `commune` : Recherche les bases locales ayant le code commune demandé
- `status` : Recherche les bases locales ayant le statut demandé

### Réponse
```
{
      page: (Number),
      limit: (Number),
      count: (Number),
      results: (Array)
}
```

**Edit 03/11/2022**
Il a finalement été décidé de retirer le filtre par nom. Ce champ ne constitue pas un filtre suffisamment intéressant.

---------

⚠️ Cette PR nécessite de mettre à jour la [documentation](https://github.com/BaseAdresseNationale/mes-adresses-api/wiki/Documentation-de-l'API#bases-locales)