### PR TITLE
Export/import commune deleguee

### DIFF
--- a/lib/communeDeleguees/__tests__/commune-deleguees.service.js
+++ b/lib/communeDeleguees/__tests__/commune-deleguees.service.js
@@ -2,6 +2,7 @@ const test = require('ava')
 const {MongoMemoryServer} = require('mongodb-memory-server')
 const mongo = require('../../util/mongo')
 const CommuneDelegueeService = require('../commune-deleguees.service')
+
 let mongod
 
 test.before('start server', async () => {
@@ -18,22 +19,22 @@ test.serial('updateCommuneDeleguees without communesDeleguees', async t => {
   const _id = new mongo.ObjectId()
   await mongo.db.collection('bases_locales').insertOne({
     _id,
-    commune: "000000"
+    commune: '000000'
   })
 
-  await CommuneDelegueeService.updateCommuneDeleguees();
+  await CommuneDelegueeService.updateCommuneDeleguees()
 
   const res = await mongo.db.collection('bases_locales').findOne({_id})
   t.deepEqual({
     _id,
-    commune: "000000",
+    commune: '000000',
   }, res)
 })
 
 test.serial('updateCommuneDeleguees with communesDeleguees', async t => {
   const _id = new mongo.ObjectId()
   const codeChefLieu = require('@etalab/decoupage-administratif/data/communes.json')
-    .filter(c => c.chefLieu)[0].chefLieu
+    .find(c => c.chefLieu).chefLieu
   const communesDeleguees = require('@etalab/decoupage-administratif/data/communes.json')
     .filter(c => c.chefLieu === codeChefLieu)
 
@@ -41,11 +42,11 @@ test.serial('updateCommuneDeleguees with communesDeleguees', async t => {
     _id,
     commune: codeChefLieu
   })
-  await CommuneDelegueeService.updateCommuneDeleguees();
+  await CommuneDelegueeService.updateCommuneDeleguees()
   const res = await mongo.db.collection('bases_locales').findOne({_id})
   t.deepEqual({
     _id,
     commune: codeChefLieu,
-    communesDeleguees: communesDeleguees.map((c) => c.code)
+    communesDeleguees: communesDeleguees.map(c => c.code)
   }, res)
 })

--- a/lib/communeDeleguees/__tests__/commune-deleguees.service.js
+++ b/lib/communeDeleguees/__tests__/commune-deleguees.service.js
@@ -1,0 +1,51 @@
+const test = require('ava')
+const {MongoMemoryServer} = require('mongodb-memory-server')
+const mongo = require('../../util/mongo')
+const CommuneDelegueeService = require('../commune-deleguees.service')
+let mongod
+
+test.before('start server', async () => {
+  mongod = await MongoMemoryServer.create()
+  await mongo.connect(mongod.getUri())
+})
+
+test.after.always('cleanup', async () => {
+  await mongo.disconnect()
+  await mongod.stop()
+})
+
+test.serial('updateCommuneDeleguees without communesDeleguees', async t => {
+  const _id = new mongo.ObjectId()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    commune: "000000"
+  })
+
+  await CommuneDelegueeService.updateCommuneDeleguees();
+
+  const res = await mongo.db.collection('bases_locales').findOne({_id})
+  t.deepEqual({
+    _id,
+    commune: "000000",
+  }, res)
+})
+
+test.serial('updateCommuneDeleguees with communesDeleguees', async t => {
+  const _id = new mongo.ObjectId()
+  const codeChefLieu = require('@etalab/decoupage-administratif/data/communes.json')
+    .filter(c => c.chefLieu)[0].chefLieu
+  const communesDeleguees = require('@etalab/decoupage-administratif/data/communes.json')
+    .filter(c => c.chefLieu === codeChefLieu)
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    commune: codeChefLieu
+  })
+  await CommuneDelegueeService.updateCommuneDeleguees();
+  const res = await mongo.db.collection('bases_locales').findOne({_id})
+  t.deepEqual({
+    _id,
+    commune: codeChefLieu,
+    communesDeleguees: communesDeleguees.map((c) => c.code)
+  }, res)
+})

--- a/lib/communeDeleguees/commune-deleguees.service.js
+++ b/lib/communeDeleguees/commune-deleguees.service.js
@@ -6,13 +6,14 @@ async function updateCommuneDeleguees() {
   const updatedPromises = []
   for (const bal of bals) {
     const communesDeleguees = getCommuneByChefLieu(bal.commune)?.map(cd => cd.code) || null
-    if ( communesDeleguees ) {
+    if (communesDeleguees) {
       const promise = mongo.db.collection('bases_locales').updateOne({
         _id: bal._id
       }, {$set: {
         communesDeleguees,
       }})
-      updatedPromises.push(promise)  
+
+      updatedPromises.push(promise)
     }
   }
 

--- a/lib/communeDeleguees/commune-deleguees.service.js
+++ b/lib/communeDeleguees/commune-deleguees.service.js
@@ -6,12 +6,14 @@ async function updateCommuneDeleguees() {
   const updatedPromises = []
   for (const bal of bals) {
     const communesDeleguees = getCommuneByChefLieu(bal.commune)?.map(cd => cd.code) || null
-    const promise = mongo.db.collection('bases_locales').updateOne({
-      _id: bal._id
-    }, {$set: {
-      communesDeleguees,
-    }})
-    updatedPromises.push(promise)
+    if ( communesDeleguees ) {
+      const promise = mongo.db.collection('bases_locales').updateOne({
+        _id: bal._id
+      }, {$set: {
+        communesDeleguees,
+      }})
+      updatedPromises.push(promise)  
+    }
   }
 
   await Promise.all(updatedPromises)

--- a/lib/communeDeleguees/commune-deleguees.service.js
+++ b/lib/communeDeleguees/commune-deleguees.service.js
@@ -1,0 +1,20 @@
+const {getCommuneByChefLieu} = require('../util/cog')
+const mongo = require('../util/mongo')
+
+async function updateCommuneDeleguees() {
+  const bals = await mongo.db.collection('bases_locales').find({}).toArray()
+  const updatedPromises = []
+  for (const bal of bals) {
+    const communesDeleguees = getCommuneByChefLieu(bal.commune)?.map(cd => cd.code) || null
+    const promise = mongo.db.collection('bases_locales').updateOne({
+      _id: bal._id
+    }, {$set: {
+      communesDeleguees,
+    }})
+    updatedPromises.push(promise)
+  }
+
+  await Promise.all(updatedPromises)
+}
+
+module.exports = {updateCommuneDeleguees}

--- a/lib/export/__tests__/csv-bal.js
+++ b/lib/export/__tests__/csv-bal.js
@@ -55,6 +55,8 @@ test('createRow', t => {
     suffixe: 'bis',
     certification_commune: '1',
     commune_nom: 'Mont-Bonvillers',
+    commune_deleguee_insee: undefined,
+    commune_deleguee_nom: '',
     position: 'entrée',
     long: '5.835188',
     lat: '49.326038',
@@ -111,6 +113,8 @@ test('exportAsCsv', async t => {
     _updated: new Date('2019-01-05')
   }
 
+  const communeDeleguee = require('@etalab/decoupage-administratif/data/communes.json')
+    .find(c => c.chefLieu).code
   const numeros = [
     {
       voie: voie1._id,
@@ -136,15 +140,17 @@ test('exportAsCsv', async t => {
           coordinates: [5.83315, 49.324433]
         }
       }],
+      communeDeleguee,
       parcelles: ['12345000AA0001', '12345000AA0002'],
       _updated: new Date('2019-02-05')
     }
   ]
 
+  const nomCommuneDeleguee = require('@etalab/decoupage-administratif/data/communes.json').find(({code, chefLieu}) => code === communeDeleguee && chefLieu).nom
   const csv = await exportAsCsv({voies: [voie1, voie2], toponymes: [hameau, lieuDit], numeros})
-  const expected = `cle_interop;uid_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;certification_commune;commune_insee;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj;voie_nom_gsw
-54084_6789_00006;;allée des acacias;La Varenne;6;;0;54084;Mont-Bonvillers;entrée;5.83315;49.324433;905967.72;6917567.98;12345000AA0001|12345000AA0002;Mairie;2019-02-05;Akazienallee
-54084_xxxx_99999;;La Varenne;;99999;;;54084;Mont-Bonvillers;;;;;;;commune;2019-01-05;
-54084_xxxx_99999;;Le Moulin;;99999;;;54084;Mont-Bonvillers;segment;5.83315;49.324433;905967.72;6917567.98;12345000AA0001|12345000AA0002;Mairie;2019-01-05;Die Mühle`.replace(/\n/g, '\r\n') + '\r\n'
+  const expected = `cle_interop;uid_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;certification_commune;commune_insee;commune_nom;commune_deleguee_insee;commune_deleguee_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj;voie_nom_gsw
+54084_6789_00006;;allée des acacias;La Varenne;6;;0;54084;Mont-Bonvillers;${communeDeleguee};${nomCommuneDeleguee};entrée;5.83315;49.324433;905967.72;6917567.98;12345000AA0001|12345000AA0002;Mairie;2019-02-05;Akazienallee
+54084_xxxx_99999;;La Varenne;;99999;;;54084;Mont-Bonvillers;;;;;;;;;commune;2019-01-05;
+54084_xxxx_99999;;Le Moulin;;99999;;;54084;Mont-Bonvillers;;;segment;5.83315;49.324433;905967.72;6917567.98;12345000AA0001|12345000AA0002;Mairie;2019-01-05;Die Mühle`.replace(/\n/g, '\r\n') + '\r\n'
   t.is(csv, expected)
 })

--- a/lib/export/csv-bal.js
+++ b/lib/export/csv-bal.js
@@ -4,7 +4,7 @@ const intoStream = require('into-stream')
 const {keyBy} = require('lodash')
 const pumpify = require('pumpify')
 const proj = require('@etalab/project-legal')
-const {getCommune} = require('../util/cog')
+const {getCommune, getCommuneDeleguee} = require('../util/cog')
 
 function roundCoordinate(coordinate, precision) {
   return Number.parseFloat(coordinate.toFixed(precision))
@@ -53,6 +53,8 @@ function createRow(obj) {
     certification_commune: toCsvBoolean(obj.certifie),
     commune_insee: obj.codeCommune,
     commune_nom: getCommune(obj.codeCommune).nom,
+    commune_deleguee_insee: obj.communeDeleguee,
+    commune_deleguee_nom: obj.communeDeleguee ? getCommuneDeleguee(obj.communeDeleguee).nom : '',
     position: '',
     long: '',
     lat: '',
@@ -123,7 +125,8 @@ async function exportAsCsv({voies, toponymes, numeros}) {
           nomToponyme: n.toponyme ? n.toponyme.nom : null,
           nomToponymeAlt: n?.toponyme?.nomAlt || null,
           parcelles: n.parcelles,
-          position: p
+          position: p,
+          communeDeleguee: n.communeDeleguee
         })
       })
     }

--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -39,9 +39,8 @@ test('create a BaseLocale', async t => {
 })
 
 test.serial('create a BaseLocale with CommunesDeleguees', async t => {
-
   const codeChefLieu = require('@etalab/decoupage-administratif/data/communes.json')
-    .filter(c => c.chefLieu)[0].chefLieu
+    .find(c => c.chefLieu).chefLieu
   const communesDeleguees = require('@etalab/decoupage-administratif/data/communes.json')
     .filter(c => c.chefLieu === codeChefLieu)
   const baseLocale = await BaseLocale.create({
@@ -54,7 +53,7 @@ test.serial('create a BaseLocale with CommunesDeleguees', async t => {
   t.true(keys.every(k => k in baseLocale))
   t.true(baseLocale.status === 'draft')
   t.is(Object.keys(baseLocale).length, 10)
-  t.deepEqual(baseLocale.communesDeleguees, communesDeleguees.map((c) => c.code))
+  t.deepEqual(baseLocale.communesDeleguees, communesDeleguees.map(c => c.code))
 })
 
 test('create a BaseLocale / minimal', async t => {

--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -38,6 +38,25 @@ test('create a BaseLocale', async t => {
   t.is(Object.keys(baseLocale).length, 9)
 })
 
+test.serial('create a BaseLocale with CommunesDeleguees', async t => {
+
+  const codeChefLieu = require('@etalab/decoupage-administratif/data/communes.json')
+    .filter(c => c.chefLieu)[0].chefLieu
+  const communesDeleguees = require('@etalab/decoupage-administratif/data/communes.json')
+    .filter(c => c.chefLieu === codeChefLieu)
+  const baseLocale = await BaseLocale.create({
+    nom: 'foo',
+    emails: ['me@domain.co'],
+    commune: codeChefLieu
+  })
+  const keys = ['nom', 'status', 'emails', 'commune', 'token', '_updated', '_created', '_id', '_deleted', 'communesDeleguees']
+
+  t.true(keys.every(k => k in baseLocale))
+  t.true(baseLocale.status === 'draft')
+  t.is(Object.keys(baseLocale).length, 10)
+  t.deepEqual(baseLocale.communesDeleguees, communesDeleguees.map((c) => c.code))
+})
+
 test('create a BaseLocale / minimal', async t => {
   const baseLocale = await BaseLocale.create({nom: 'foo', emails: ['me@domain.co'], commune: '27115'})
   const keys = ['nom', 'status', 'emails', 'commune', 'token', '_updated', '_created', '_id', '_deleted']

--- a/lib/models/__tests__/numero.mongo.js
+++ b/lib/models/__tests__/numero.mongo.js
@@ -48,6 +48,43 @@ test('create a numero', async t => {
   t.deepEqual(numero._created, voie._updated)
 })
 
+test('create a numero with commune deleguee', async t => {
+  const idBal = new mongo.ObjectId()
+  const _id = new mongo.ObjectId()
+  const referenceDate = new Date('2019-01-01')
+  const codeChefLieu = require('@etalab/decoupage-administratif/data/communes.json')
+    .filter(c => c.chefLieu)[0].chefLieu
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: idBal,
+    _updated: referenceDate
+  })
+  await mongo.db.collection('voies').insertOne({
+    _id,
+    _bal: idBal,
+    _updated: referenceDate
+  })
+  const numero = await Numero.create(_id, {
+    numero: 42,
+    suffixe: 'foo',
+    comment: 'bar',
+    positions: [],
+    communeDeleguee: codeChefLieu
+  })
+
+  const keys = ['_id', '_bal', 'commune', '_updated', '_created', 'voie', 'numero', 'suffixe', 'comment', 'toponyme', 'positions', 'parcelles', 'certifie', 'communeDeleguee']
+  t.true(keys.every(k => k in numero))
+  t.is(Object.keys(numero).length, keys.length)
+
+  const bal = await mongo.db.collection('bases_locales').findOne({_id: idBal})
+  t.deepEqual(numero._created, bal._updated)
+
+  const voie = await mongo.db.collection('voies').findOne({_id})
+  t.deepEqual(numero._created, voie._updated)
+
+  t.is(numero.communeDeleguee, codeChefLieu)
+})
+
 test('create a numero / invalid numero type', t => {
   const idVoie = new mongo.ObjectId()
   return t.throwsAsync(Numero.create(idVoie, {

--- a/lib/models/__tests__/numero.mongo.js
+++ b/lib/models/__tests__/numero.mongo.js
@@ -53,7 +53,7 @@ test('create a numero with commune deleguee', async t => {
   const _id = new mongo.ObjectId()
   const referenceDate = new Date('2019-01-01')
   const codeChefLieu = require('@etalab/decoupage-administratif/data/communes.json')
-    .filter(c => c.chefLieu)[0].chefLieu
+    .find(c => c.chefLieu).chefLieu
 
   await mongo.db.collection('bases_locales').insertOne({
     _id: idBal,

--- a/lib/models/__tests__/numero.schema.js
+++ b/lib/models/__tests__/numero.schema.js
@@ -30,6 +30,24 @@ test('valid payload', async t => {
   t.deepEqual(error, {})
 })
 
+test('valid payload with commune deleguee', async t => {
+  const communesDeleguees = require('@etalab/decoupage-administratif/data/communes.json')
+  .filter(c => c.chefLieu)
+  const numero = {
+    numero: 42,
+    suffixe: 'bis',
+    positions: [],
+    parcelles: [],
+    certifie: false,
+    communeDeleguee: communesDeleguees[0].code
+  }
+
+  const {value, error} = await validSchema(numero, createSchema)
+
+  t.deepEqual(value, numero)
+  t.deepEqual(error, {})
+})
+
 test('valid payload / uppercase suffixe', async t => {
   const numero = {
     numero: 41,
@@ -124,6 +142,25 @@ test('valid payload update', async t => {
     voie: _idVoie
   })
   t.deepEqual(error, {})
+})
+
+test('not valid payload with bad commune deleguee', async t => {
+  const communesDeleguees = require('@etalab/decoupage-administratif/data/communes.json')
+  .filter(c => c.chefLieu)
+  const numero = {
+    numero: 42,
+    suffixe: 'bis',
+    positions: [],
+    parcelles: [],
+    certifie: false,
+    communeDeleguee: "000000"
+  }
+
+  const {error} = await validSchema(numero, createSchema)
+
+  t.deepEqual(error, {
+    commune: ['Code commune deleguee inconnu'],
+  })
 })
 
 test('invalid payload update', async t => {

--- a/lib/models/__tests__/numero.schema.js
+++ b/lib/models/__tests__/numero.schema.js
@@ -31,15 +31,15 @@ test('valid payload', async t => {
 })
 
 test('valid payload with commune deleguee', async t => {
-  const communesDeleguees = require('@etalab/decoupage-administratif/data/communes.json')
-  .filter(c => c.chefLieu)
+  const communeDeleguee = require('@etalab/decoupage-administratif/data/communes.json')
+    .find(c => c.chefLieu)
   const numero = {
     numero: 42,
     suffixe: 'bis',
     positions: [],
     parcelles: [],
     certifie: false,
-    communeDeleguee: communesDeleguees[0].code
+    communeDeleguee: communeDeleguee.code
   }
 
   const {value, error} = await validSchema(numero, createSchema)
@@ -145,15 +145,13 @@ test('valid payload update', async t => {
 })
 
 test('not valid payload with bad commune deleguee', async t => {
-  const communesDeleguees = require('@etalab/decoupage-administratif/data/communes.json')
-  .filter(c => c.chefLieu)
   const numero = {
     numero: 42,
     suffixe: 'bis',
     positions: [],
     parcelles: [],
     certifie: false,
-    communeDeleguee: "000000"
+    communeDeleguee: '000000'
   }
 
   const {error} = await validSchema(numero, createSchema)

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -14,7 +14,7 @@ const {extract} = require('../populate/extract-ban')
 const {extractFromCsv} = require('../populate/extract-csv')
 const adressesToCsv = require('../export/csv-bal').exportAsCsv
 const {transformToGeoJSON} = require('../export/geojson')
-const {getCommune: getCommuneCOG} = require('../util/cog')
+const {getCommune: getCommuneCOG, getCommuneByChefLieu} = require('../util/cog')
 const {getCommunesSummary} = require('../util/api-ban')
 const Voie = require('./voie')
 const Numero = require('./numero')
@@ -142,12 +142,14 @@ function parseQueryFilters(query) {
 
 async function create(payload) {
   const {nom, emails, commune} = await validPayload(payload, createSchema)
+  const communesDeleguees = getCommuneByChefLieu(commune)?.map(cd => cd.code) || null
 
   const baseLocale = {
     _id: new mongo.ObjectId(),
     nom,
     emails,
     commune,
+    communesDeleguees,
     token: generateBase62String(20),
     status: 'draft'
   }

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -142,16 +142,18 @@ function parseQueryFilters(query) {
 
 async function create(payload) {
   const {nom, emails, commune} = await validPayload(payload, createSchema)
-  const communesDeleguees = getCommuneByChefLieu(commune)?.map(cd => cd.code) || null
 
   const baseLocale = {
     _id: new mongo.ObjectId(),
     nom,
     emails,
     commune,
-    communesDeleguees,
     token: generateBase62String(20),
     status: 'draft'
+  }
+  const communesDeleguees = getCommuneByChefLieu(commune)?.map(cd => cd.code) || null
+  if (communesDeleguees) {
+    baseLocale.communesDeleguees = communesDeleguees
   }
 
   mongo.decorateCreation(baseLocale, true)
@@ -173,6 +175,10 @@ async function createDemo(payload) {
     commune,
     nom: `Adresses de ${getCommuneCOG(commune).nom} [démo]`,
     status: 'demo'
+  }
+  const communesDeleguees = getCommuneByChefLieu(commune)?.map(cd => cd.code) || null
+  if (communesDeleguees) {
+    baseLocale.communesDeleguees = communesDeleguees
   }
 
   mongo.decorateCreation(baseLocale, true)

--- a/lib/models/numero.js
+++ b/lib/models/numero.js
@@ -4,6 +4,7 @@ const {getFilteredPayload, addError, validSchema} = require('../util/payload')
 const mongo = require('../util/mongo')
 const {validPayload} = require('../util/payload')
 const {validateurBAL} = require('../validateur-bal')
+const {getCommuneDeleguee} = require('../util/cog')
 const positionModel = require('./position')
 
 function validObjectID(id) {
@@ -77,6 +78,12 @@ async function validParcelles(parcelles, error) {
   }
 }
 
+async function validCommuneDeleguee(commune, error) {
+  if (!getCommuneDeleguee(commune)) {
+    addError(error, 'commune', 'Code commune deleguee inconnu')
+  }
+}
+
 const createSchema = {
   numero: {valid: validNumero, isRequired: true, nullAllowed: false, type: 'number'},
   suffixe: {valid: validSuffixe, isRequired: false, nullAllowed: true, type: 'string'},
@@ -84,7 +91,8 @@ const createSchema = {
   positions: {valid: validPositions, isRequired: false, nullAllowed: false, type: 'array'},
   toponyme: {valid: validToponyme, isRequired: false, nullAllowed: true, type: 'string'},
   parcelles: {valid: validParcelles, isRequired: false, nullAllowed: false, type: 'array'},
-  certifie: {valid: null, isRequired: false, nullAllowed: false, type: 'boolean'}
+  certifie: {valid: null, isRequired: false, nullAllowed: false, type: 'boolean'},
+  communeDeleguee: {valid: validCommuneDeleguee, isRequired: false, nullAllowed: true, type: 'string'}
 }
 
 const updateSchema = {
@@ -95,7 +103,8 @@ const updateSchema = {
   positions: {valid: validPositions, isRequired: false, nullAllowed: false, type: 'array'},
   toponyme: {valid: validToponyme, isRequired: false, nullAllowed: true, type: 'string'},
   parcelles: {valid: validParcelles, isRequired: false, nullAllowed: false, type: 'array'},
-  certifie: {valid: null, isRequired: false, nullAllowed: false, type: 'boolean'}
+  certifie: {valid: null, isRequired: false, nullAllowed: false, type: 'boolean'},
+  communeDeleguee: {valid: validCommuneDeleguee, isRequired: false, nullAllowed: true, type: 'string'}
 }
 
 const batchUpdateSchema = {
@@ -103,7 +112,8 @@ const batchUpdateSchema = {
   positionType: {valid: positionModel.validPositionType, isRequired: false, nullAllowed: true, type: 'string'},
   comment: {valid: validComment, isRequired: false, nullAllowed: true, type: 'string'},
   toponyme: {valid: validToponyme, isRequired: false, nullAllowed: true, type: 'string'},
-  certifie: {valid: null, isRequired: false, nullAllowed: false, type: 'boolean'}
+  certifie: {valid: null, isRequired: false, nullAllowed: false, type: 'boolean'},
+  communeDeleguee: {valid: validCommuneDeleguee, isRequired: false, nullAllowed: true, type: 'string'}
 }
 
 async function create(idVoie, payload) {
@@ -238,7 +248,6 @@ async function update(id, payload) {
   }
 
   mongo.decorateModification(numeroChanges)
-
   const {value} = await mongo.db.collection('numeros').findOneAndUpdate(
     {_id: mongo.parseObjectID(id)},
     {$set: numeroChanges},
@@ -323,7 +332,7 @@ function normalizeSuffixe(suffixe) {
 
 async function batchUpdateNumeros(idBal, body) {
   const {numerosIds, changes} = body
-  const {voie, certifie, positionType, toponyme, comment} = await validPayload(changes, batchUpdateSchema)
+  const {voie, certifie, positionType, toponyme, comment, communeDeleguee} = await validPayload(changes, batchUpdateSchema)
 
   if (voie) {
     const voieRequested = await mongo.db.collection('voies').findOne({
@@ -393,6 +402,11 @@ async function batchUpdateNumeros(idBal, body) {
     batchChanges.comment = comment
   }
 
+  if (communeDeleguee !== undefined) {
+    batchConditions.push({communeDeleguee: {$ne: communeDeleguee}})
+    batchChanges.communeDeleguee = communeDeleguee
+  }
+
   if (Object.keys(batchChanges) === 0) {
     return {changes: {}, modifiedCount: 0}
   }
@@ -421,7 +435,7 @@ async function batchUpdateNumeros(idBal, body) {
     await mongo.touchDocument('bases_locales', idBal, now)
   }
 
-  return {changes: {voie, certifie, positionType, toponyme, comment}, modifiedCount}
+  return {changes: {voie, certifie, positionType, toponyme, comment, communeDeleguee}, modifiedCount}
 }
 
 async function batchRemoveNumeros(idBal, body) {

--- a/lib/populate/__tests__/extract-csv.js
+++ b/lib/populate/__tests__/extract-csv.js
@@ -1,22 +1,22 @@
 const test = require('ava')
 const {extractFromCsv} = require('../extract-csv')
 
-const csvFile = `cle_interop;uid_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj;voie_nom_gsw;lieudit_complement_nom_gsw
-55326_xxxx_00001;;Nouvelle Voie avec des numéros;;1;;Maulan;entrée;5.25237;48.668935;865837.51;6843339.94;64284000BI0459|64284000BI0450;;2021-04-27;Neuer Weg mit Zahlen;
-55326_xxxx_00001;;Nouvelle Voie avec des numéros;;1;;Maulan;délivrance postale;5.25237;48.669494;865835.73;6843402.13;;;2021-04-27;Neuer Weg mit Zahlen;
-55326_xxxx_00002;;Nouvelle Voie avec des numéros;;2;;Maulan;entrée;5.254912;48.667116;866030.41;6843143.15;;;2021-04-27;Neuer Weg mit Zahlen;
-55326_xxxx_00003;;Nouvelle Voie avec des numéros;;3;;Maulan;entrée;5.255336;48.669354;866054.49;6843392.82;;;2021-04-27;Neuer Weg mit Zahlen;
-55326_xxxx_00003;;Nouvelle Voie avec des numéros;;3;;Maulan;délivrance postale;5.256289;48.669914;866122.88;6843457.02;;;2021-04-27;Neuer Weg mit Zahlen;
-55326_xxxx_00003;;Nouvelle Voie avec des numéros;;3;;Maulan;bâtiment;5.25576;48.670264;866082.79;6843494.77;;;2021-04-27;Neuer Weg mit Zahlen;
-55326_xxxx_00003;;Nouvelle Voie avec des numéros;;3;;Maulan;logement;5.257137;48.670404;866183.7;6843513.22;;;2021-04-27;Neuer Weg mit Zahlen;
-55326_xxxx_00001;;voie dans un toponyme;Nouveau Toponyme;1;;Maulan;entrée;5.255501;48.662923;866087.07;6842678.39;;;2021-04-27;;leeres Toponym
-55326_xxxx_00002;;voie dans un toponyme;Nouveau Toponyme;2;;Maulan;entrée;5.256137;48.663057;866133.48;6842694.64;;;2021-04-27;;leeres Toponym
-55326_xxxx_00001;;Voie à moitié dans un toponyme;Nouveau Toponyme;1;;Maulan;entrée;5.255077;48.6631;866055.3;6842697.21;;;2021-04-27;;leeres Toponym
-55326_xxxx_00002;;Voie à moitié dans un toponyme;Toponyme implicite;2;;Maulan;entrée;5.254396;48.663192;866004.84;6842706.03;;;2021-04-27;;implizite Toponyme
-55326_xxxx_00003;;Voie à moitié dans un toponyme;;3;;Maulan;entrée;5.253747;48.663252;865956.9;6842711.29;;;2021-04-27;;
-55326_xxxx_00004;;Voie à moitié dans un toponyme;;4;;Maulan;entrée;5.253197;48.663013;865917.16;6842683.62;;;2021-04-27;;
-55326_xxxx_99999;;Nouveau Toponyme;;99999;;Maulan;segment;5.25504;48.663112;866052.5;6842698.52;;;2021-04-27;;
-55326_xxxx_99999;;Toponyme Vide;;99999;;Maulan;segment;5.247276;48.664948;865475.13;6842886.26;;;2021-04-27;leeres Toponym;`
+const csvFile = `cle_interop;uid_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;commune_nom;commune_deleguee_insee;commune_deleguee_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj;voie_nom_gsw;lieudit_complement_nom_gsw
+55326_xxxx_00001;;Nouvelle Voie avec des numéros;;1;;Maulan;00001;Maulan2;entrée;5.25237;48.668935;865837.51;6843339.94;64284000BI0459|64284000BI0450;;2021-04-27;Neuer Weg mit Zahlen;
+55326_xxxx_00001;;Nouvelle Voie avec des numéros;;1;;Maulan;;;délivrance postale;5.25237;48.669494;865835.73;6843402.13;;;2021-04-27;Neuer Weg mit Zahlen;
+55326_xxxx_00002;;Nouvelle Voie avec des numéros;;2;;Maulan;;;entrée;5.254912;48.667116;866030.41;6843143.15;;;2021-04-27;Neuer Weg mit Zahlen;
+55326_xxxx_00003;;Nouvelle Voie avec des numéros;;3;;Maulan;;;entrée;5.255336;48.669354;866054.49;6843392.82;;;2021-04-27;Neuer Weg mit Zahlen;
+55326_xxxx_00003;;Nouvelle Voie avec des numéros;;3;;Maulan;;;délivrance postale;5.256289;48.669914;866122.88;6843457.02;;;2021-04-27;Neuer Weg mit Zahlen;
+55326_xxxx_00003;;Nouvelle Voie avec des numéros;;3;;Maulan;;;bâtiment;5.25576;48.670264;866082.79;6843494.77;;;2021-04-27;Neuer Weg mit Zahlen;
+55326_xxxx_00003;;Nouvelle Voie avec des numéros;;3;;Maulan;;;logement;5.257137;48.670404;866183.7;6843513.22;;;2021-04-27;Neuer Weg mit Zahlen;
+55326_xxxx_00001;;voie dans un toponyme;Nouveau Toponyme;1;;Maulan;;;entrée;5.255501;48.662923;866087.07;6842678.39;;;2021-04-27;;leeres Toponym
+55326_xxxx_00002;;voie dans un toponyme;Nouveau Toponyme;2;;Maulan;;;entrée;5.256137;48.663057;866133.48;6842694.64;;;2021-04-27;;leeres Toponym
+55326_xxxx_00001;;Voie à moitié dans un toponyme;Nouveau Toponyme;1;;Maulan;;;entrée;5.255077;48.6631;866055.3;6842697.21;;;2021-04-27;;leeres Toponym
+55326_xxxx_00002;;Voie à moitié dans un toponyme;Toponyme implicite;2;;Maulan;;;entrée;5.254396;48.663192;866004.84;6842706.03;;;2021-04-27;;implizite Toponyme
+55326_xxxx_00003;;Voie à moitié dans un toponyme;;3;;Maulan;;;entrée;5.253747;48.663252;865956.9;6842711.29;;;2021-04-27;;
+55326_xxxx_00004;;Voie à moitié dans un toponyme;;4;;Maulan;;;entrée;5.253197;48.663013;865917.16;6842683.62;;;2021-04-27;;
+55326_xxxx_99999;;Nouveau Toponyme;;99999;;Maulan;;;segment;5.25504;48.663112;866052.5;6842698.52;;;2021-04-27;;
+55326_xxxx_99999;;Toponyme Vide;;99999;;Maulan;;;segment;5.247276;48.664948;865475.13;6842886.26;;;2021-04-27;leeres Toponym;`
 
 test('import CSV file', async t => {
   const {isValid, accepted, numeros, voies, toponymes} = await extractFromCsv(Buffer.from(csvFile), '55326')

--- a/lib/populate/extract-csv.js
+++ b/lib/populate/extract-csv.js
@@ -103,6 +103,7 @@ function extractData(rows, codeCommune) {
         certifie: numeroRows[0].parsedValues.certification_commune,
         positions: extractPositions(numeroRows),
         parcelles: numeroRows[0].parsedValues.cad_parcelles,
+        communeDeleguee: numeroRows[0].parsedValues.commune_deleguee_insee || null,
         _created: date,
         _updated: date
       }

--- a/lib/routes/admin.js
+++ b/lib/routes/admin.js
@@ -8,6 +8,7 @@ const pumpify = require('pumpify')
 const mongo = require('../util/mongo')
 const w = require('../util/w')
 const BaseLocale = require('../models/base-locale')
+const CommunesDeleguees = require('../communeDeleguees/commune-deleguees.service')
 
 const app = new express.Router()
 
@@ -21,6 +22,11 @@ app.get('/emails.csv', w(async (req, res) => {
   ))
 
   res.set('Content-Type', 'text/csv').send(csvContent)
+}))
+
+app.post('/update-communes-deleguees', w(async (req, res) => {
+  await CommunesDeleguees.updateCommuneDeleguees()
+  res.status(201).send('Communes deleguees updated')
 }))
 
 app.post('/merge-bases-locales', w(async (req, res) => {

--- a/lib/util/cog.js
+++ b/lib/util/cog.js
@@ -12,6 +12,7 @@ const communesByDepartementIndex = groupBy(communes, 'departement')
 const communesIndex = keyBy(communes, 'code')
 const departementsIndex = keyBy(departements, 'code')
 const communesDelegueesByChefLieuIndex = groupBy(communesDeleguees, 'chefLieu')
+const communesDelegueesIndex = keyBy(communesDeleguees, 'code')
 
 function getCommunesByDepartement(codeDepartement) {
   return communesByDepartementIndex[codeDepartement] || []
@@ -29,8 +30,12 @@ function getDepartement(codeDepartement) {
   return departementsIndex[codeDepartement]
 }
 
+function getCommuneDeleguee(codeCommune) {
+  return communesDelegueesIndex[codeCommune]
+}
+
 function getCommuneByChefLieu(chefLieu) {
   return communesDelegueesByChefLieuIndex[chefLieu]
 }
 
-module.exports = {getCommunesByDepartement, getCommune, getCodesCommunes, getDepartement, communesDeleguees, getCommuneByChefLieu}
+module.exports = {getCommunesByDepartement, getCommune, getCodesCommunes, getDepartement, communesDeleguees, getCommuneByChefLieu, getCommuneDeleguee}

--- a/lib/util/cog.js
+++ b/lib/util/cog.js
@@ -1,5 +1,8 @@
 const {groupBy, keyBy} = require('lodash')
 
+const communesDeleguees = require('@etalab/decoupage-administratif/data/communes.json')
+  .filter(c => c.chefLieu)
+
 const communes = require('@etalab/decoupage-administratif/data/communes.json')
   .filter(c => ['commune-actuelle', 'arrondissement-municipal'].includes(c.type))
 
@@ -8,6 +11,7 @@ const departements = require('@etalab/decoupage-administratif/data/departements.
 const communesByDepartementIndex = groupBy(communes, 'departement')
 const communesIndex = keyBy(communes, 'code')
 const departementsIndex = keyBy(departements, 'code')
+const communesDelegueesByChefLieuIndex = groupBy(communesDeleguees, 'chefLieu')
 
 function getCommunesByDepartement(codeDepartement) {
   return communesByDepartementIndex[codeDepartement] || []
@@ -25,4 +29,8 @@ function getDepartement(codeDepartement) {
   return departementsIndex[codeDepartement]
 }
 
-module.exports = {getCommunesByDepartement, getCommune, getCodesCommunes, getDepartement}
+function getCommuneByChefLieu(chefLieu) {
+  return communesDelegueesByChefLieuIndex[chefLieu]
+}
+
+module.exports = {getCommunesByDepartement, getCommune, getCodesCommunes, getDepartement, communesDeleguees, getCommuneByChefLieu}


### PR DESCRIPTION
## Context

Après l'ajout des commune déléguées dans le modèle numéro, il faut pouvoir les importer et exporter

## Fonctionnalité

Mise a jour des fonctions import/export pour prendre en compte les champs `commune_deleguee_insee` et `commune_deleguee_nom` du format-bal csv

## Issue

https://github.com/BaseAdresseNationale/mes-adresses/issues/771

## Apercu

https://user-images.githubusercontent.com/8143924/230899058-bdb090ad-d1b6-43b7-8a18-a6e691615e95.mov

