### PR TITLE
Mise à jour de @etalab/decoupage-administratif

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@ban-team/adresses-util": "^0.9.0",
     "@ban-team/shared-data": "^1.1.0",
     "@ban-team/validateur-bal": "^2.11.0",
-    "@etalab/decoupage-administratif": "^2.0.0",
+    "@etalab/decoupage-administratif": "^2.3.1",
     "@etalab/project-legal": "^0.6.0",
     "bluebird": "^3.7.2",
     "body-parser": "^1.20.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -253,10 +253,10 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@etalab/decoupage-administratif@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@etalab/decoupage-administratif/-/decoupage-administratif-2.0.0.tgz#24ee640070c47e3c62883873c35450197fa5f78c"
-  integrity sha512-X+pQDnm0Sk8T5KPhT5kU9cLyMKc+LagK8ObYxyzVDoQapjLNZl9/KY2VFr42aw4LEiTnUfqCgNZc9lhHfi6shQ==
+"@etalab/decoupage-administratif@^2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@etalab/decoupage-administratif/-/decoupage-administratif-2.3.1.tgz#9d8c4606407ceef062c1bcde3aa57be31d661fdc"
+  integrity sha512-52zR447e9Csr/HkzmLJIrOTCAuwJNd4O9fay8BRgOQUSbqaKOP6vFpsrj5lKlrH9vA+ii07h1TnChdMFZNgcwg==
 
 "@etalab/project-legal@^0.6.0":
   version "0.6.0"


### PR DESCRIPTION
## Contexte
Mise à jour de la dépendance `@etalab/decoupage-administratif` de la `v2.0.0` à la `v2.3.1`.

Cette mise à jour permet notamment le support COM pour les départements et régions.