### PR TITLE
Ajout de l'archivage/restauration des voies/toponymes/numeros

### DIFF
--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -172,6 +172,29 @@ test('update a BaseLocale', async t => {
   t.is(Object.keys(baseLocale).length, 9)
 })
 
+test('update a BaseLocale / numero deleted', async t => {
+  const _id = new mongo.ObjectId()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    nom: 'foo',
+    commune: '27115',
+    emails: ['me@domain.co', 'me2@domain.co'],
+    token: 'coucou',
+    status: 'draft',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01'),
+    _deleted: null
+  })
+  await mongo.db.collection('numeros').insertOne({_bal: _id, numero: 1, _deleted: new Date()})
+
+  return t.throwsAsync(BaseLocale.update(_id, {
+    nom: 'foo2',
+    emails: ['me2@domain.co', 'me3@domain.co'],
+    status: 'ready-to-publish',
+    token: 'hack'
+  }), {message: 'La base locale ne possède aucune adresse'})
+})
+
 test('update a BaseLocale / empty base local', async t => {
   const _id = new mongo.ObjectId()
   await mongo.db.collection('bases_locales').insertOne({
@@ -533,9 +556,11 @@ test('Get all assigned parcelles', async t => {
   await mongo.db.collection('numeros').insertOne({_bal: _id, numero: 1, commune: '54084', parcelles: ['12345000AA0002']})
   await mongo.db.collection('numeros').insertOne({_bal: _id, numero: 2, commune: '54084', parcelles: ['12345000AA0001', '12345000AA0003']})
   await mongo.db.collection('numeros').insertOne({_bal: _id, numero: 3, commune: '54084'})
+  await mongo.db.collection('numeros').insertOne({_bal: _id, numero: 4, _deleted: new Date(), parcelles: ['12345000AA0005', '12345000AA0006']})
   await mongo.db.collection('toponymes').insertOne({_bal: _id, commune: '54084'})
   await mongo.db.collection('toponymes').insertOne({_bal: _id, commune: '54084', parcelles: ['12345000AA0003']})
   await mongo.db.collection('toponymes').insertOne({_bal: _id, commune: '54084', parcelles: ['12345000AA0004', '12345000AA0001']})
+  await mongo.db.collection('toponymes').insertOne({_bal: _id, commune: '54084', parcelles: ['12345000AA0005', '12345000AA0006'], _deleted: new Date()})
 
   const parcelles = await getAssignedParcelles(_id.toString(), '54084')
 
@@ -551,6 +576,7 @@ test('batch baselocale numeros', async t => {
   const idVoieB = new mongo.ObjectId()
   const idNumeroA = new mongo.ObjectId()
   const idNumeroB = new mongo.ObjectId()
+  const idNumeroC = new mongo.ObjectId()
   const referenceDate = new Date('2021-01-01')
 
   await mongo.db.collection('bases_locales').insertOne({
@@ -591,6 +617,18 @@ test('batch baselocale numeros', async t => {
     _created: referenceDate,
     _updated: referenceDate
   })
+  await mongo.db.collection('numeros').insertOne({
+    _id: idNumeroC,
+    _bal: idBal,
+    commune: '12345',
+    voie: idVoieB,
+    numero: 27,
+    positions: [],
+    certifie: false,
+    _created: referenceDate,
+    _updated: referenceDate,
+    _deleted: referenceDate
+  })
 
   await BaseLocale.batchUpdateNumeros(idBal, {certifie: true})
 
@@ -604,6 +642,7 @@ test('batch baselocale numeros', async t => {
   const numeros = await mongo.db.collection('numeros').find({_bal: idBal}).toArray()
   t.is(numeros[0].certifie, true)
   t.is(numeros[1].certifie, true)
+  t.is(numeros[2].certifie, false)
   t.notDeepEqual(numeros[0]._updated, referenceDate)
   t.deepEqual(numeros[1]._updated, referenceDate)
 })

--- a/lib/models/__tests__/numero.mongo.js
+++ b/lib/models/__tests__/numero.mongo.js
@@ -143,6 +143,28 @@ test('create a numero with certifie false', async t => {
   t.is(numero.certifie, false)
 })
 
+test('create a numero / voie deleted', async t => {
+  const _id = new mongo.ObjectId()
+  await mongo.db.collection('voies').insertOne({_id, _deleted: new Date()})
+  return t.throwsAsync(Numero.create(_id, {numero: 42}, {message: 'Voie not found'}))
+})
+
+test('create a numero / toponyme is deleted', async t => {
+  const _idBal = new mongo.ObjectId()
+  const _idVoie = new mongo.ObjectId()
+  const _idToponyme = new mongo.ObjectId()
+
+  await mongo.db.collection('voies').insertOne({_id: _idVoie})
+  await mongo.db.collection('toponymes').insertOne({
+    _id: _idToponyme,
+    _bal: _idBal,
+    nom: 'foo',
+    commune: '12345',
+    _deleted: new Date()
+  })
+  return t.throwsAsync(Numero.create(_idVoie, {numero: 42, toponyme: _idToponyme.toString()}), {message: 'Toponyme not found'})
+})
+
 test('importMany', async t => {
   const idBal = new mongo.ObjectId()
   const idVoie = new mongo.ObjectId()
@@ -265,6 +287,67 @@ test('update a numero / voie null', async t => {
   })
 
   return t.throwsAsync(() => Numero.update(_id, {voie: null}), {message: 'Invalid payload'})
+})
+
+test('update a numero / voie deleted', async t => {
+  const idBal = new mongo.ObjectId()
+  const idVoie = new mongo.ObjectId()
+  const _id = new mongo.ObjectId()
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: idBal
+  })
+  await mongo.db.collection('voies').insertOne({
+    _id: idVoie,
+    _bal: idBal,
+    commune: '12345',
+    _deleted: new Date()
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _id,
+    _bal: idBal,
+    commune: '12345',
+    voie: idVoie,
+    numero: 42,
+    suffixe: 'foo',
+    positions: []
+  })
+
+  return t.throwsAsync(() => Numero.update(_id, {voie: idVoie.toString(), numero: 24}), {message: 'Voie not found'})
+})
+
+test('update a numero / toponyme deleted', async t => {
+  const idBal = new mongo.ObjectId()
+  const idVoie = new mongo.ObjectId()
+  const idToponyme = new mongo.ObjectId()
+  const _id = new mongo.ObjectId()
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: idBal
+  })
+  await mongo.db.collection('voies').insertOne({
+    _id: idVoie,
+    _bal: idBal,
+    commune: '12345',
+  })
+  await mongo.db.collection('toponymes').insertOne({
+    _id: idToponyme,
+    _bal: idBal,
+    nom: 'foo',
+    commune: '12345',
+    _deleted: new Date()
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _id,
+    _bal: idBal,
+    commune: '12345',
+    voie: idVoie,
+    numero: 42,
+    suffixe: 'foo',
+    positions: []
+  })
+
+  return t.throwsAsync(() => Numero.update(_id, {voie: idVoie.toString(), toponyme: idToponyme.toString()}), {message: 'Toponyme not found'})
 })
 
 test('update a numero / no suffixe', async t => {
@@ -502,6 +585,47 @@ test('update a numero / change toponyme', async t => {
   t.deepEqual(numero.toponyme, idToponymeB)
 })
 
+test('update a numero / numero deleted', async t => {
+  const idBal = new mongo.ObjectId()
+  const idVoie = new mongo.ObjectId()
+  const _id = new mongo.ObjectId()
+  const referenceDate = new Date('2021-01-01')
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: idBal,
+    _updated: referenceDate
+  })
+  await mongo.db.collection('voies').insertOne({
+    _id: idVoie,
+    _bal: idBal,
+    commune: '12345',
+    _updated: referenceDate
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _id,
+    _bal: idBal,
+    commune: '12345',
+    voie: idVoie,
+    numero: 42,
+    positions: [],
+    certifie: false,
+    _created: referenceDate,
+    _updated: referenceDate,
+    _deleted: referenceDate,
+  })
+
+  return t.throwsAsync(Numero.update(_id, {
+    numero: 42,
+    voie: idVoie.toString(),
+    parcelles: [],
+    positions: [{
+      point: {type: 'Point', coordinates: [0, 0]},
+      source: 'source',
+      type: 'entrée'
+    }]
+  }), {message: 'Numero not found'})
+})
+
 test('update a numero / not found', t => {
   const _id = new mongo.ObjectId()
   return t.throwsAsync(() => Numero.update(_id, {numero: 42}), {message: 'Numero not found'})
@@ -539,6 +663,46 @@ test('delete a numero', async t => {
 
   const numero = await mongo.db.collection('numeros').findOne({_id})
   t.falsy(numero)
+
+  const bal = await mongo.db.collection('bases_locales').findOne({_id: idBal})
+  t.notDeepEqual(referenceDate, bal._updated)
+
+  const voie = await mongo.db.collection('voies').findOne({_id: idVoie})
+  t.notDeepEqual(referenceDate, voie._updated)
+})
+
+test('softdelete a numero', async t => {
+  const idBal = new mongo.ObjectId()
+  const idVoie = new mongo.ObjectId()
+  const _id = new mongo.ObjectId()
+  const referenceDate = new Date('2019-01-01')
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: idBal,
+    _updated: referenceDate
+  })
+  await mongo.db.collection('voies').insertOne({
+    _bal: idBal,
+    _id: idVoie,
+    commune: '12345',
+    _updated: referenceDate
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _bal: idBal,
+    voie: idVoie,
+    _id,
+    commune: '12345',
+    numero: 42,
+    suffixe: 'foo',
+    positions: [],
+    _created: referenceDate,
+    _updated: referenceDate
+  })
+
+  await Numero.softRemove(_id)
+
+  const numero = await mongo.db.collection('numeros').findOne({_id})
+  t.not(numero._deleted, null)
 
   const bal = await mongo.db.collection('bases_locales').findOne({_id: idBal})
   t.notDeepEqual(referenceDate, bal._updated)
@@ -616,6 +780,52 @@ test('batch numeros', async t => {
   t.deepEqual(numeros[1]._updated, referenceDate)
 })
 
+test('batch numeros / numero deleted', async t => {
+  const idBal = new mongo.ObjectId()
+  const idVoieA = new mongo.ObjectId()
+  const idVoieB = new mongo.ObjectId()
+  const idNumeroA = new mongo.ObjectId()
+  const referenceDate = new Date('2021-01-01')
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: idBal,
+    _updated: referenceDate
+  })
+  await mongo.db.collection('voies').insertOne({
+    _id: idVoieA,
+    _bal: idBal,
+    commune: '12345',
+    _updated: referenceDate
+  })
+  await mongo.db.collection('voies').insertOne({
+    _id: idVoieB,
+    _bal: idBal,
+    commune: '12345',
+    _updated: referenceDate
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _id: idNumeroA,
+    _bal: idBal,
+    commune: '12345',
+    voie: idVoieA,
+    numero: 21,
+    positions: [],
+    certifie: false,
+    _created: referenceDate,
+    _updated: referenceDate,
+    _deleted: referenceDate
+  })
+
+  const res = await Numero.batchUpdateNumeros(idBal, {
+    numerosIds: [idNumeroA.toString()],
+    changes: {
+      voie: idVoieB.toString(),
+      certifie: true
+    }
+  })
+  t.is(res.modifiedCount, 0)
+})
+
 test('batch numeros / invalid certifie value', async t => {
   const idBal = new mongo.ObjectId()
   const idVoie = new mongo.ObjectId()
@@ -631,4 +841,276 @@ test('batch numeros / invalid certifie value', async t => {
   t.deepEqual(error.validation, {
     certifie: ['Le champ certifie doit être de type "boolean"']
   })
+})
+
+test('batchRemoveNumeros', async t => {
+  const idBal = new mongo.ObjectId()
+  const referenceDate = new Date('2021-01-01')
+  const idNumeroA = new mongo.ObjectId()
+  const idNumeroB = new mongo.ObjectId()
+  const idNumeroC = new mongo.ObjectId()
+
+  await mongo.db.collection('numeros').insertMany([
+    {
+      _id: idNumeroA,
+      _bal: idBal,
+      numero: 42,
+      _created: referenceDate,
+      _updated: referenceDate
+    },
+    {
+      _id: idNumeroB,
+      _bal: idBal,
+      numero: 42,
+      _created: referenceDate,
+      _updated: referenceDate
+    },
+    {
+      _id: idNumeroC,
+      _bal: idBal,
+      numero: 42,
+      _created: referenceDate,
+      _updated: referenceDate,
+      _deleted: referenceDate
+    }
+
+  ])
+  const res = await Numero.batchRemoveNumeros(idBal, {numerosIds: [idNumeroA, idNumeroB, idNumeroC]})
+
+  t.deepEqual(res, {deletedCount: 3})
+  const numeroA = await mongo.db.collection('numeros').findOne({_id: idNumeroA})
+  t.falsy(numeroA)
+  const numeroB = await mongo.db.collection('numeros').findOne({_id: idNumeroB})
+  t.falsy(numeroB)
+})
+
+test('batchSoftRemoveNumeros', async t => {
+  const idBal = new mongo.ObjectId()
+  const referenceDate = new Date('2021-01-01')
+  const idNumeroA = new mongo.ObjectId()
+  const idNumeroB = new mongo.ObjectId()
+  const idNumeroC = new mongo.ObjectId()
+
+  await mongo.db.collection('numeros').insertMany([
+    {
+      _id: idNumeroA,
+      _bal: idBal,
+      numero: 42,
+      _created: referenceDate,
+      _updated: referenceDate
+    },
+    {
+      _id: idNumeroB,
+      _bal: idBal,
+      numero: 42,
+      _created: referenceDate,
+      _updated: referenceDate
+    },
+    {
+      _id: idNumeroC,
+      _bal: idBal,
+      numero: 42,
+      _created: referenceDate,
+      _updated: referenceDate,
+      _deleted: referenceDate
+    }
+
+  ])
+  const res = await Numero.batchSoftRemoveNumeros(idBal, {numerosIds: [idNumeroA, idNumeroB, idNumeroC]})
+
+  t.deepEqual(res, {modifiedCount: 3})
+  const numeroA = await mongo.db.collection('numeros').findOne({_id: idNumeroA})
+  t.not(numeroA._deleted, null)
+  const numeroB = await mongo.db.collection('numeros').findOne({_id: idNumeroB})
+  t.not(numeroB._deleted, null)
+})
+
+test('fetchByToponyme', async t => {
+  const idVoieA = new mongo.ObjectId()
+  const idNumeroA = new mongo.ObjectId()
+  const idNumeroB = new mongo.ObjectId()
+  const idToponyme = new mongo.ObjectId()
+  const referenceDate = new Date('2021-01-01')
+
+  await mongo.db.collection('voies').insertOne({
+    _id: idVoieA,
+    commune: '12345',
+    _updated: referenceDate
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _id: idNumeroA,
+    commune: '12345',
+    voie: idVoieA,
+    numero: 21,
+    toponyme: idToponyme.toString(),
+    _created: referenceDate,
+    _updated: referenceDate
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _id: idNumeroB,
+    commune: '12345',
+    voie: idVoieA,
+    numero: 42,
+    toponyme: idToponyme.toString(),
+    _created: referenceDate,
+    _updated: referenceDate
+  })
+  await mongo.db.collection('toponymes').insertOne({
+    _id: idToponyme,
+    nom: 'foo',
+    commune: '12345'
+  })
+
+  const res = await Numero.fetchByToponyme(idToponyme.toString())
+
+  t.is(res.length, 2)
+  t.deepEqual(res[0].toponyme, idToponyme.toString())
+  t.deepEqual(res[1].toponyme, idToponyme.toString())
+  t.deepEqual(res[0].voie._id, idVoieA)
+  t.deepEqual(res[1].voie._id, idVoieA)
+})
+
+test('fetchByToponyme / numero deleted', async t => {
+  const idVoieA = new mongo.ObjectId()
+  const idNumeroA = new mongo.ObjectId()
+  const idNumeroB = new mongo.ObjectId()
+  const idToponyme = new mongo.ObjectId()
+  const referenceDate = new Date('2021-01-01')
+
+  await mongo.db.collection('voies').insertOne({
+    _id: idVoieA,
+    commune: '12345',
+    _updated: referenceDate
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _id: idNumeroA,
+    commune: '12345',
+    voie: idVoieA,
+    numero: 21,
+    toponyme: idToponyme.toString(),
+    _created: referenceDate,
+    _updated: referenceDate,
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _id: idNumeroB,
+    commune: '12345',
+    voie: idVoieA,
+    numero: 42,
+    toponyme: idToponyme.toString(),
+    _created: referenceDate,
+    _updated: referenceDate,
+    _deleted: referenceDate
+  })
+  await mongo.db.collection('toponymes').insertOne({
+    _id: idToponyme,
+    nom: 'foo',
+    commune: '12345'
+  })
+
+  const res = await Numero.fetchByToponyme(idToponyme.toString())
+
+  t.is(res.length, 1)
+  t.deepEqual(res[0].toponyme, idToponyme.toString())
+  t.deepEqual(res[0].voie._id, idVoieA)
+})
+
+test('batch numeros / voie is deleted', async t => {
+  const idBal = new mongo.ObjectId()
+  const idVoieA = new mongo.ObjectId()
+  const idVoieB = new mongo.ObjectId()
+  const idNumeroA = new mongo.ObjectId()
+  const idNumeroB = new mongo.ObjectId()
+  const referenceDate = new Date('2021-01-01')
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: idBal,
+    _updated: referenceDate
+  })
+  await mongo.db.collection('voies').insertOne({
+    _id: idVoieA,
+    _bal: idBal,
+    commune: '12345',
+    _updated: referenceDate
+  })
+  await mongo.db.collection('voies').insertOne({
+    _id: idVoieB,
+    _bal: idBal,
+    commune: '12345',
+    _updated: referenceDate,
+    _deleted: referenceDate
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _id: idNumeroA,
+    _bal: idBal,
+    commune: '12345',
+    voie: idVoieA,
+    numero: 21,
+    positions: [],
+    certifie: false,
+    _created: referenceDate,
+    _updated: referenceDate
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _id: idNumeroB,
+    _bal: idBal,
+    commune: '12345',
+    voie: idVoieB,
+    numero: 42,
+    positions: [],
+    certifie: true,
+    _created: referenceDate,
+    _updated: referenceDate
+  })
+
+  return t.throwsAsync(Numero.batchUpdateNumeros(idBal, {
+    numerosIds: [idNumeroA.toString(), idNumeroB.toString()],
+    changes: {
+      voie: idVoieB.toString(),
+      certifie: true
+    }
+  }), {message: 'Voie not found'})
+})
+
+test('batch numeros / toponyme is deleted', async t => {
+  const idBal = new mongo.ObjectId()
+  const idVoie = new mongo.ObjectId()
+  const idToponyme = new mongo.ObjectId()
+  const idNumero = new mongo.ObjectId()
+  const referenceDate = new Date('2021-01-01')
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: idBal,
+    _updated: referenceDate
+  })
+  await mongo.db.collection('voies').insertOne({
+    _id: idVoie,
+    _bal: idBal,
+    commune: '12345',
+    _updated: referenceDate
+  })
+  await mongo.db.collection('toponymes').insertOne({
+    _id: idToponyme,
+    _bal: idBal,
+    _updated: referenceDate,
+    _deleted: referenceDate
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _id: idNumero,
+    _bal: idBal,
+    commune: '12345',
+    voie: idVoie,
+    numero: 21,
+    positions: [],
+    certifie: false,
+    _created: referenceDate,
+    _updated: referenceDate
+  })
+
+  return t.throwsAsync(Numero.batchUpdateNumeros(idBal, {
+    numerosIds: [idNumero.toString()],
+    changes: {
+      toponyme: idToponyme.toString(),
+      certifie: true
+    }
+  }), {message: 'Toponyme not found'})
 })

--- a/lib/models/__tests__/toponyme.mongo.js
+++ b/lib/models/__tests__/toponyme.mongo.js
@@ -180,6 +180,37 @@ test('update a Toponyme', async t => {
   t.deepEqual(bal._updated, toponyme._updated)
 })
 
+test('update a Toponyme / toponyme deleted', async t => {
+  const _idBal = new mongo.ObjectId()
+  const _id = new mongo.ObjectId()
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: _idBal,
+    _updated: new Date('2021-01-01')
+  })
+  await mongo.db.collection('toponymes').insertOne({
+    _id,
+    _bal: _idBal,
+    nom: 'foo',
+    commune: '97125',
+    parcelles: [],
+    _deleted: new Date()
+  })
+
+  return t.throwsAsync(Toponyme.update(_id, {
+    nom: 'la Pointe des Châteaux',
+    nomAlt: {
+      gcf: 'Lapwent'
+    },
+    parcelles: ['64284000BI0459', '64284000BI0450'],
+    positions: [{
+      point: {type: 'Point', coordinates: [0, 0]},
+      source: 'source',
+      type: 'entrée'
+    }]
+  }), {message: 'Toponyme not found'})
+})
+
 test('update a Toponyme / with unsupported nomAlt', async t => {
   const _idBal = new mongo.ObjectId()
   const _id = new mongo.ObjectId()
@@ -272,7 +303,8 @@ test('remove a Toponyme', async t => {
 
   await Toponyme.remove(_idToponyme)
 
-  t.falsy(await mongo.db.collection('toponymes').findOne({_id: _idToponyme}))
+  const toponyme = await mongo.db.collection('toponymes').findOne({_id: _idToponyme})
+  t.falsy(toponyme)
 
   const numero = await mongo.db.collection('numeros').findOne({_id: _idNumero})
   t.truthy(numero)
@@ -280,4 +312,98 @@ test('remove a Toponyme', async t => {
 
   const bal = await mongo.db.collection('bases_locales').findOne({_id: _idBal})
   t.notDeepEqual(bal._updated, referenceDate)
+})
+
+test('softRemove a Toponyme', async t => {
+  const _idBal = new mongo.ObjectId()
+  const _idToponyme = new mongo.ObjectId()
+  const _idNumero = new mongo.ObjectId()
+  const referenceDate = new Date('2021-01-01')
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: _idBal,
+    _updated: referenceDate
+  })
+  await mongo.db.collection('toponymes').insertOne({
+    _id: _idToponyme,
+    _bal: _idBal,
+    nom: 'foo',
+    commune: '12345'
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _id: _idNumero,
+    _bal: _idBal,
+    commune: '12345',
+    toponyme: _idToponyme,
+    numero: 42,
+    suffixe: 'foo',
+    positions: [],
+    parcelles: [],
+    _created: referenceDate,
+    _updated: referenceDate
+  })
+
+  await Toponyme.softRemove(_idToponyme)
+
+  const toponyme = await mongo.db.collection('toponymes').findOne({_id: _idToponyme})
+  t.not(toponyme._deleted, null)
+
+  const numero = await mongo.db.collection('numeros').findOne({_id: _idNumero})
+  t.truthy(numero)
+  t.falsy(numero.toponyme)
+
+  const bal = await mongo.db.collection('bases_locales').findOne({_id: _idBal})
+  t.notDeepEqual(bal._updated, referenceDate)
+})
+
+test('restore a Toponyme', async t => {
+  const _idBal = new mongo.ObjectId()
+  const _idToponyme = new mongo.ObjectId()
+  const referenceDate = new Date('2021-01-01')
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: _idBal,
+    _updated: referenceDate
+  })
+  await mongo.db.collection('toponymes').insertOne({
+    _id: _idToponyme,
+    _bal: _idBal,
+    nom: 'foo',
+    commune: '12345',
+    _deleted: referenceDate
+  })
+
+  await Toponyme.restore(_idToponyme)
+
+  const toponyme = await mongo.db.collection('toponymes').findOne({_id: _idToponyme})
+  t.is(toponyme._deleted, null)
+
+  const bal = await mongo.db.collection('bases_locales').findOne({_id: _idBal})
+  t.notDeepEqual(bal._updated, referenceDate)
+})
+
+test('fetchAllDelete Toponyme', async t => {
+  const _idBal = new mongo.ObjectId()
+  const referenceDate = new Date('2021-01-01')
+
+  await mongo.db.collection('toponymes').insertOne({
+    _bal: _idBal,
+    nom: 'foo',
+    commune: '12345',
+    _deleted: referenceDate
+  })
+  await mongo.db.collection('toponymes').insertOne({
+    _bal: _idBal,
+    nom: 'foo',
+    commune: '12345',
+    _deleted: referenceDate
+  })
+  await mongo.db.collection('toponymes').insertOne({
+    _bal: _idBal,
+    nom: 'foo',
+    commune: '12345',
+  })
+
+  const res = await Toponyme.fetchAllDeleted(_idBal)
+  t.is(res.length, 2)
 })

--- a/lib/models/__tests__/voie.mongo.js
+++ b/lib/models/__tests__/voie.mongo.js
@@ -151,6 +151,30 @@ test('update a Voie', async t => {
   t.deepEqual(bal._updated, voie._updated)
 })
 
+test('update a Voie / voie deleted', async t => {
+  const _idBal = new mongo.ObjectId()
+  const _id = new mongo.ObjectId()
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: _idBal,
+    _updated: new Date('2019-01-01')
+  })
+  await mongo.db.collection('voies').insertOne({
+    _id,
+    _bal: _idBal,
+    nom: 'foo',
+    commune: '97125',
+    _deleted: new Date()
+  })
+
+  return t.throwsAsync(Voie.update(_id, {
+    nom: 'la Pointe des Châteaux',
+    nomAlt: {
+      gcf: 'Lapwent'
+    }
+  }), {message: 'Voie not found'})
+})
+
 test('update a Voie / with unsupported nomAlt', async t => {
   const _idBal = new mongo.ObjectId()
   const _id = new mongo.ObjectId()
@@ -204,11 +228,140 @@ test('remove a Voie', async t => {
 
   await Voie.remove(_id)
 
-  t.falsy(await mongo.db.collection('voies').findOne({_id}))
-  t.falsy(await mongo.db.collection('numeros').findOne({voie: _id}))
-
+  const voie = await mongo.db.collection('voies').findOne({_id})
+  t.falsy(voie)
+  const numero = await mongo.db.collection('numeros').findOne({voie: _id})
+  t.falsy(numero)
   const bal = await mongo.db.collection('bases_locales').findOne({_id: _idBal})
   t.notDeepEqual(bal._updated, referenceDate)
+})
+
+test('softremove a Voie', async t => {
+  const _idBal = new mongo.ObjectId()
+  const _id = new mongo.ObjectId()
+  const referenceDate = new Date('2019-01-01')
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: _idBal,
+    _updated: referenceDate
+  })
+  await mongo.db.collection('voies').insertOne({
+    _id,
+    _bal: _idBal,
+    nom: 'foo'
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _bal: _idBal,
+    voie: _id,
+    numero: 1
+  })
+
+  await Voie.softRemove(_id)
+
+  const voie = await mongo.db.collection('voies').findOne({_id})
+  t.not(voie._deleted, null)
+  const numero = await mongo.db.collection('numeros').findOne({voie: _id})
+  t.not(numero._deleted, null)
+  const bal = await mongo.db.collection('bases_locales').findOne({_id: _idBal})
+  t.notDeepEqual(bal._updated, referenceDate)
+})
+
+test('restore a Voie', async t => {
+  const _idBal = new mongo.ObjectId()
+  const _id = new mongo.ObjectId()
+  const _numeroId1 = new mongo.ObjectId()
+  const _numeroId2 = new mongo.ObjectId()
+  const referenceDate = new Date('2019-01-01')
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: _idBal,
+    _updated: referenceDate
+  })
+  await mongo.db.collection('voies').insertOne({
+    _id,
+    _bal: _idBal,
+    nom: 'foo',
+    _deleted: referenceDate
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _id: _numeroId1,
+    _bal: _idBal,
+    voie: _id,
+    numero: 1,
+    _deleted: referenceDate
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _id: _numeroId2,
+    _bal: _idBal,
+    voie: _id,
+    numero: 1,
+    _deleted: referenceDate
+  })
+
+  await Voie.restore(_id, {numerosIds: [_numeroId1]})
+
+  const voie = await mongo.db.collection('voies').findOne({_id})
+  t.is(voie._deleted, null)
+  const numero1 = await mongo.db.collection('numeros').findOne({_id: _numeroId1})
+  t.is(numero1._deleted, null)
+  const numero2 = await mongo.db.collection('numeros').findOne({_id: _numeroId2})
+  t.not(numero2._deleted, null)
+  const bal = await mongo.db.collection('bases_locales').findOne({_id: _idBal})
+  t.notDeepEqual(bal._updated, referenceDate)
+})
+
+test('fetchAllDelete a Voie', async t => {
+  const _idBal = new mongo.ObjectId()
+  const _voieId1 = new mongo.ObjectId()
+  const _voieId2 = new mongo.ObjectId()
+  const referenceDate = new Date('2019-01-01')
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: _idBal,
+    _updated: referenceDate
+  })
+  await mongo.db.collection('voies').insertOne({
+    _id: _voieId1,
+    _bal: _idBal,
+    nom: 'foo',
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _bal: _idBal,
+    voie: _voieId1,
+    numero: 1,
+    _deleted: referenceDate
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _bal: _idBal,
+    voie: _voieId1,
+    numero: 1,
+  })
+  await mongo.db.collection('voies').insertOne({
+    _id: _voieId2,
+    _bal: _idBal,
+    nom: 'foo',
+    _deleted: referenceDate
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _bal: _idBal,
+    voie: _voieId2,
+    numero: 1,
+    _deleted: referenceDate
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _bal: _idBal,
+    voie: _voieId2,
+    numero: 1,
+  })
+  await mongo.db.collection('voies').insertOne({
+    _bal: _idBal,
+    nom: 'foo',
+  })
+
+  const res = await Voie.fetchAllDeleted(_idBal)
+  t.is(res.length, 2)
+  t.is(res[0].numeros.length, 1)
+  t.is(res[1].numeros.length, 1)
 })
 
 test('batch voie numeros', async t => {
@@ -280,6 +433,38 @@ test('batch voie numeros', async t => {
   t.deepEqual(numeros[2]._updated, referenceDate)
 })
 
+test('batch voie numeros / voie deleted', async t => {
+  const idBal = new mongo.ObjectId()
+  const idVoie = new mongo.ObjectId()
+  const idNumeroA = new mongo.ObjectId()
+  const referenceDate = new Date('2021-01-01')
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: idBal,
+    _updated: referenceDate
+  })
+  await mongo.db.collection('voies').insertOne({
+    _id: idVoie,
+    _bal: idBal,
+    commune: '12345',
+    _updated: referenceDate,
+    _deleted: referenceDate
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _id: idNumeroA,
+    _bal: idBal,
+    commune: '12345',
+    voie: idVoie,
+    numero: 21,
+    positions: [],
+    certifie: false,
+    _created: referenceDate,
+    _updated: referenceDate
+  })
+
+  return t.throwsAsync(Voie.batchUpdateNumeros(idVoie, {certifie: true}), {message: 'Voie not found'})
+})
+
 test('batch voie numeros / invalid certifie', async t => {
   const idVoie = new mongo.ObjectId()
 
@@ -318,18 +503,18 @@ test('Convert voie to toponyme', async t => {
   t.is(toponyme.commune, '27115')
   t.deepEqual(toponyme.positions, [])
   t.deepEqual(toponyme.parcelles, [])
-  const voieExist = await mongo.db.collection('voies').findOne({_bal: idSourceBAL})
-  t.is(voieExist, null)
+  const voie = await mongo.db.collection('voies').findOne({_bal: idSourceBAL})
+  t.falsy(voie)
 })
 
-test('Convert voie to toponyme fail voie', async t => {
+test('Convert voie to toponyme / without voie', async t => {
   const error = await t.throwsAsync(() =>
     Voie.convertToToponyme('xxxx')
   )
   t.is(error.message, 'Voie not found')
 })
 
-test('Convert voie to toponyme fail numero', async t => {
+test('Convert voie to toponyme / has numero', async t => {
   // CREATE VOIE
   const idVoie = new mongo.ObjectId()
   await mongo.db.collection('voies').insertOne({
@@ -346,3 +531,26 @@ test('Convert voie to toponyme fail numero', async t => {
   t.is(error.message, 'Voie has numero(s)')
 })
 
+test('Convert voie to toponyme / voie deleted', async t => {
+  const idSourceBAL = new mongo.ObjectId()
+  // CREATE BAL
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: idSourceBAL,
+    _updated: new Date('2019-01-01'),
+    commune: '27115',
+  })
+  // CREATE VOIE
+  const idVoie = new mongo.ObjectId()
+  await mongo.db.collection('voies').insertOne({
+    _id: idVoie,
+    _bal: idSourceBAL,
+    commune: '27115',
+    nom: 'Voie To Toponyme',
+    nomAlt: {bre: 'brasil'},
+    trace: {type: 'LineString', coordinates: []},
+    typeNumerotation: 'metrique',
+    _deleted: new Date()
+  })
+  // RUN CONVERT TO TOPONYME
+  return t.throwsAsync(Voie.convertToToponyme(idVoie), {message: 'Voie not found'})
+})

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -200,7 +200,7 @@ async function update(id, payload) {
     throw new Error('La base locale a été publiée, son statut ne peut plus être changé')
   }
 
-  const numeroCount = await mongo.db.collection('numeros').countDocuments({_bal: mongo.parseObjectID(id)})
+  const numeroCount = await mongo.db.collection('numeros').countDocuments({_bal: mongo.parseObjectID(id), _deleted: null})
   if (numeroCount === 0 && baseLocaleChanges.status === 'ready-to-publish') {
     throw createHttpError(412, 'La base locale ne possède aucune adresse')
   }
@@ -363,16 +363,16 @@ async function cleanContent(id, query = {}) {
 }
 
 async function exportAsCsv(id) {
-  const voies = await mongo.db.collection('voies').find({_bal: mongo.parseObjectID(id)}).toArray()
-  const toponymes = await mongo.db.collection('toponymes').find({_bal: mongo.parseObjectID(id)}).toArray()
-  const numeros = await mongo.db.collection('numeros').find({_bal: mongo.parseObjectID(id)}).toArray()
+  const voies = await mongo.db.collection('voies').find({_bal: mongo.parseObjectID(id), _deleted: null}).toArray()
+  const toponymes = await mongo.db.collection('toponymes').find({_bal: mongo.parseObjectID(id), _deleted: null}).toArray()
+  const numeros = await mongo.db.collection('numeros').find({_bal: mongo.parseObjectID(id), _deleted: null}).toArray()
   return adressesToCsv({voies, toponymes, numeros})
 }
 
 async function streamToGeoJSON(id) {
-  const voiesCursor = mongo.db.collection('voies').find({_bal: id})
-  const numerosCursor = mongo.db.collection('numeros').find({_bal: id, 'positions.point': {$exists: true}})
-  const toponymesCursor = mongo.db.collection('toponymes').find({_bal: id})
+  const voiesCursor = mongo.db.collection('voies').find({_bal: id, _deleted: null})
+  const numerosCursor = mongo.db.collection('numeros').find({_bal: id, 'positions.point': {$exists: true}, _deleted: null})
+  const toponymesCursor = mongo.db.collection('toponymes').find({_bal: id, _deleted: null})
   return transformToGeoJSON({voiesCursor, numerosCursor, toponymesCursor})
 }
 
@@ -620,10 +620,10 @@ async function publishedBasesLocalesStats(codesCommunes = null) {
   const publishedBasesLocalesIds = await mongo.db.collection('bases_locales')
     .distinct('_id', basesLocalesQuery)
 
-  const nbVoies = await mongo.db.collection('voies').countDocuments({_bal: {$in: publishedBasesLocalesIds}})
-  const nbLieuxDits = await mongo.db.collection('toponymes').countDocuments({_bal: {$in: publishedBasesLocalesIds}})
-  const nbNumeros = await mongo.db.collection('numeros').countDocuments({_bal: {$in: publishedBasesLocalesIds}})
-  const nbNumerosCertifies = await mongo.db.collection('numeros').countDocuments({_bal: {$in: publishedBasesLocalesIds}, certifie: true})
+  const nbNumeros = await mongo.db.collection('numeros').countDocuments({_bal: {$in: publishedBasesLocalesIds}, _deleted: null})
+  const nbNumerosCertifies = await mongo.db.collection('numeros').countDocuments({_bal: {$in: publishedBasesLocalesIds}, certifie: true, _deleted: null})
+  const nbVoies = await mongo.db.collection('voies').countDocuments({_bal: {$in: publishedBasesLocalesIds}, _deleted: null})
+  const nbLieuxDits = await mongo.db.collection('toponymes').countDocuments({_bal: {$in: publishedBasesLocalesIds}, _deleted: null})
 
   return {
     nbCommunes: publishedBasesLocalesIds.length,
@@ -650,8 +650,8 @@ async function basesLocalesRecovery(userEmail, baseLocaleId) {
 }
 
 async function getAssignedParcelles(balId) {
-  const numeroWithParcelles = await mongo.db.collection('numeros').distinct('parcelles', {_bal: mongo.parseObjectID(balId)})
-  const toponymesWithParcelles = await mongo.db.collection('toponymes').distinct('parcelles', {_bal: mongo.parseObjectID(balId)})
+  const numeroWithParcelles = await mongo.db.collection('numeros').distinct('parcelles', {_bal: mongo.parseObjectID(balId), _deleted: null})
+  const toponymesWithParcelles = await mongo.db.collection('toponymes').distinct('parcelles', {_bal: mongo.parseObjectID(balId), _deleted: null})
 
   const parcelles = [
     ...numeroWithParcelles,
@@ -668,7 +668,8 @@ async function batchUpdateNumeros(idBal, changes) {
   const {modifiedCount} = await mongo.db.collection('numeros').updateMany({
     $and: [
       {_bal: mongo.parseObjectID(idBal)},
-      {certifie: {$ne: Boolean(certifie)}}
+      {certifie: {$ne: Boolean(certifie)}},
+      {_deleted: null}
     ]
   }, {
     $set: {certifie: Boolean(certifie), _updated: now}
@@ -678,7 +679,8 @@ async function batchUpdateNumeros(idBal, changes) {
     const updatedVoies = await mongo.db.collection('numeros').distinct('voie', {
       _bal: mongo.parseObjectID(idBal),
       certifie: {$eq: certifie},
-      _updated: now
+      _updated: now,
+      _deleted: null
     })
     const voieIds = updatedVoies.map(id => mongo.parseObjectID(id))
 

--- a/lib/models/numero.js
+++ b/lib/models/numero.js
@@ -109,7 +109,10 @@ const batchUpdateSchema = {
 async function create(idVoie, payload) {
   const numero = await validPayload(payload, createSchema)
 
-  const voie = await mongo.db.collection('voies').findOne({_id: mongo.parseObjectID(idVoie)})
+  const voie = await mongo.db.collection('voies').findOne({
+    _id: mongo.parseObjectID(idVoie),
+    _deleted: null
+  })
 
   if (!voie) {
     throw new Error('Voie not found')
@@ -129,7 +132,8 @@ async function create(idVoie, payload) {
 
   if (numero.toponyme) {
     const toponyme = await mongo.db.collection('toponymes').findOne({
-      _id: mongo.parseObjectID(numero.toponyme)
+      _id: mongo.parseObjectID(numero.toponyme),
+      _deleted: null
     })
 
     if (!toponyme) {
@@ -211,7 +215,8 @@ async function update(id, payload) {
 
   if (numeroChanges.voie) {
     const voie = await mongo.db.collection('voies').findOne({
-      _id: mongo.parseObjectID(numeroChanges.voie)
+      _id: mongo.parseObjectID(numeroChanges.voie),
+      _deleted: null
     })
 
     if (!voie) {
@@ -223,7 +228,8 @@ async function update(id, payload) {
 
   if (numeroChanges.toponyme) {
     const toponyme = await mongo.db.collection('toponymes').findOne({
-      _id: mongo.parseObjectID(numeroChanges.toponyme)
+      _id: mongo.parseObjectID(numeroChanges.toponyme),
+      _deleted: null
     })
 
     if (!toponyme) {
@@ -240,7 +246,7 @@ async function update(id, payload) {
   mongo.decorateModification(numeroChanges)
 
   const {value} = await mongo.db.collection('numeros').findOneAndUpdate(
-    {_id: mongo.parseObjectID(id)},
+    {_id: mongo.parseObjectID(id), _deleted: null},
     {$set: numeroChanges},
     {returnDocument: 'after'}
   )
@@ -262,11 +268,11 @@ async function fetchOne(id) {
 }
 
 async function fetchAll(idVoie) {
-  return mongo.db.collection('numeros').find({voie: idVoie}).sort({numero: 1}).toArray()
+  return mongo.db.collection('numeros').find({voie: idVoie, _deleted: null}).sort({numero: 1}).toArray()
 }
 
 async function fetchByToponyme(id) {
-  const numerosWithToponyme = await mongo.db.collection('numeros').find({toponyme: id}).toArray()
+  const numerosWithToponyme = await mongo.db.collection('numeros').find({toponyme: id, _deleted: null}).toArray()
   const voiesIds = uniqBy(numerosWithToponyme.map(n => n.voie), voieId => voieId.toString())
   const voies = await mongo.db.collection('voies').find({_id: {$in: voiesIds}}).toArray()
 
@@ -282,6 +288,29 @@ async function fetchByToponyme(id) {
   })
 
   return numerosToponymeWithNomVoie
+}
+
+async function softRemove(id) {
+  const now = new Date()
+  const {value} = await mongo.db.collection('numeros').findOneAndUpdate(
+    {_id: mongo.parseObjectID(id)},
+    {$set: {
+      _deleted: now,
+      _updated: now
+    }},
+    {returnDocument: 'after'}
+  )
+
+  if (!value) {
+    throw new Error('Numero not found')
+  }
+
+  await Promise.all([
+    mongo.touchDocument('bases_locales', value._bal, now),
+    mongo.touchDocument('voies', value.voie, now)
+  ])
+
+  return value
 }
 
 async function remove(id) {
@@ -328,7 +357,8 @@ async function batchUpdateNumeros(idBal, body) {
   if (voie) {
     const voieRequested = await mongo.db.collection('voies').findOne({
       _id: mongo.parseObjectID(voie),
-      _bal: idBal
+      _bal: idBal,
+      _deleted: null
     })
 
     if (!voieRequested) {
@@ -339,7 +369,8 @@ async function batchUpdateNumeros(idBal, body) {
   if (toponyme) {
     const toponymeRequested = await mongo.db.collection('toponymes').findOne({
       _id: mongo.parseObjectID(toponyme),
-      _bal: idBal
+      _bal: idBal,
+      _deleted: null
     })
 
     if (!toponymeRequested) {
@@ -399,6 +430,7 @@ async function batchUpdateNumeros(idBal, body) {
 
   const {modifiedCount} = await mongo.db.collection('numeros').updateMany({
     _id: {$in: numeros},
+    _deleted: null,
     $or: batchConditions
   }, {$set: {...batchChanges, _updated: now}})
 
@@ -408,20 +440,61 @@ async function batchUpdateNumeros(idBal, body) {
     const updatedVoies = await mongo.db.collection('numeros').distinct('voie', {
       _id: {$in: numeros},
       _bal: idBal,
-      _updated: now
+      _updated: now,
+      _deleted: null,
     })
 
     // We update Voie._updated when older than 'now'
     await mongo.db.collection('voies').updateMany({
       _id: {$in: updatedVoies},
       _updated: {$lt: now}
-    }, {$set: {_updated: now}})
+    },
+    {$set: {
+      _updated: now
+    }})
 
     // And now we update BaseLocale._updated
     await mongo.touchDocument('bases_locales', idBal, now)
   }
 
   return {changes: {voie, certifie, positionType, toponyme, comment}, modifiedCount}
+}
+
+async function batchSoftRemoveNumeros(idBal, body) {
+  const {numerosIds} = body
+  const numeros = numerosIds.map(id => {
+    const objectID = mongo.parseObjectID(id)
+
+    if (!objectID) {
+      throw createError(400, 'Identifiant incorrect')
+    }
+
+    return objectID
+  })
+
+  const voieIds = await mongo.db.collection('numeros').distinct('voie', {
+    _id: {$in: numeros},
+    _bal: idBal
+  })
+
+  const now = new Date()
+  const {modifiedCount} = await mongo.db.collection('numeros').updateMany(
+    {
+      _id: {$in: numeros},
+      _bal: idBal
+    },
+    {$set: {
+      _deleted: now,
+      _updated: now
+    }}
+  )
+
+  await Promise.all([
+    mongo.touchDocument('bases_locales', idBal),
+    mongo.touchDocumentWithManyIds('voies', voieIds)
+  ])
+
+  return {modifiedCount}
 }
 
 async function batchRemoveNumeros(idBal, body) {
@@ -467,8 +540,10 @@ module.exports = {
   fetchAll,
   fetchByToponyme,
   remove,
+  softRemove,
   expandModel,
   normalizeSuffixe,
   batchUpdateNumeros,
-  batchRemoveNumeros
+  batchRemoveNumeros,
+  batchSoftRemoveNumeros
 }

--- a/lib/models/toponyme.js
+++ b/lib/models/toponyme.js
@@ -77,7 +77,7 @@ async function update(id, payload) {
 
   mongo.decorateModification(toponymeChanges)
   const {value} = await mongo.db.collection('toponymes').findOneAndUpdate(
-    {_id: mongo.parseObjectID(id)},
+    {_id: mongo.parseObjectID(id), _deleted: null},
     {$set: toponymeChanges},
     {returnDocument: 'after'}
   )
@@ -146,8 +146,64 @@ async function fetchOne(id) {
 
 async function fetchAll(idBal) {
   return mongo.db.collection('toponymes').find({
-    _bal: idBal
+    _bal: idBal,
+    _deleted: null
   }).toArray()
+}
+
+async function fetchAllDeleted(idBal) {
+  return mongo.db.collection('toponymes').find({
+    _bal: idBal,
+    _deleted: {$ne: null}
+  }).toArray()
+}
+
+async function restore(toponymeId) {
+  const now = new Date()
+  const {value} = await mongo.db.collection('toponymes').findOneAndUpdate(
+    {_id: mongo.parseObjectID(toponymeId)},
+    {$set: {
+      _deleted: null,
+      _updated: now
+    }},
+    {returnDocument: 'after'}
+  )
+
+  if (!value) {
+    throw new Error('Toponyme not found')
+  }
+
+  await mongo.touchDocument('bases_locales', value._bal, value._updated)
+
+  return value
+}
+
+async function softRemove(id) {
+  // On supprime d'abord les références à ce toponyme
+  const now = new Date()
+  await mongo.db.collection('numeros').updateMany(
+    {toponyme: id},
+    {$set: {
+      toponyme: null,
+      _updated: now
+    }}
+  )
+
+  const {value} = await mongo.db.collection('toponymes').findOneAndUpdate(
+    {_id: mongo.parseObjectID(id)},
+    {$set: {
+      _deleted: now,
+      _updated: now
+    }},
+    {returnDocument: 'after'}
+  )
+
+  if (value) {
+    const now = new Date()
+    await mongo.touchDocument('bases_locales', value._bal, now)
+  }
+
+  return value
 }
 
 async function remove(id) {
@@ -175,5 +231,8 @@ module.exports = {
   updateSchema,
   fetchOne,
   fetchAll,
-  remove
+  remove,
+  fetchAllDeleted,
+  restore,
+  softRemove
 }

--- a/lib/models/voie.js
+++ b/lib/models/voie.js
@@ -1,3 +1,4 @@
+const {groupBy, keys, forEach} = require('lodash')
 const {getFilteredPayload, addError} = require('../util/payload')
 const mongo = require('../util/mongo')
 const {validPayload} = require('../util/payload')
@@ -150,7 +151,7 @@ async function update(id, payload) {
 
   mongo.decorateModification(voieChanges)
   const {value} = await mongo.db.collection('voies').findOneAndUpdate(
-    {_id: mongo.parseObjectID(id)},
+    {_id: mongo.parseObjectID(id), _deleted: null},
     {$set: voieChanges},
     {returnDocument: 'after'}
   )
@@ -170,8 +171,106 @@ async function fetchOne(id) {
 
 async function fetchAll(idBal) {
   return mongo.db.collection('voies').find({
-    _bal: idBal
+    _bal: idBal,
+    _deleted: null
   }).toArray()
+}
+
+async function fetchAllDeleted(idBal) {
+  const numerosDeleted = await mongo.db.collection('numeros').find({
+    _bal: idBal,
+    _deleted: {$ne: null}
+  }).toArray()
+
+  const numerosByVoieId = groupBy(numerosDeleted, 'voie')
+  const voies = await mongo.db.collection('voies').find({
+    _bal: idBal,
+    $or: [
+      {_id: {$in: keys(numerosByVoieId).map(id => mongo.parseObjectID(id))}},
+      {_deleted: {$ne: null}}
+    ]
+  }).toArray()
+
+  forEach(voies, voie => {
+    voie.numeros = numerosByVoieId[voie._id] || []
+  })
+  return voies
+}
+
+async function restore(voieId, body) {
+  const {numerosIds} = body
+  const numeros = numerosIds.map(id => {
+    const objectID = mongo.parseObjectID(id)
+
+    if (!objectID) {
+      throw new Error('Identifiant incorrect')
+    }
+
+    return objectID
+  })
+
+  const now = new Date()
+
+  const {value} = await mongo.db.collection('voies').findOneAndUpdate(
+    {_id: mongo.parseObjectID(voieId)},
+    {$set: {
+      _deleted: null,
+      _updated: now
+    }},
+    {returnDocument: 'after'}
+  )
+
+  if (!value) {
+    throw new Error('Voie not found')
+  }
+
+  const {modifiedCount} = await mongo.db.collection('numeros').updateMany({
+    $and: [
+      {voie: mongo.parseObjectID(voieId)},
+      {_id: {$in: numeros}},
+    ]
+  }, {
+    $set: {
+      _deleted: null,
+      _updated: now
+    }
+  })
+
+  if (modifiedCount > 0) {
+    await Promise.all([
+      mongo.touchDocument('bases_locales', value._bal, now),
+    ])
+  }
+
+  return {modifiedCount}
+}
+
+async function softRemove(id) {
+  const now = new Date()
+  const {value} = await mongo.db.collection('voies').findOneAndUpdate(
+    {_id: mongo.parseObjectID(id)},
+    {$set: {
+      _deleted: now,
+      _updated: now
+    }},
+    {returnDocument: 'after'}
+  )
+
+  if (!value) {
+    throw new Error('Voie not found')
+  }
+
+  await mongo.db.collection('numeros').updateMany(
+    {voie: mongo.parseObjectID(id)},
+    {$set: {
+      _deleted: now,
+      _updated: now
+    }}
+  )
+
+  // Update base locales
+  await mongo.touchDocument('bases_locales', value._bal)
+  return value
 }
 
 async function remove(id) {
@@ -186,22 +285,22 @@ async function remove(id) {
   await mongo.touchDocument('bases_locales', value._bal)
 }
 
-async function getVoie(id) {
-  const voie = await mongo.db.collection('voies').findOne({_id: mongo.parseObjectID(id)})
-  const nbNumeros = await mongo.db.collection('numeros').countDocuments({voie: mongo.parseObjectID(id)})
-  const nbNumerosCertifies = await mongo.db.collection('numeros').countDocuments({voie: mongo.parseObjectID(id), certifie: true})
-
-  return {...voie, nbNumeros, nbNumerosCertifies}
-}
-
 async function batchUpdateNumeros(idVoie, changes) {
   const now = new Date()
   const {certifie} = await validPayload(changes, Numero.updateSchema)
 
-  const voie = await mongo.db.collection('voies').findOne({_id: mongo.parseObjectID(idVoie)})
+  const voie = await mongo.db.collection('voies').findOne({
+    _id: mongo.parseObjectID(idVoie),
+    _deleted: null
+  })
+  if (!voie) {
+    throw new Error('Voie not found')
+  }
+
   const {modifiedCount} = await mongo.db.collection('numeros').updateMany({
     $and: [
       {voie: mongo.parseObjectID(idVoie)},
+      {_deleted: null},
       {certifie: {$ne: Boolean(certifie)}}
     ]
   }, {
@@ -219,13 +318,19 @@ async function batchUpdateNumeros(idVoie, changes) {
 }
 
 async function convertToToponyme(idVoie) {
-  const voie = await mongo.db.collection('voies').findOne({_id: mongo.parseObjectID(idVoie)})
+  const voie = await mongo.db.collection('voies').findOne({
+    _id: mongo.parseObjectID(idVoie),
+    _deleted: null
+  })
   if (!voie) {
     throw new Error('Voie not found')
   }
 
   // CHECK VOIE HAS NO NUMERO
-  const numerosCount = await mongo.db.collection('numeros').countDocuments({voie: idVoie})
+  const numerosCount = await mongo.db.collection('numeros').countDocuments({
+    voie: idVoie,
+    _deleted: null
+  })
   if (numerosCount > 0) {
     throw new Error('Voie has numero(s)')
   }
@@ -254,6 +359,8 @@ module.exports = {
   fetchAll,
   remove,
   batchUpdateNumeros,
-  getVoie,
-  convertToToponyme
+  convertToToponyme,
+  fetchAllDeleted,
+  restore,
+  softRemove
 }

--- a/lib/routes/__tests__/numeros.js
+++ b/lib/routes/__tests__/numeros.js
@@ -915,6 +915,51 @@ test.serial('delete a numero', async t => {
   t.falsy(numero)
 })
 
+test.serial('soft-delete a numero', async t => {
+  const _idVoie = new mongo.ObjectId()
+  const _idBal = new mongo.ObjectId()
+  const _id = new mongo.ObjectId()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: _idBal,
+    nom: 'foo',
+    emails: ['me@domain.tld'],
+    commune: '12345',
+    token: 'coucou',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+  await mongo.db.collection('voies').insertOne({
+    _id: _idVoie,
+    _bal: _idBal,
+    commune: '12345',
+    nom: 'voie',
+    code: null,
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _id,
+    _bal: _idBal,
+    commune: '12345',
+    voie: _idVoie,
+    numero: 42,
+    suffixe: null,
+    positions: [],
+    comment: null,
+    toponyme: null,
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+
+  const {status} = await request(getApp())
+    .put(`/numeros/${_id}/soft-delete`)
+    .set({Authorization: 'Token coucou'})
+
+  t.is(status, 200)
+  const numero = await mongo.db.collection('numeros').findOne({_id})
+  t.not(numero._deleted, null)
+})
+
 test.serial('delete a numero / invalid numero', async t => {
   const {status} = await request(getApp())
     .delete('/numeros/42')

--- a/lib/routes/__tests__/toponymes.js
+++ b/lib/routes/__tests__/toponymes.js
@@ -405,6 +405,38 @@ test.serial('delete a toponyme', async t => {
   t.falsy(toponyme)
 })
 
+test.serial('soft-delete a toponyme', async t => {
+  const _idBal = new mongo.ObjectId()
+  const _id = new mongo.ObjectId()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: _idBal,
+    nom: 'foo',
+    emails: ['me@domain.tld'],
+    commune: '12345',
+    token: 'coucou',
+    _created: new Date('2021-01-01'),
+    _updated: new Date('2021-01-01')
+  })
+  await mongo.db.collection('toponymes').insertOne({
+    _id,
+    _bal: _idBal,
+    nom: 'toponyme',
+    commune: '12345',
+    positions: [],
+    parcelles: [],
+    _created: new Date('2021-01-01'),
+    _updated: new Date('2021-01-01')
+  })
+
+  const {status} = await request(getApp())
+    .put(`/toponymes/${_id}/soft-delete`)
+    .set({Authorization: 'Token coucou'})
+
+  t.is(status, 200)
+  const toponyme = await mongo.db.collection('toponymes').findOne({_id})
+  t.not(toponyme._deleted, null)
+})
+
 test.serial('delete a toponyme / invalid toponyme', async t => {
   const {status} = await request(getApp())
     .delete('/toponymes/42')

--- a/lib/routes/__tests__/voies.js
+++ b/lib/routes/__tests__/voies.js
@@ -564,7 +564,38 @@ test.serial('delete a voie', async t => {
 
   t.is(status, 204)
   const voie = await mongo.db.collection('voies').findOne({_id})
-  t.is(voie, null)
+  t.falsy(voie)
+})
+
+test.serial('soft-delete a voie', async t => {
+  const _balId = new mongo.ObjectId()
+  const _id = new mongo.ObjectId()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: _balId,
+    nom: 'foo',
+    emails: ['me@domain.tld'],
+    commune: '12345',
+    token: 'coucou',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+  await mongo.db.collection('voies').insertOne({
+    _id,
+    _bal: _balId,
+    commune: '12345',
+    nom: 'voie',
+    code: null,
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+
+  const {status} = await request(getApp())
+    .put(`/voies/${_id}/soft-delete`)
+    .set({Authorization: 'Token coucou'})
+
+  t.is(status, 200)
+  const voie = await mongo.db.collection('voies').findOne({_id})
+  t.not(voie._deleted, null)
 })
 
 test.serial('delete a voie / without admin token', async t => {

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -209,6 +209,12 @@ app.route('/bases-locales/:baseLocaleId/numeros/batch')
     res.send(batchRemove)
   }))
 
+app.route('/bases-locales/:baseLocaleId/numeros/batch/soft-delete')
+  .put(ensureIsAdmin, w(async (req, res) => {
+    const batchSoftRemove = await Numero.batchSoftRemoveNumeros(req.baseLocale._id, req.body)
+    res.send(batchSoftRemove)
+  }))
+
 app.route('/bases-locales/:baseLocaleId/:token/recovery')
   .get(w(async (req, res) => {
     if (req.baseLocale.token !== req.params.token) {
@@ -320,6 +326,12 @@ app.route('/bases-locales/:baseLocaleId/voies')
     res.send(voiesExpanded)
   }))
 
+app.route('/bases-locales/:baseLocaleId/voies-deleted')
+  .get(w(async (req, res) => {
+    const voiesDeleted = await Voie.fetchAllDeleted(req.baseLocale._id)
+    res.send(voiesDeleted)
+  }))
+
 app.route('/bases-locales/:baseLocaleId/toponymes')
   .post(ensureIsAdmin, w(async (req, res) => {
     const toponyme = await Toponyme.create(req.baseLocale._id, req.body)
@@ -332,6 +344,12 @@ app.route('/bases-locales/:baseLocaleId/toponymes')
       toponymes.map(toponyme => expandModelWithNumeros(toponyme, 'toponyme'))
     )
     res.send(toponymesExpanded)
+  }))
+
+app.route('/bases-locales/:baseLocaleId/toponymes-deleted')
+  .get(w(async (req, res) => {
+    const toponymesDeleted = await Toponyme.fetchAllDeleted(req.baseLocale._id)
+    res.send(toponymesDeleted)
   }))
 
 app.route('/bases-locales/:baseLocaleId/parcelles')
@@ -391,6 +409,18 @@ app.route('/voies/:voieId/convert-to-toponyme')
     res.send(toponyme)
   }))
 
+app.route('/voies/:voieId/soft-delete')
+  .put(ensureIsAdmin, w(async (req, res) => {
+    const voie = await Voie.softRemove(req.voie._id, req.body)
+    res.send(voie)
+  }))
+
+app.route('/voies/:voieId/restore')
+  .put(ensureIsAdmin, w(async (req, res) => {
+    const voie = await Voie.restore(req.voie._id, req.body)
+    res.send(voie)
+  }))
+
 app.route('/numeros/:numeroId')
   .get(w(async (req, res) => {
     if (req.isAdmin) {
@@ -410,6 +440,12 @@ app.route('/numeros/:numeroId')
     res.sendStatus(204)
   }))
 
+app.route('/numeros/:numeroId/soft-delete')
+  .put(ensureIsAdmin, w(async (req, res) => {
+    const numero = await Numero.softRemove(req.numero._id)
+    res.send(numero)
+  }))
+
 app.route('/toponymes/:toponymeId')
   .get(w(async (req, res) => {
     const toponyme = await expandModelWithNumeros(req.toponyme, 'toponyme')
@@ -422,6 +458,18 @@ app.route('/toponymes/:toponymeId')
   .delete(ensureIsAdmin, w(async (req, res) => {
     await Toponyme.remove(req.toponyme._id)
     res.sendStatus(204)
+  }))
+
+app.route('/toponymes/:toponymeId/restore')
+  .put(ensureIsAdmin, w(async (req, res) => {
+    const toponyme = await Toponyme.restore(req.toponyme._id)
+    res.send(toponyme)
+  }))
+
+app.route('/toponymes/:toponymeId/soft-delete')
+  .put(ensureIsAdmin, w(async (req, res) => {
+    const toponyme = await Toponyme.softRemove(req.toponyme._id)
+    res.send(toponyme)
   }))
 
 app.route('/toponymes/:toponymeId/numeros')

--- a/lib/sync/index.js
+++ b/lib/sync/index.js
@@ -124,7 +124,7 @@ async function exec(balId, options = {}) {
     throw createError(412, 'L’habilitation rattachée a expiré')
   }
 
-  const numeroCount = await mongo.db.collection('numeros').countDocuments({_bal: mongo.parseObjectID(balId)})
+  const numeroCount = await mongo.db.collection('numeros').countDocuments({_bal: mongo.parseObjectID(balId), _deleted: null})
   if (numeroCount === 0) {
     throw createError(412, 'La base locale ne possède aucune adresse')
   }

--- a/lib/util/models.js
+++ b/lib/util/models.js
@@ -1,13 +1,21 @@
 const mongo = require('../util/mongo')
 
 async function expandModelWithNumeros(model, idProperty) {
-  const nbNumeros = await mongo.db.collection('numeros').countDocuments({[idProperty]: mongo.parseObjectID(model._id)})
-  const nbNumerosCertifies = await mongo.db.collection('numeros').countDocuments({[idProperty]: mongo.parseObjectID(model._id), certifie: true})
+  const nbNumeros = await mongo.db.collection('numeros').countDocuments({
+    [idProperty]: mongo.parseObjectID(model._id),
+    _deleted: null
+  })
+  const nbNumerosCertifies = await mongo.db.collection('numeros').countDocuments({
+    [idProperty]: mongo.parseObjectID(model._id),
+    certifie: true,
+    _deleted: null
+  })
   const isAllCertified = nbNumeros > 0 && nbNumeros === nbNumerosCertifies
   const commentedNumeros = await mongo.db.collection('numeros').find({
     [idProperty]: mongo.parseObjectID(model._id),
-    comment: {$ne: null}})
-    .project({numero: 1, suffixe: 1, comment: 1}).toArray()
+    comment: {$ne: null},
+    _deleted: null
+  }).project({numero: 1, suffixe: 1, comment: 1}).toArray()
 
   model.nbNumeros = nbNumeros
   model.nbNumerosCertifies = nbNumerosCertifies

--- a/lib/util/mongo.js
+++ b/lib/util/mongo.js
@@ -24,14 +24,17 @@ class Mongo {
 
     await this.db.collection('voies').createIndex({_bal: 1})
     await this.db.collection('voies').createIndex({_bal: 1, commune: 1})
+    await this.db.collection('voies').createIndex({_deleted: 1})
 
     await this.db.collection('toponymes').createIndex({_bal: 1})
     await this.db.collection('toponymes').createIndex({_bal: 1, commune: 1})
+    await this.db.collection('toponymes').createIndex({_deleted: 1})
 
     await this.db.collection('numeros').createIndex({_bal: 1})
     await this.db.collection('numeros').createIndex({_bal: 1, commune: 1})
     await this.db.collection('numeros').createIndex({voie: 1})
     await this.db.collection('numeros').createIndex({toponyme: 1})
+    await this.db.collection('numeros').createIndex({_deleted: 1})
   }
 
   disconnect(force) {


### PR DESCRIPTION
## Context

https://github.com/BaseAdresseNationale/mes-adresses/issues/528
https://github.com/BaseAdresseNationale/mes-adresses/issues/529
https://github.com/BaseAdresseNationale/mes-adresses/issues/772

## Collection

Ajout du champ `_delete` aux collections `numero`, `voie` et `toponyme`

## Fonctionnalité

### base_local
#### Modification
- `update`: `numeroCount` ne retourne que le nombre de `numero` non archivés
- `exportAsCsv`:  export juste les `numero`, `voie` et `toponyme` non archivés
- `streamToGeoJSON`: renvoie un geojson des `numero`, `voie` et `toponyme` non archivés
- `publishedBasesLocalesStats`: renvoie les nombres de `numero`, `voie` et `toponyme` non archivés
- `getAssignedParcelles`: renvoie les parcelles des `numero` et `toponyme` non archivés
- `batchUpdateNumeros`: ne certifie que les `numero` non archivés
#### Creation
- Route GET `/bases-locales/:baseLocaleId/voies-deleted`: Retourne les `voie` archivées avec leurs `numero`
- Route GET `/bases-locales/:baseLocaleId/toponymes-deleted`: Retourne les `toponyme` archivées

### numero
#### Modification
- `create`: Il faut que la `voie` et le `toponyme` ne soit pas archivés
- `update`:  Il faut que la `voie`, le `numero` et le `toponyme` ne soit pas archivés
- `fetchAll`: Retourne tous les `numero` non archivés
- `fetchByToponyme`: Retourne les `numero` non archivés
- `batchUpdateNumeros`:  Il faut que la `voie` et le `toponyme` ne soit pas archivés, n'update pas les `numero` archivés
- `batchRemoveNumeros`: Archive le `numero`
#### Creation
- Route PUT `/numero/:id/soft-delete`: Archive le `numero`

### Toponyme
#### Modification
- `update`: Il faut que le `toponyme` ne soit pas archivés
- `fetchAll`: Retourne les `toponyme` non archivés
#### Creation
- Route `/toponymes/:id/soft-delete`: Archive le `toponyme`
- Route PUT `/toponymes/:id/soft-delete`: Archive le `toponyme`
- Route PUT `/toponymes/:id/restore`: Restaure un `toponyme` archivé

### Voie
#### Modification
- `update`: Il faut que la `voie` ne soit pas archivés
- `fetchAll`: Retourne les `voie` qui ne sont pas archivés
- `batchUpdateNumeros`: Il faut que la `voie` ne soit pas archivés
- `convertToToponyme`: Archive la `voie` au lieu de la supprimer
#### Creation
- Route `/voies/:id/soft-delete`: Archive le `voie`
- Route PUT `/voies/:id/soft-delete`: Archive le `voie`
- Route PUT `/voies/:id/restore`: Restaure une `voie` archivé

### Util
#### Model
- `expandModelWithNumeros`: Retourne les `numero` certifier (ou non) et les commentaires des `numero` non archivé
#### Mongo
- Ajout d`index sur les champs `_deleted` de `voie`, `toponyme` et `numero`

## PR FRONT:
https://github.com/BaseAdresseNationale/mes-adresses/pull/783