### PR TITLE
Suppression automatisé des BAL de démonstration créées il y a plus d'un mois

### DIFF
--- a/cron.js
+++ b/cron.js
@@ -2,7 +2,7 @@
 require('dotenv').config()
 const ms = require('ms')
 const {detectOutdated, detectConflict, syncOutdated} = require('./lib/sync')
-const {removeSoftDeletedBALsOlderThanOneYear} = require('./lib/models/base-locale')
+const {removeSoftDeletedBALsOlderThanOneYear, removeDemoBALsOlderThanAMonth} = require('./lib/models/base-locale')
 const mongo = require('./lib/util/mongo')
 
 const jobs = [
@@ -32,6 +32,13 @@ const jobs = [
     every: '1h',
     async handler() {
       await removeSoftDeletedBALsOlderThanOneYear()
+    }
+  },
+  {
+    name: 'purge demo BALs',
+    every: '24h',
+    async handler() {
+      await removeDemoBALsOlderThanAMonth()
     }
   }
 ]

--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -651,3 +651,39 @@ test('Delete Bases Locales permanently', async t => {
   t.falsy(await mongo.db.collection('bases_locales').findOne({_id: idBalC}))
   t.falsy(await mongo.db.collection('bases_locales').findOne({_id: idBalD}))
 })
+
+test('Delete demo base locales', async t => {
+  const now = new Date()
+  const idBalA = new mongo.ObjectId()
+  const idBalB = new mongo.ObjectId()
+
+  await mongo.db.collection('bases_locales').insertMany([{
+    _id: idBalA,
+    status: 'demo',
+    _updated: now,
+    _created: subMonths(now, 2)
+  }, {
+    _id: idBalB,
+    status: 'demo',
+    _updated: now,
+    _created: now
+  }])
+
+  const idVoieA = new mongo.ObjectId()
+  await mongo.db.collection('voies').insertOne({_id: idVoieA, _bal: idBalA})
+
+  const idToponymeA = new mongo.ObjectId()
+  await mongo.db.collection('toponymes').insertOne({_id: idToponymeA, _bal: idBalA})
+
+  const idNumeroA = new mongo.ObjectId()
+  await mongo.db.collection('numeros').insertOne({_id: idNumeroA, _bal: idBalA})
+
+  await BaseLocale.removeDemoBALsOlderThanAMonth()
+
+  t.truthy(await mongo.db.collection('bases_locales').findOne({_id: idBalB}))
+
+  t.falsy(await mongo.db.collection('bases_locales').findOne({_id: idBalA}))
+  t.falsy(await mongo.db.collection('voies').findOne({_id: idVoieA}))
+  t.falsy(await mongo.db.collection('toponymes').findOne({_id: idToponymeA}))
+  t.falsy(await mongo.db.collection('numeros').findOne({_id: idNumeroA}))
+})

--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -680,6 +680,10 @@ test('Delete demo base locales', async t => {
 
   await BaseLocale.removeDemoBALsOlderThanAMonth()
 
+  const basesLocalesCount = await mongo.db.collection('bases_locales').countDocuments()
+
+  t.is(basesLocalesCount, 1)
+
   t.truthy(await mongo.db.collection('bases_locales').findOne({_id: idBalB}))
 
   t.falsy(await mongo.db.collection('bases_locales').findOne({_id: idBalA}))

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -566,6 +566,22 @@ async function removeSoftDeletedBALsOlderThanOneYear() {
   console.log(`\n${softDeletedBALsIDs.length} BALs supprimées définitivement\n`)
 }
 
+async function removeDemoBALsOlderThanAMonth() {
+  const now = new Date()
+  const creationTime = subMonths(now, 1)
+
+  const demoBALsIDs = await mongo.db.collection('bases_locales').distinct('_id',
+    {status: 'demo', _created: {$lt: creationTime}}
+  )
+
+  for (const demoBALsID of demoBALsIDs) {
+    await mongo.db.collection('bases_locales').deleteOne({_id: demoBALsID})
+    await cleanContent(demoBALsID)
+  }
+
+  console.log(`\n${demoBALsIDs.length} BALs de démonstration supprimées définitivement\n`)
+}
+
 module.exports = {
   create,
   createSchema,
@@ -595,5 +611,6 @@ module.exports = {
   getAssignedParcelles,
   batchUpdateNumeros,
   updateHabilitation,
-  removeSoftDeletedBALsOlderThanOneYear
+  removeSoftDeletedBALsOlderThanOneYear,
+  removeDemoBALsOlderThanAMonth
 }

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -575,8 +575,8 @@ async function removeDemoBALsOlderThanAMonth() {
   )
 
   for (const demoBALsID of demoBALsIDs) {
-    await mongo.db.collection('bases_locales').deleteOne({_id: demoBALsID})
     await cleanContent(demoBALsID)
+    await mongo.db.collection('bases_locales').deleteOne({_id: demoBALsID})
   }
 
   console.log(`\n${demoBALsIDs.length} BALs de démonstration supprimées définitivement\n`)

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -345,6 +345,7 @@ async function populateCommune(id) {
 async function cleanContent(id, query = {}) {
   await Promise.all([
     mongo.db.collection('voies').deleteMany({...query, _bal: mongo.parseObjectID(id)}),
+    mongo.db.collection('toponymes').deleteMany({...query, _bal: mongo.parseObjectID(id)}),
     mongo.db.collection('numeros').deleteMany({...query, _bal: mongo.parseObjectID(id)})
   ])
 }


### PR DESCRIPTION
## Contexte
L'interface avertie lors de la création d'une BAL de démonstration que celle-ci ne sera disponible que 24. En réalité, ces dernières ne sont jamais supprimées.

## Évolution
Cette PR ajoute une tâche au `cron` qui supprime tous les jours les BAL de démonstration créées il y a plus d'un mois.
Nous gardons encore une belle marge afin de permettre à un utilisateur de convertir sa BAL de démo en brouillon.