### PR TITLE
Ajouter un script pour charger les contoures des communes

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -16,3 +16,4 @@ API_DEPOT_URL=https://plateforme-bal.adresse.data.gouv.fr/api-depot
 API_DEPOT_CLIENT_ID=
 API_DEPOT_CLIENT_SECRET=
 BAN_API_URL=https://plateforme.adresse.data.gouv.fr
+URL_CONTOURS_COMMUNES=http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/2023/geojson/communes-100m.geojson

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  URL_CONTOURS_COMMUNES: http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/2023/geojson/communes-100m.geojson
+
 jobs:
   build:
 

--- a/.gitignore
+++ b/.gitignore
@@ -112,4 +112,7 @@ typings/
 # DynamoDB Local files
 .dynamodb/
 
+# Contours Communes
+contours-communes.json
+
 # End of https://www.gitignore.io/api/node,macos

--- a/README.md
+++ b/README.md
@@ -35,6 +35,22 @@ yarn start
 yarn test
 ```
 
+## Mise a jour
+
+
+### Contoures des communes
+
+```
+yarn update-contours
+```
+
+### Cadastres des communes
+
+```
+yarn update-cadastre
+```
+
+
 ## Configuration
 
 Cette application utilise des variables d'environnement pour sa configuration.

--- a/lib/util/contours-communes.js
+++ b/lib/util/contours-communes.js
@@ -1,3 +1,5 @@
+const {writeFile} = require('node:fs/promises')
+const path = require('node:path')
 const got = require('got')
 const {keyBy} = require('lodash')
 
@@ -8,10 +10,24 @@ async function getRemoteFeatures(url) {
   return response.body.features
 }
 
-async function prepareContoursCommunes() {
-  const communesFeatures = await getRemoteFeatures('http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/2023/geojson/communes-100m.geojson')
+async function createContoursCommunesJson() {
+  const url = process.env.URL_CONTOURS_COMMUNES || 'http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/2023/geojson/communes-100m.geojson'
+  const communesFeatures = await getRemoteFeatures(url)
+  await writeFile(path.join(__dirname, '../..', 'contours-communes.json'), JSON.stringify(communesFeatures, null, 2))
+  console.log('contours-communes.json updated successfully !')
+  return communesFeatures
+}
 
-  communesIndex = keyBy([...communesFeatures], f => f.properties.code)
+async function prepareContoursCommunes() {
+  let contoursCommunes
+  try {
+    contoursCommunes = require('../../contours-communes.json')
+  } catch {
+    console.log('Fetch Contours Communes...')
+    contoursCommunes = await createContoursCommunesJson()
+  } finally {
+    communesIndex = keyBy([...contoursCommunes], f => f.properties.code)
+  }
 }
 
 function getContourCommune(codeCommune) {
@@ -19,6 +35,7 @@ function getContourCommune(codeCommune) {
 }
 
 module.exports = {
+  createContoursCommunesJson,
   prepareContoursCommunes,
   getContourCommune
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test-unit": "nyc ava --serial",
     "test": "yarn lint && yarn test-unit",
     "start": "node server",
-    "update-cadastre": "node ./scripts/update-communes-cadastre.js"
+    "update-cadastre": "node ./scripts/update-communes-cadastre.js",
+    "update-contours": "node ./scripts/update-contours-communes.js"
   },
   "dependencies": {
     "@ban-team/adresses-util": "^0.9.0",

--- a/scripts/update-contours-communes.js
+++ b/scripts/update-contours-communes.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+require('dotenv').config()
+const {createContoursCommunesJson} = require('../lib/util/contours-communes')
+
+async function updateContoursCommune() {
+  try {
+    await createContoursCommunesJson()
+  } catch (error) {
+    console.error(error)
+    process.exit(1)
+  }
+}
+
+updateContoursCommune()

--- a/server.js
+++ b/server.js
@@ -12,7 +12,7 @@ async function main() {
   const port = process.env.PORT || 5000
 
   await mongo.connect()
-  console.log('Prepare contours communes…')
+
   await prepareContoursCommunes()
 
   app.use(cors({origin: true}))


### PR DESCRIPTION
## Context

La fonction `prepareContoursCommunes` au lancement du serveur peut prendre jusqu'a 30s, car elle charge un geojson je 6000000 de lignes.

## Fonctionnalité

Charger les contoures de communes avec le `scripts/update-contours-communes.js` qui va écrire le geosjon dans le fichier `contours-communes.json` à la racine. Peut être appelé via `yarn update-contours`. Le script est également appelé au démarrage de l'appli si je fichier n'existe pas.
