### PR TITLE
Correction de la méthode de fusion de communes

### DIFF
--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -579,9 +579,17 @@ async function copyBaseLocale(from, to) {
     }
   })
 
-  await mongo.db.collection('voies').insertMany(voieCopies)
-  await mongo.db.collection('toponymes').insertMany(toponymesCopies)
-  await mongo.db.collection('numeros').insertMany(numerosCopies)
+  if (voieCopies.length > 0) {
+    await mongo.db.collection('voies').insertMany(voieCopies)
+  }
+
+  if (toponymesCopies.length > 0) {
+    await mongo.db.collection('toponymes').insertMany(toponymesCopies)
+  }
+
+  if (numerosCopies.length > 0) {
+    await mongo.db.collection('numeros').insertMany(numerosCopies)
+  }
 }
 
 async function publishedBasesLocalesStats(codesCommunes = null) {

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -480,48 +480,54 @@ async function createBaseLocaleFromCommunesMerge({codeCommune, nom, communesDele
 
   await mongo.db.collection('bases_locales').insertOne(baseLocale)
 
-  // Populate BAL with communesDeleguees
-  if (communesDeleguees?.length > 0) {
-    for (const code of communesDeleguees) {
-      const {numeros, voies, toponymes} = await extract(code)
-      await Promise.all([
-        Voie.importMany(balId, voies.map(d => ({...d, commune: codeCommune})), {validate: false, keepIds: true}),
-        Numero.importMany(balId, numeros.map(d => ({...d, commune: codeCommune})), {validate: false}),
-        Toponyme.importMany(balId, toponymes.map(d => ({...d, commune: codeCommune})), {validate: false, keepIds: true})
-      ])
-    }
-  }
-
-  // Copy voies, toponyme and numeros from other bases locales
-  if (basesLocales?.length > 0) {
-    for (const bal of basesLocales) {
-      // Union all emails
-      const _baseLocale = await mongo.db.collection('bases_locales').findOne({_id: mongo.parseObjectID(bal)})
-      unionEmails = union(unionEmails, _baseLocale.emails)
-
-      // Get most advanced status
-      if (!isReadyToPublish) {
-        isReadyToPublish = ['ready-to-publish', 'published'].includes(_baseLocale.status)
+  try {
+    // Populate BAL with communesDeleguees
+    if (communesDeleguees?.length > 0) {
+      for (const code of communesDeleguees) {
+        const {numeros, voies, toponymes} = await extract(code)
+        await Promise.all([
+          Voie.importMany(balId, voies.map(d => ({...d, commune: codeCommune})), {validate: false, keepIds: true}),
+          Numero.importMany(balId, numeros.map(d => ({...d, commune: codeCommune})), {validate: false}),
+          Toponyme.importMany(balId, toponymes.map(d => ({...d, commune: codeCommune})), {validate: false, keepIds: true})
+        ])
       }
-
-      await copyBaseLocale(bal, balId)
-
-      const now = new Date()
-      await mongo.db.collection('bases_locales').findOneAndUpdate(
-        {_id: mongo.parseObjectID(bal)},
-        {$set: {_deleted: now, _updated: now}}
-      )
     }
+
+    // Copy voies, toponyme and numeros from other bases locales
+    if (basesLocales?.length > 0) {
+      for (const bal of basesLocales) {
+        // Union all emails
+        const _baseLocale = await mongo.db.collection('bases_locales').findOne({_id: mongo.parseObjectID(bal)})
+        unionEmails = union(unionEmails, _baseLocale.emails)
+
+        // Get most advanced status
+        if (!isReadyToPublish) {
+          isReadyToPublish = ['ready-to-publish', 'published'].includes(_baseLocale.status)
+        }
+
+        await copyBaseLocale(bal, balId)
+
+        const now = new Date()
+        await mongo.db.collection('bases_locales').findOneAndUpdate(
+          {_id: mongo.parseObjectID(bal)},
+          {$set: {_deleted: now, _updated: now}}
+        )
+      }
+    }
+
+    await mongo.db.collection('bases_locales').updateOne({
+      _id: balId
+    }, {$set: {
+      emails: unionEmails,
+      status: isReadyToPublish ? 'ready-to-publish' : 'draft'
+    }})
+
+    return {...baseLocale, emails: unionEmails, status: isReadyToPublish ? 'ready-to-publish' : 'draft'}
+  } catch (error) {
+    // Delete base locale when something goes wrong
+    await mongo.db.collection('bases_locales').deleteOne({_id: balId})
+    throw new Error('Impossible de fusionner les communes :', error)
   }
-
-  await mongo.db.collection('bases_locales').updateOne({
-    _id: balId
-  }, {$set: {
-    emails: unionEmails,
-    status: isReadyToPublish ? 'ready-to-publish' : 'draft'
-  }})
-
-  return {...baseLocale, emails: unionEmails, status: isReadyToPublish ? 'ready-to-publish' : 'draft'}
 }
 
 async function copyBaseLocale(from, to) {


### PR DESCRIPTION
## Contexte
Une erreur 500 est provoquée lorsque aucun document mongo n'était fourni lors d'un `insertMany`.

De plus, en cas d'erreur, la nouvelle base locale n'était pas supprimée.