### PR TITLE
Gestion des communes deleguées

### DIFF
--- a/lib/communeDeleguees/__tests__/commune-deleguees.service.js
+++ b/lib/communeDeleguees/__tests__/commune-deleguees.service.js
@@ -2,6 +2,7 @@ const test = require('ava')
 const {MongoMemoryServer} = require('mongodb-memory-server')
 const mongo = require('../../util/mongo')
 const CommuneDelegueeService = require('../commune-deleguees.service')
+
 let mongod
 
 test.before('start server', async () => {
@@ -18,22 +19,22 @@ test.serial('updateCommuneDeleguees without communesDeleguees', async t => {
   const _id = new mongo.ObjectId()
   await mongo.db.collection('bases_locales').insertOne({
     _id,
-    commune: "000000"
+    commune: '000000'
   })
 
-  await CommuneDelegueeService.updateCommuneDeleguees();
+  await CommuneDelegueeService.updateCommuneDeleguees()
 
   const res = await mongo.db.collection('bases_locales').findOne({_id})
   t.deepEqual({
     _id,
-    commune: "000000",
+    commune: '000000',
   }, res)
 })
 
 test.serial('updateCommuneDeleguees with communesDeleguees', async t => {
   const _id = new mongo.ObjectId()
   const codeChefLieu = require('@etalab/decoupage-administratif/data/communes.json')
-    .filter(c => c.chefLieu)[0].chefLieu
+    .find(c => c.chefLieu).chefLieu
   const communesDeleguees = require('@etalab/decoupage-administratif/data/communes.json')
     .filter(c => c.chefLieu === codeChefLieu)
 
@@ -41,11 +42,11 @@ test.serial('updateCommuneDeleguees with communesDeleguees', async t => {
     _id,
     commune: codeChefLieu
   })
-  await CommuneDelegueeService.updateCommuneDeleguees();
+  await CommuneDelegueeService.updateCommuneDeleguees()
   const res = await mongo.db.collection('bases_locales').findOne({_id})
   t.deepEqual({
     _id,
     commune: codeChefLieu,
-    communesDeleguees: communesDeleguees.map((c) => c.code)
+    communesDeleguees: communesDeleguees.map(c => c.code)
   }, res)
 })

--- a/lib/communeDeleguees/__tests__/commune-deleguees.service.js
+++ b/lib/communeDeleguees/__tests__/commune-deleguees.service.js
@@ -1,0 +1,51 @@
+const test = require('ava')
+const {MongoMemoryServer} = require('mongodb-memory-server')
+const mongo = require('../../util/mongo')
+const CommuneDelegueeService = require('../commune-deleguees.service')
+let mongod
+
+test.before('start server', async () => {
+  mongod = await MongoMemoryServer.create()
+  await mongo.connect(mongod.getUri())
+})
+
+test.after.always('cleanup', async () => {
+  await mongo.disconnect()
+  await mongod.stop()
+})
+
+test.serial('updateCommuneDeleguees without communesDeleguees', async t => {
+  const _id = new mongo.ObjectId()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    commune: "000000"
+  })
+
+  await CommuneDelegueeService.updateCommuneDeleguees();
+
+  const res = await mongo.db.collection('bases_locales').findOne({_id})
+  t.deepEqual({
+    _id,
+    commune: "000000",
+  }, res)
+})
+
+test.serial('updateCommuneDeleguees with communesDeleguees', async t => {
+  const _id = new mongo.ObjectId()
+  const codeChefLieu = require('@etalab/decoupage-administratif/data/communes.json')
+    .filter(c => c.chefLieu)[0].chefLieu
+  const communesDeleguees = require('@etalab/decoupage-administratif/data/communes.json')
+    .filter(c => c.chefLieu === codeChefLieu)
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    commune: codeChefLieu
+  })
+  await CommuneDelegueeService.updateCommuneDeleguees();
+  const res = await mongo.db.collection('bases_locales').findOne({_id})
+  t.deepEqual({
+    _id,
+    commune: codeChefLieu,
+    communesDeleguees: communesDeleguees.map((c) => c.code)
+  }, res)
+})

--- a/lib/communeDeleguees/commune-deleguees.service.js
+++ b/lib/communeDeleguees/commune-deleguees.service.js
@@ -6,13 +6,14 @@ async function updateCommuneDeleguees() {
   const updatedPromises = []
   for (const bal of bals) {
     const communesDeleguees = getCommuneByChefLieu(bal.commune)?.map(cd => cd.code) || null
-    if ( communesDeleguees ) {
+    if (communesDeleguees) {
       const promise = mongo.db.collection('bases_locales').updateOne({
         _id: bal._id
       }, {$set: {
         communesDeleguees,
       }})
-      updatedPromises.push(promise)  
+
+      updatedPromises.push(promise)
     }
   }
 

--- a/lib/communeDeleguees/commune-deleguees.service.js
+++ b/lib/communeDeleguees/commune-deleguees.service.js
@@ -6,12 +6,14 @@ async function updateCommuneDeleguees() {
   const updatedPromises = []
   for (const bal of bals) {
     const communesDeleguees = getCommuneByChefLieu(bal.commune)?.map(cd => cd.code) || null
-    const promise = mongo.db.collection('bases_locales').updateOne({
-      _id: bal._id
-    }, {$set: {
-      communesDeleguees,
-    }})
-    updatedPromises.push(promise)
+    if ( communesDeleguees ) {
+      const promise = mongo.db.collection('bases_locales').updateOne({
+        _id: bal._id
+      }, {$set: {
+        communesDeleguees,
+      }})
+      updatedPromises.push(promise)  
+    }
   }
 
   await Promise.all(updatedPromises)

--- a/lib/communeDeleguees/commune-deleguees.service.js
+++ b/lib/communeDeleguees/commune-deleguees.service.js
@@ -1,0 +1,20 @@
+const {getCommuneByChefLieu} = require('../util/cog')
+const mongo = require('../util/mongo')
+
+async function updateCommuneDeleguees() {
+  const bals = await mongo.db.collection('bases_locales').find({}).toArray()
+  const updatedPromises = []
+  for (const bal of bals) {
+    const communesDeleguees = getCommuneByChefLieu(bal.commune)?.map(cd => cd.code) || null
+    const promise = mongo.db.collection('bases_locales').updateOne({
+      _id: bal._id
+    }, {$set: {
+      communesDeleguees,
+    }})
+    updatedPromises.push(promise)
+  }
+
+  await Promise.all(updatedPromises)
+}
+
+module.exports = {updateCommuneDeleguees}

--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -39,9 +39,8 @@ test('create a BaseLocale', async t => {
 })
 
 test.serial('create a BaseLocale with CommunesDeleguees', async t => {
-
   const codeChefLieu = require('@etalab/decoupage-administratif/data/communes.json')
-    .filter(c => c.chefLieu)[0].chefLieu
+    .find(c => c.chefLieu).chefLieu
   const communesDeleguees = require('@etalab/decoupage-administratif/data/communes.json')
     .filter(c => c.chefLieu === codeChefLieu)
   const baseLocale = await BaseLocale.create({
@@ -54,7 +53,7 @@ test.serial('create a BaseLocale with CommunesDeleguees', async t => {
   t.true(keys.every(k => k in baseLocale))
   t.true(baseLocale.status === 'draft')
   t.is(Object.keys(baseLocale).length, 10)
-  t.deepEqual(baseLocale.communesDeleguees, communesDeleguees.map((c) => c.code))
+  t.deepEqual(baseLocale.communesDeleguees, communesDeleguees.map(c => c.code))
 })
 
 test('create a BaseLocale / minimal', async t => {

--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -38,6 +38,25 @@ test('create a BaseLocale', async t => {
   t.is(Object.keys(baseLocale).length, 9)
 })
 
+test.serial('create a BaseLocale with CommunesDeleguees', async t => {
+
+  const codeChefLieu = require('@etalab/decoupage-administratif/data/communes.json')
+    .filter(c => c.chefLieu)[0].chefLieu
+  const communesDeleguees = require('@etalab/decoupage-administratif/data/communes.json')
+    .filter(c => c.chefLieu === codeChefLieu)
+  const baseLocale = await BaseLocale.create({
+    nom: 'foo',
+    emails: ['me@domain.co'],
+    commune: codeChefLieu
+  })
+  const keys = ['nom', 'status', 'emails', 'commune', 'token', '_updated', '_created', '_id', '_deleted', 'communesDeleguees']
+
+  t.true(keys.every(k => k in baseLocale))
+  t.true(baseLocale.status === 'draft')
+  t.is(Object.keys(baseLocale).length, 10)
+  t.deepEqual(baseLocale.communesDeleguees, communesDeleguees.map((c) => c.code))
+})
+
 test('create a BaseLocale / minimal', async t => {
   const baseLocale = await BaseLocale.create({nom: 'foo', emails: ['me@domain.co'], commune: '27115'})
   const keys = ['nom', 'status', 'emails', 'commune', 'token', '_updated', '_created', '_id', '_deleted']

--- a/lib/models/__tests__/numero.mongo.js
+++ b/lib/models/__tests__/numero.mongo.js
@@ -48,6 +48,43 @@ test('create a numero', async t => {
   t.deepEqual(numero._created, voie._updated)
 })
 
+test('create a numero with commune deleguee', async t => {
+  const idBal = new mongo.ObjectId()
+  const _id = new mongo.ObjectId()
+  const referenceDate = new Date('2019-01-01')
+  const codeChefLieu = require('@etalab/decoupage-administratif/data/communes.json')
+    .filter(c => c.chefLieu)[0].chefLieu
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: idBal,
+    _updated: referenceDate
+  })
+  await mongo.db.collection('voies').insertOne({
+    _id,
+    _bal: idBal,
+    _updated: referenceDate
+  })
+  const numero = await Numero.create(_id, {
+    numero: 42,
+    suffixe: 'foo',
+    comment: 'bar',
+    positions: [],
+    communeDeleguee: codeChefLieu
+  })
+
+  const keys = ['_id', '_bal', 'commune', '_updated', '_created', 'voie', 'numero', 'suffixe', 'comment', 'toponyme', 'positions', 'parcelles', 'certifie', 'communeDeleguee']
+  t.true(keys.every(k => k in numero))
+  t.is(Object.keys(numero).length, keys.length)
+
+  const bal = await mongo.db.collection('bases_locales').findOne({_id: idBal})
+  t.deepEqual(numero._created, bal._updated)
+
+  const voie = await mongo.db.collection('voies').findOne({_id})
+  t.deepEqual(numero._created, voie._updated)
+
+  t.is(numero.communeDeleguee, codeChefLieu)
+})
+
 test('create a numero / invalid numero type', t => {
   const idVoie = new mongo.ObjectId()
   return t.throwsAsync(Numero.create(idVoie, {

--- a/lib/models/__tests__/numero.mongo.js
+++ b/lib/models/__tests__/numero.mongo.js
@@ -53,7 +53,7 @@ test('create a numero with commune deleguee', async t => {
   const _id = new mongo.ObjectId()
   const referenceDate = new Date('2019-01-01')
   const codeChefLieu = require('@etalab/decoupage-administratif/data/communes.json')
-    .filter(c => c.chefLieu)[0].chefLieu
+    .find(c => c.chefLieu).chefLieu
 
   await mongo.db.collection('bases_locales').insertOne({
     _id: idBal,

--- a/lib/models/__tests__/numero.schema.js
+++ b/lib/models/__tests__/numero.schema.js
@@ -30,6 +30,24 @@ test('valid payload', async t => {
   t.deepEqual(error, {})
 })
 
+test('valid payload with commune deleguee', async t => {
+  const communesDeleguees = require('@etalab/decoupage-administratif/data/communes.json')
+  .filter(c => c.chefLieu)
+  const numero = {
+    numero: 42,
+    suffixe: 'bis',
+    positions: [],
+    parcelles: [],
+    certifie: false,
+    communeDeleguee: communesDeleguees[0].code
+  }
+
+  const {value, error} = await validSchema(numero, createSchema)
+
+  t.deepEqual(value, numero)
+  t.deepEqual(error, {})
+})
+
 test('valid payload / uppercase suffixe', async t => {
   const numero = {
     numero: 41,
@@ -124,6 +142,25 @@ test('valid payload update', async t => {
     voie: _idVoie
   })
   t.deepEqual(error, {})
+})
+
+test('not valid payload with bad commune deleguee', async t => {
+  const communesDeleguees = require('@etalab/decoupage-administratif/data/communes.json')
+  .filter(c => c.chefLieu)
+  const numero = {
+    numero: 42,
+    suffixe: 'bis',
+    positions: [],
+    parcelles: [],
+    certifie: false,
+    communeDeleguee: "000000"
+  }
+
+  const {error} = await validSchema(numero, createSchema)
+
+  t.deepEqual(error, {
+    commune: ['Code commune deleguee inconnu'],
+  })
 })
 
 test('invalid payload update', async t => {

--- a/lib/models/__tests__/numero.schema.js
+++ b/lib/models/__tests__/numero.schema.js
@@ -157,7 +157,9 @@ test('not valid payload with bad commune deleguee', async t => {
   const {error} = await validSchema(numero, createSchema)
 
   t.deepEqual(error, {
-    commune: ['Code commune deleguee inconnu'],
+    commune_delegue_insee: [
+     'Le code INSEE renseigné n’est pas un code valide ou n’a jamais existé',
+    ],
   })
 })
 

--- a/lib/models/__tests__/numero.schema.js
+++ b/lib/models/__tests__/numero.schema.js
@@ -157,8 +157,8 @@ test('not valid payload with bad commune deleguee', async t => {
   const {error} = await validSchema(numero, createSchema)
 
   t.deepEqual(error, {
-    commune_delegue_insee: [
-     'Le code INSEE renseigné n’est pas un code valide ou n’a jamais existé',
+    communeDelegueInsee: [
+      'Le code INSEE renseigné n’est pas un code valide ou n’a jamais existé',
     ],
   })
 })

--- a/lib/models/__tests__/numero.schema.js
+++ b/lib/models/__tests__/numero.schema.js
@@ -31,15 +31,15 @@ test('valid payload', async t => {
 })
 
 test('valid payload with commune deleguee', async t => {
-  const communesDeleguees = require('@etalab/decoupage-administratif/data/communes.json')
-  .filter(c => c.chefLieu)
+  const communeDeleguee = require('@etalab/decoupage-administratif/data/communes.json')
+    .find(c => c.chefLieu)
   const numero = {
     numero: 42,
     suffixe: 'bis',
     positions: [],
     parcelles: [],
     certifie: false,
-    communeDeleguee: communesDeleguees[0].code
+    communeDeleguee: communeDeleguee.code
   }
 
   const {value, error} = await validSchema(numero, createSchema)
@@ -145,15 +145,13 @@ test('valid payload update', async t => {
 })
 
 test('not valid payload with bad commune deleguee', async t => {
-  const communesDeleguees = require('@etalab/decoupage-administratif/data/communes.json')
-  .filter(c => c.chefLieu)
   const numero = {
     numero: 42,
     suffixe: 'bis',
     positions: [],
     parcelles: [],
     certifie: false,
-    communeDeleguee: "000000"
+    communeDeleguee: '000000'
   }
 
   const {error} = await validSchema(numero, createSchema)

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -14,7 +14,7 @@ const {extract} = require('../populate/extract-ban')
 const {extractFromCsv} = require('../populate/extract-csv')
 const adressesToCsv = require('../export/csv-bal').exportAsCsv
 const {transformToGeoJSON} = require('../export/geojson')
-const {getCommune: getCommuneCOG} = require('../util/cog')
+const {getCommune: getCommuneCOG, getCommuneByChefLieu} = require('../util/cog')
 const {getCommunesSummary} = require('../util/api-ban')
 const Voie = require('./voie')
 const Numero = require('./numero')
@@ -142,12 +142,14 @@ function parseQueryFilters(query) {
 
 async function create(payload) {
   const {nom, emails, commune} = await validPayload(payload, createSchema)
+  const communesDeleguees = getCommuneByChefLieu(commune)?.map(cd => cd.code) || null
 
   const baseLocale = {
     _id: new mongo.ObjectId(),
     nom,
     emails,
     commune,
+    communesDeleguees,
     token: generateBase62String(20),
     status: 'draft'
   }

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -142,16 +142,18 @@ function parseQueryFilters(query) {
 
 async function create(payload) {
   const {nom, emails, commune} = await validPayload(payload, createSchema)
-  const communesDeleguees = getCommuneByChefLieu(commune)?.map(cd => cd.code) || null
 
   const baseLocale = {
     _id: new mongo.ObjectId(),
     nom,
     emails,
     commune,
-    communesDeleguees,
     token: generateBase62String(20),
     status: 'draft'
+  }
+  const communesDeleguees = getCommuneByChefLieu(commune)?.map(cd => cd.code) || null
+  if (communesDeleguees) {
+    baseLocale.communesDeleguees = communesDeleguees
   }
 
   mongo.decorateCreation(baseLocale, true)
@@ -173,6 +175,10 @@ async function createDemo(payload) {
     commune,
     nom: `Adresses de ${getCommuneCOG(commune).nom} [démo]`,
     status: 'demo'
+  }
+  const communesDeleguees = getCommuneByChefLieu(commune)?.map(cd => cd.code) || null
+  if (communesDeleguees) {
+    baseLocale.communesDeleguees = communesDeleguees
   }
 
   mongo.decorateCreation(baseLocale, true)

--- a/lib/models/numero.js
+++ b/lib/models/numero.js
@@ -79,9 +79,13 @@ async function validParcelles(parcelles, error) {
 }
 
 async function validCommuneDeleguee(commune, error) {
-  if (!getCommuneDeleguee(commune)) {
-    addError(error, 'commune', 'Code commune deleguee inconnu')
-  }
+  const {value, errors} = await validateurBAL(commune, 'commune_deleguee_insee')
+
+  errors.forEach(err => {
+    addError(error, 'commune deleguee', err)
+  })
+
+  return value || numero
 }
 
 const createSchema = {

--- a/lib/models/numero.js
+++ b/lib/models/numero.js
@@ -4,7 +4,6 @@ const {getFilteredPayload, addError, validSchema} = require('../util/payload')
 const mongo = require('../util/mongo')
 const {validPayload} = require('../util/payload')
 const {validateurBAL} = require('../validateur-bal')
-const {getCommuneDeleguee} = require('../util/cog')
 const positionModel = require('./position')
 
 function validObjectID(id) {
@@ -82,10 +81,10 @@ async function validCommuneDeleguee(commune, error) {
   const {value, errors} = await validateurBAL(commune, 'commune_deleguee_insee')
 
   errors.forEach(err => {
-    addError(error, 'commune deleguee', err)
+    addError(error, 'commune_delegue_insee', err)
   })
 
-  return value || numero
+  return value || commune
 }
 
 const createSchema = {

--- a/lib/models/numero.js
+++ b/lib/models/numero.js
@@ -81,7 +81,7 @@ async function validCommuneDeleguee(commune, error) {
   const {value, errors} = await validateurBAL(commune, 'commune_deleguee_insee')
 
   errors.forEach(err => {
-    addError(error, 'commune_delegue_insee', err)
+    addError(error, 'communeDelegueInsee', err)
   })
 
   return value || commune

--- a/lib/models/numero.js
+++ b/lib/models/numero.js
@@ -4,6 +4,7 @@ const {getFilteredPayload, addError, validSchema} = require('../util/payload')
 const mongo = require('../util/mongo')
 const {validPayload} = require('../util/payload')
 const {validateurBAL} = require('../validateur-bal')
+const {getCommuneDeleguee} = require('../util/cog')
 const positionModel = require('./position')
 
 function validObjectID(id) {
@@ -77,6 +78,12 @@ async function validParcelles(parcelles, error) {
   }
 }
 
+async function validCommuneDeleguee(commune, error) {
+  if (!getCommuneDeleguee(commune)) {
+    addError(error, 'commune', 'Code commune deleguee inconnu')
+  }
+}
+
 const createSchema = {
   numero: {valid: validNumero, isRequired: true, nullAllowed: false, type: 'number'},
   suffixe: {valid: validSuffixe, isRequired: false, nullAllowed: true, type: 'string'},
@@ -84,7 +91,8 @@ const createSchema = {
   positions: {valid: validPositions, isRequired: false, nullAllowed: false, type: 'array'},
   toponyme: {valid: validToponyme, isRequired: false, nullAllowed: true, type: 'string'},
   parcelles: {valid: validParcelles, isRequired: false, nullAllowed: false, type: 'array'},
-  certifie: {valid: null, isRequired: false, nullAllowed: false, type: 'boolean'}
+  certifie: {valid: null, isRequired: false, nullAllowed: false, type: 'boolean'},
+  communeDeleguee: {valid: validCommuneDeleguee, isRequired: false, nullAllowed: true, type: 'string'}
 }
 
 const updateSchema = {
@@ -95,7 +103,8 @@ const updateSchema = {
   positions: {valid: validPositions, isRequired: false, nullAllowed: false, type: 'array'},
   toponyme: {valid: validToponyme, isRequired: false, nullAllowed: true, type: 'string'},
   parcelles: {valid: validParcelles, isRequired: false, nullAllowed: false, type: 'array'},
-  certifie: {valid: null, isRequired: false, nullAllowed: false, type: 'boolean'}
+  certifie: {valid: null, isRequired: false, nullAllowed: false, type: 'boolean'},
+  communeDeleguee: {valid: validCommuneDeleguee, isRequired: false, nullAllowed: true, type: 'string'}
 }
 
 const batchUpdateSchema = {
@@ -103,7 +112,8 @@ const batchUpdateSchema = {
   positionType: {valid: positionModel.validPositionType, isRequired: false, nullAllowed: true, type: 'string'},
   comment: {valid: validComment, isRequired: false, nullAllowed: true, type: 'string'},
   toponyme: {valid: validToponyme, isRequired: false, nullAllowed: true, type: 'string'},
-  certifie: {valid: null, isRequired: false, nullAllowed: false, type: 'boolean'}
+  certifie: {valid: null, isRequired: false, nullAllowed: false, type: 'boolean'},
+  communeDeleguee: {valid: validCommuneDeleguee, isRequired: false, nullAllowed: true, type: 'string'}
 }
 
 async function create(idVoie, payload) {
@@ -238,7 +248,6 @@ async function update(id, payload) {
   }
 
   mongo.decorateModification(numeroChanges)
-
   const {value} = await mongo.db.collection('numeros').findOneAndUpdate(
     {_id: mongo.parseObjectID(id)},
     {$set: numeroChanges},
@@ -323,7 +332,7 @@ function normalizeSuffixe(suffixe) {
 
 async function batchUpdateNumeros(idBal, body) {
   const {numerosIds, changes} = body
-  const {voie, certifie, positionType, toponyme, comment} = await validPayload(changes, batchUpdateSchema)
+  const {voie, certifie, positionType, toponyme, comment, communeDeleguee} = await validPayload(changes, batchUpdateSchema)
 
   if (voie) {
     const voieRequested = await mongo.db.collection('voies').findOne({
@@ -393,6 +402,11 @@ async function batchUpdateNumeros(idBal, body) {
     batchChanges.comment = comment
   }
 
+  if (communeDeleguee !== undefined) {
+    batchConditions.push({communeDeleguee: {$ne: communeDeleguee}})
+    batchChanges.communeDeleguee = communeDeleguee
+  }
+
   if (Object.keys(batchChanges) === 0) {
     return {changes: {}, modifiedCount: 0}
   }
@@ -421,7 +435,7 @@ async function batchUpdateNumeros(idBal, body) {
     await mongo.touchDocument('bases_locales', idBal, now)
   }
 
-  return {changes: {voie, certifie, positionType, toponyme, comment}, modifiedCount}
+  return {changes: {voie, certifie, positionType, toponyme, comment, communeDeleguee}, modifiedCount}
 }
 
 async function batchRemoveNumeros(idBal, body) {

--- a/lib/routes/admin.js
+++ b/lib/routes/admin.js
@@ -8,6 +8,7 @@ const pumpify = require('pumpify')
 const mongo = require('../util/mongo')
 const w = require('../util/w')
 const BaseLocale = require('../models/base-locale')
+const CommunesDeleguees = require('../communeDeleguees/commune-deleguees.service')
 
 const app = new express.Router()
 
@@ -21,6 +22,11 @@ app.get('/emails.csv', w(async (req, res) => {
   ))
 
   res.set('Content-Type', 'text/csv').send(csvContent)
+}))
+
+app.post('/update-communes-deleguees', w(async (req, res) => {
+  await CommunesDeleguees.updateCommuneDeleguees()
+  res.status(201).send('Communes deleguees updated')
 }))
 
 app.post('/merge-bases-locales', w(async (req, res) => {

--- a/lib/util/cog.js
+++ b/lib/util/cog.js
@@ -12,6 +12,7 @@ const communesByDepartementIndex = groupBy(communes, 'departement')
 const communesIndex = keyBy(communes, 'code')
 const departementsIndex = keyBy(departements, 'code')
 const communesDelegueesByChefLieuIndex = groupBy(communesDeleguees, 'chefLieu')
+const communesDelegueesIndex = keyBy(communesDeleguees, 'code')
 
 function getCommunesByDepartement(codeDepartement) {
   return communesByDepartementIndex[codeDepartement] || []
@@ -29,8 +30,12 @@ function getDepartement(codeDepartement) {
   return departementsIndex[codeDepartement]
 }
 
+function getCommuneDeleguee(codeCommune) {
+  return communesDelegueesIndex[codeCommune]
+}
+
 function getCommuneByChefLieu(chefLieu) {
   return communesDelegueesByChefLieuIndex[chefLieu]
 }
 
-module.exports = {getCommunesByDepartement, getCommune, getCodesCommunes, getDepartement, communesDeleguees, getCommuneByChefLieu}
+module.exports = {getCommunesByDepartement, getCommune, getCodesCommunes, getDepartement, communesDeleguees, getCommuneByChefLieu, getCommuneDeleguee}

--- a/lib/util/cog.js
+++ b/lib/util/cog.js
@@ -1,5 +1,8 @@
 const {groupBy, keyBy} = require('lodash')
 
+const communesDeleguees = require('@etalab/decoupage-administratif/data/communes.json')
+  .filter(c => c.chefLieu)
+
 const communes = require('@etalab/decoupage-administratif/data/communes.json')
   .filter(c => ['commune-actuelle', 'arrondissement-municipal'].includes(c.type))
 
@@ -8,6 +11,7 @@ const departements = require('@etalab/decoupage-administratif/data/departements.
 const communesByDepartementIndex = groupBy(communes, 'departement')
 const communesIndex = keyBy(communes, 'code')
 const departementsIndex = keyBy(departements, 'code')
+const communesDelegueesByChefLieuIndex = groupBy(communesDeleguees, 'chefLieu')
 
 function getCommunesByDepartement(codeDepartement) {
   return communesByDepartementIndex[codeDepartement] || []
@@ -25,4 +29,8 @@ function getDepartement(codeDepartement) {
   return departementsIndex[codeDepartement]
 }
 
-module.exports = {getCommunesByDepartement, getCommune, getCodesCommunes, getDepartement}
+function getCommuneByChefLieu(chefLieu) {
+  return communesDelegueesByChefLieuIndex[chefLieu]
+}
+
+module.exports = {getCommunesByDepartement, getCommune, getCodesCommunes, getDepartement, communesDeleguees, getCommuneByChefLieu}


### PR DESCRIPTION
## Contexte

Pour le moment, il n'y a aucune gestion des communes déléguées dans mes-adresses, alors que c'est bien présent dans le format-bal

## Model

- Ajout du champ `communesDeleguees` dans la collection `BaseLocales` qui est un Array des communes déléguées
- Ajout du champ `communeDeleguee`à la collection `numeros`qui est le codeCommune auquel appartient le numéro

## Fonctionnalité

- À la création d'une bal: Création et populate du champ `communesDeleguees`
- Route `/admin/update-communes-deleguees` pour mettre à jour les communes déléguées de chaque bal (par exemple quand le cog est maj)
- Ajout du `ValidatorCommuneDeleguee` au schéma de create/update/batch de la collection `numéro`

## Issue

https://github.com/BaseAdresseNationale/mes-adresses/issues/771
