### PR TITLE
Corrige la mise à jour des informations de synchronisation

### DIFF
--- a/lib/sync/index.js
+++ b/lib/sync/index.js
@@ -54,7 +54,7 @@ async function updateSyncInfo(balId) {
 
   const currentRevision = await getCurrentRevision(codeCommune)
 
-  if (currentRevision._id !== baseLocale.sync.lastUploadedRevisionId) {
+  if (currentRevision && currentRevision._id !== baseLocale.sync.lastUploadedRevisionId) {
     return applyAndReturnSync(baseLocale, {
       status: 'conflict',
       isPaused: true


### PR DESCRIPTION
## Contexte
Pour une raison encore non identifiée, il arrive qu'une commune dispose de plusieurs révisions publiées sans pour autant que l'une d'elle soit `current: true`.

Ce cas a pour effet de mettre la méthode `updateSyncInfo` en défaut, car celle-ci s'attend à récupérer une révision courante.

## Correction
En attendant de corriger ce problème à la source, cette correction s'assure qu'une révision courante est bien récupérée afin de comparer son identifiant à celui de la base locale.