### PR TITLE
Correction de la vérification de l'adresse email d'une BAL

### DIFF
--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -29,6 +29,13 @@ async function validNom(nom, error) {
 }
 
 function checkValidEmail(email) {
+  // This regex checks for:
+  // 1. Forbidden characters such as angle brackets, square brackets, double quotes, backslashes, commas, semicolons, colons, spaces, and at signs.
+  // 2. Quoted email addresses.
+  // 3. IP addresses within square brackets.
+  // 4. Domains with hyphens.
+  // 5. Domains with numbers.
+  // 6. Domains with extensions of 2 or more characters.
   const regex = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[(?:\d{1,3}\.){3}\d{1,3}])|(([a-zA-Z\-\d]+\.)+[a-zA-Z]{2,}))$/
   return regex.test(email)
 }

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -28,8 +28,13 @@ async function validNom(nom, error) {
   }
 }
 
+function checkValidEmail(email) {
+  const regex = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[(?:\d{1,3}\.){3}\d{1,3}])|(([a-zA-Z\-\d]+\.)+[a-zA-Z]{2,}))$/
+  return regex.test(email)
+}
+
 async function validEmail(email, error) {
-  if (!(/^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[(?:\d{1,3}\.){3}\d{1,3}])|(([a-zA-Z\-\d]+\.)+[a-zA-Z]{2,}))$/.test(email))) {
+  if (!checkValidEmail(email)) {
     addError(error, 'emails', `L’adresse email ${email} est invalide`)
   }
 }
@@ -110,7 +115,7 @@ function parseQueryFilters(query) {
   }
 
   if (query.email) {
-    if (typeof query.email === 'string' && validEmail(query.email)) {
+    if (typeof query.email === 'string' && checkValidEmail(query.email)) {
       filters.emails = {$eq: query.email}
     } else {
       throw createHttpError(400, 'La valeur du champ "email" est invalide')


### PR DESCRIPTION
## Contexte
Lors de la création d'une BAL, une erreur est provoquée si jamais une adresse email est invalide est envoyé à l'API.

Cette erreur est provoquée car la fonction `validEmail` est appelé sans fournir d'objet `error`. Cette méthode est ici détournée de sa fonction d'origine qui est de valider le `payload`.

## Correction
Création d'une fonction `checkValidEmail` qui renvoi uniquement `true/false` et qui pourra être appelé par `validEmails` et  `parseQueryFilters`.

> Des commentaires ont étaient ajoutés afin d'explicité la regex très complexe.