### PR TITLE
Permettre la récupération de l'habilitation sans jeton admin

### DIFF
--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -334,6 +334,10 @@ function filterSensitiveFields(baseLocale) {
   return omit(baseLocale, 'token', 'emails')
 }
 
+function filterHabilitationSensitiveFields(habilitation) {
+  return omit(habilitation, 'emailCommune', 'franceconnectAuthenticationUrl', 'strategy', 'client')
+}
+
 async function computeStats() {
   const results = await mongo.db.collection('bases_locales').aggregate([
     {$match: {status: {$ne: 'demo'}, _deleted: {$eq: null}}},
@@ -533,6 +537,7 @@ module.exports = {
   cleanContent,
   importFile,
   filterSensitiveFields,
+  filterHabilitationSensitiveFields,
   computeStats,
   publishedBasesLocalesStats,
   basesLocalesRecovery,

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -239,8 +239,12 @@ function ensurePendingHabilitation(req, res, next) {
 }
 
 app.route('/bases-locales/:baseLocaleId/habilitation')
-  .get(ensureIsAdmin, loadHabilitation(), w(async (req, res) => {
-    res.send(req.habilitation)
+  .get(loadHabilitation(), w(async (req, res) => {
+    if (req.isAdmin) {
+      res.send(req.habilitation)
+    } else {
+      res.send(BaseLocale.filterHabilitationSensitiveFields(req.habilitation))
+    }
   }))
   .post(ensureIsAdmin, loadHabilitation(true), w(async (req, res) => {
     if (req.habilitation) {


### PR DESCRIPTION
## Contexte
Savoir si une BAL est habilitée est une information qui est utile notamment pour les partenaires (cf:  BaseAdresseNationale/mes-adresses/issues/715).

Cependant, la route `GET /bases-locales/:baseLocaleId/habilitation` est actuellement protégé par `ensureIsAdmin` qui empêche l'appel de cette route sans jeton administrateur.

## Évolution
Lorsque l'on interroge la route `GET /bases-locales/:baseLocaleId/habilitation` sans jeton admin, alors celle-ci renvoi les informations non sensibles de l'habilitation.

### Champs filtrés
- emailCommune
- franceconnectAuthenticationUrl
- strategy
- client