### PR TITLE
Remplacer GeoJson par Tuiles Vectorielle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,4 +115,7 @@ typings/
 # Contours Communes
 contours-communes.json
 
+#pm2
+ecosystem.json
+
 # End of https://www.gitignore.io/api/node,macos

--- a/lib/export/__tests__/geojson.js
+++ b/lib/export/__tests__/geojson.js
@@ -1,100 +1,186 @@
 const test = require('ava')
-const {numeroVoieToAdresseFeature} = require('../geojson')
+const randomColor = require('randomcolor')
+const {voiesLineStringsToGeoJSON, voiesPointsToGeoJSON, numerosPointsToGeoJSON} = require('../geojson')
+const mongo = require('../../util/mongo')
 
-test('numeroVoieToAdresseFeature', t => {
-  const numero = {
-    _bal: 'bal',
-    _id: 'foo',
-    voie: 'bar',
-    toponyme: '_toponyme',
-    nomToponyme: null,
-    commune: '12345',
-    numero: 12,
-    suffixe: 'ter',
-    source: 'Mairie',
-    positions: [
-      {
-        type: 'entrée',
-        point: {type: 'Point', coordinates: [4, 5]}
-      }
-    ],
-    parcelles: ['12345666AA', '12345666BB'],
-    certifie: true
+test('voiesLineStringsToGeoJSON', t => {
+  const trace = {
+    type: 'LineString',
+    coordinates: [[-122.09, 37.42], [-122.08, 37.43]]
   }
-  const voie = {
-    _bal: 'bal',
-    _id: 'bar',
-    code: 'A123',
-    nom: 'rue de la gare',
-    commune: '12345',
-    source: 'Métropole'
-  }
-  t.deepEqual(numeroVoieToAdresseFeature(numero, voie), {
-    type: 'Feature',
-    geometry: {type: 'Point', coordinates: [4, 5]},
-    properties: {
-      type: 'adresse',
-      idNumero: 'foo',
-      nomVoie: 'rue de la gare',
-      idVoie: 'bar',
-      idToponyme: '_toponyme',
-      nomToponyme: null,
-      numero: 12,
-      suffixe: 'ter',
-      typePosition: 'entrée',
-      parcelles: ['12345666AA', '12345666BB'],
-      certifie: true
-    }
+  const voies = [
+    {
+      _id: new mongo.ObjectId(),
+      nom: 'voie1',
+      trace,
+      typeNumerotation: 'metrique'
+    },
+  ]
+  const color = randomColor({
+    luminosity: 'dark',
+    seed: voies[0]._id.toHexString()
   })
+  const funcRes = voiesLineStringsToGeoJSON(voies)
+  const expectedRes = {
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        geometry: trace,
+        properties: {
+          id: voies[0]._id.toHexString(),
+          type: 'voie-trace',
+          nom: voies[0].nom,
+          color,
+          originalGeometry: trace
+        }
+      }
+    ]
+  }
+  t.deepEqual(funcRes, expectedRes)
 })
 
-test('numeroVoieToAdresseFeature with toponyme', t => {
-  const numero = {
-    _bal: 'bal',
-    _id: 'foo',
-    voie: 'bar',
-    toponyme: '_toponyme',
-    nomToponyme: 'le moulin',
-    commune: '12345',
-    numero: 12,
-    suffixe: 'ter',
-    source: 'Mairie',
-    positions: [
-      {
-        type: 'entrée',
-        point: {type: 'Point', coordinates: [4, 5]}
-      }
-    ],
-    parcelles: ['12345666AA', '12345666BB'],
-    certifie: true
+test('voiesPointsToGeoJSON', t => {
+  const trace = {
+    type: 'LineString',
+    coordinates: [[-122.09, 37.42], [-122.08, 37.43]]
   }
-  const voie = {
-    _bal: 'bal',
-    _id: 'bar',
-    code: 'A123',
-    nom: 'rue de la gare',
-    commune: '12345',
-    source: 'Métropole'
-  }
-  const toponyme = {
-    _id: '_toponyme',
-    nom: 'le moulin'
-  }
-  t.deepEqual(numeroVoieToAdresseFeature(numero, voie, toponyme), {
-    type: 'Feature',
-    geometry: {type: 'Point', coordinates: [4, 5]},
-    properties: {
-      type: 'adresse',
-      idNumero: 'foo',
-      nomVoie: 'rue de la gare',
-      idVoie: 'bar',
-      idToponyme: '_toponyme',
-      nomToponyme: 'le moulin',
-      numero: 12,
-      suffixe: 'ter',
-      typePosition: 'entrée',
-      parcelles: ['12345666AA', '12345666BB'],
-      certifie: true
+
+  const voies = [
+    {
+      _id: new mongo.ObjectId(),
+      nom: 'voie1',
+      trace,
+      typeNumerotation: 'metrique',
+      centroid: {geometry: [0, 0]}
+    },
+    {
+      _id: new mongo.ObjectId(),
+      nom: 'voie2',
+      centroid: {geometry: [1, 1]}
     }
+  ]
+
+  const color = randomColor({
+    luminosity: 'dark',
+    seed: voies[0]._id.toHexString()
   })
+
+  const color2 = randomColor({
+    luminosity: 'dark',
+    seed: voies[1]._id.toHexString()
+  })
+
+  const funcRes = voiesPointsToGeoJSON(voies)
+  const expectedRes = {
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        geometry: [0, 0],
+        properties: {
+          id: voies[0]._id.toHexString(),
+          type: 'voie',
+          nom: voies[0].nom,
+          color,
+        }
+      },
+      {
+        type: 'Feature',
+        geometry: [1, 1],
+        properties: {
+          id: voies[1]._id.toHexString(),
+          type: 'voie',
+          nom: voies[1].nom,
+          color: color2,
+        }
+      }
+    ]
+  }
+  t.deepEqual(funcRes, expectedRes)
+})
+
+test('numerosPointsToGeoJSON', t => {
+  const voie1 = new mongo.ObjectId()
+  const voie2 = new mongo.ObjectId()
+  const toponyme1 = new mongo.ObjectId()
+
+  const numeros = [
+    {
+      _id: new mongo.ObjectId(),
+      voie: voie1,
+      numero: 1,
+      suffixe: 'ter',
+      toponyme: toponyme1,
+      positions: [{
+        type: 'entrée',
+        point: {
+          type: 'Point',
+          coordinates: [1, 1]
+        }
+      }],
+      parcelles: ['1', '2', '3'],
+      certifie: true,
+    },
+    {
+      _id: new mongo.ObjectId(),
+      voie: voie2,
+      numero: 2,
+      suffixe: 'bis',
+      positions: [{
+        type: 'entrée',
+        point: {
+          type: 'Point',
+          coordinates: [2, 2]
+        }
+      }],
+    },
+  ]
+  const color1 = randomColor({
+    luminosity: 'dark',
+    seed: voie1.toHexString()
+  })
+  const color2 = randomColor({
+    luminosity: 'dark',
+    seed: voie2.toHexString()
+  })
+  const funcRes = numerosPointsToGeoJSON(numeros)
+  const expectedRes = {
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        geometry: numeros[0].positions[0].point,
+        properties: {
+          type: 'adresse',
+          id: numeros[0]._id.toHexString(),
+          idVoie: voie1.toHexString(),
+          idToponyme: toponyme1.toHexString(),
+          numero: numeros[0].numero,
+          suffixe: numeros[0].suffixe,
+          typePosition: 'entrée',
+          parcelles: numeros[0].parcelles,
+          certifie: numeros[0].certifie,
+          color: color1,
+        }
+      },
+      {
+        type: 'Feature',
+        geometry: numeros[1].positions[0].point,
+        properties: {
+          type: 'adresse',
+          id: numeros[1]._id.toHexString(),
+          idVoie: voie2.toHexString(),
+          idToponyme: null,
+          numero: numeros[1].numero,
+          suffixe: numeros[1].suffixe,
+          typePosition: 'entrée',
+          parcelles: numeros[1].parcelles,
+          certifie: numeros[1].certifie,
+          color: color2,
+        }
+      },
+    ]
+  }
+  t.deepEqual(funcRes, expectedRes)
 })

--- a/lib/export/geojson.js
+++ b/lib/export/geojson.js
@@ -1,21 +1,7 @@
-const {keyBy, maxBy} = require('lodash')
-const pumpify = require('pumpify')
+const {maxBy} = require('lodash')
+const randomColor = require('randomcolor')
+const turf = require('@turf/turf')
 const {getPositionPriorityByType} = require('@ban-team/adresses-util')
-const {stringify} = require('../util/geojson-stream')
-
-function voieToLineFeature(v) {
-  const properties = {
-    type: 'voie-trace',
-    nom: v.nom,
-    idVoie: v._id
-  }
-
-  return {
-    type: 'Feature',
-    geometry: v.trace,
-    properties
-  }
-}
 
 function getPriorityPosition(positions) {
   if (positions.length === 0) {
@@ -25,54 +11,72 @@ function getPriorityPosition(positions) {
   return maxBy(positions, p => getPositionPriorityByType(p.type))
 }
 
-function numeroVoieToAdresseFeature(n, v, t) {
-  const nomToponyme = t ? t.nom : null
-  const position = getPriorityPosition(n.positions)
-
-  const properties = {
-    type: 'adresse',
-    idNumero: n._id,
-    nomVoie: v.nom,
-    idVoie: v._id,
-    idToponyme: n.toponyme,
-    nomToponyme,
-    numero: n.numero,
-    suffixe: n.suffixe,
-    typePosition: position.type,
-    parcelles: n.parcelles,
-    certifie: n.certifie
-  }
-
-  return {
-    type: 'Feature',
-    geometry: position.point,
-    properties
-  }
+function getColorById(id) {
+  return randomColor({
+    luminosity: 'dark',
+    seed: id.toHexString()
+  })
 }
 
-async function transformToGeoJSON({voiesCursor, numerosCursor, toponymesCursor}) {
-  const voies = await voiesCursor.toArray()
-  const toponymes = await toponymesCursor.toArray()
-  const voiesIndex = keyBy(voies, v => v._id.toHexString())
-  const toponymesIndex = keyBy(toponymes, t => t._id.toHexString())
-
-  const geojsonStream = stringify()
-
-  voies.forEach(v => {
-    const {typeNumerotation, trace} = v
-    if (typeNumerotation === 'metrique' && trace) {
-      geojsonStream.write(voieToLineFeature(v))
+function numeroToPointFeature(n) {
+  const position = getPriorityPosition(n.positions)
+  return turf.feature(
+    position.point,
+    {
+      type: 'adresse',
+      id: n._id.toHexString(),
+      numero: n.numero,
+      suffixe: n.suffixe,
+      typePosition: position.type,
+      parcelles: n.parcelles,
+      certifie: n.certifie,
+      idVoie: n.voie.toHexString(),
+      idToponyme: n.toponyme ? n.toponyme.toHexString() : null,
+      color: getColorById(n.voie)
     }
-  })
-
-  return pumpify(
-    numerosCursor.stream({transform(n) {
-      const v = voiesIndex[n.voie.toHexString()]
-      const t = n.toponyme ? toponymesIndex[n.toponyme.toHexString()] : null
-      return numeroVoieToAdresseFeature(n, v, t)
-    }}),
-    geojsonStream
   )
 }
 
-module.exports = {transformToGeoJSON, numeroVoieToAdresseFeature}
+function voieToLineStringFeature(v) {
+  return turf.feature(
+    v.trace,
+    {
+      id: v._id.toHexString(),
+      type: 'voie-trace',
+      nom: v.nom,
+      originalGeometry: v.trace,
+      color: getColorById(v._id)
+    }
+  )
+}
+
+function voieToPointFeature(v) {
+  return turf.feature(
+    v.centroid.geometry,
+    {
+      id: v._id.toHexString(),
+      type: 'voie',
+      nom: v.nom,
+      color: getColorById(v._id)
+    }
+  )
+}
+
+function voiesPointsToGeoJSON(voies) {
+  return turf.featureCollection(voies.map(n => voieToPointFeature(n)))
+}
+
+function voiesLineStringsToGeoJSON(voies) {
+  return turf.featureCollection(voies.map(n => voieToLineStringFeature(n)))
+}
+
+function numerosPointsToGeoJSON(numeros) {
+  return turf.featureCollection(numeros.map(n => numeroToPointFeature(n)))
+}
+
+module.exports = {
+  voiesPointsToGeoJSON,
+  numerosPointsToGeoJSON,
+  voiesLineStringsToGeoJSON,
+  getPriorityPosition
+}

--- a/lib/models/__tests__/numero.mongo.js
+++ b/lib/models/__tests__/numero.mongo.js
@@ -37,7 +37,7 @@ test('create a numero', async t => {
     positions: []
   })
 
-  const keys = ['_id', '_bal', 'commune', '_updated', '_created', 'voie', 'numero', 'suffixe', 'comment', 'toponyme', 'positions', 'parcelles', 'certifie']
+  const keys = ['_id', '_bal', 'commune', '_updated', '_created', 'voie', 'numero', 'suffixe', 'comment', 'toponyme', 'positions', 'parcelles', 'certifie', 'tiles']
   t.true(keys.every(k => k in numero))
   t.is(Object.keys(numero).length, keys.length)
 
@@ -46,6 +46,63 @@ test('create a numero', async t => {
 
   const voie = await mongo.db.collection('voies').findOne({_id})
   t.deepEqual(numero._created, voie._updated)
+})
+
+test('create a numero with position', async t => {
+  const _id = new mongo.ObjectId()
+  const referenceDate = new Date('2019-01-01')
+
+  await mongo.db.collection('voies').insertOne({
+    _id,
+    _updated: referenceDate
+  })
+  const numero = await Numero.create(_id, {
+    numero: 42,
+    suffixe: 'foo',
+    comment: 'bar',
+    positions: [{
+      source: 'inconnue',
+      type: 'entrée',
+      point: {type: 'Point', coordinates: [1, 1]}
+    }]
+  })
+
+  const keys = ['_id', '_bal', 'commune', '_updated', '_created', 'voie', 'numero', 'suffixe', 'comment', 'toponyme', 'positions', 'parcelles', 'certifie', 'tiles']
+  t.true(keys.every(k => k in numero))
+  t.is(Object.keys(numero).length, keys.length)
+  // CHECK TILE
+  const tiles = [
+    '13/4118/4073',
+    '14/8237/8146',
+    '15/16475/16292',
+    '16/32950/32585',
+    '17/65900/65171',
+    '18/131800/130343',
+    '19/263600/260687'
+  ]
+  t.deepEqual(numero.tiles, tiles)
+  // CHECK VOIE
+  const voie = await mongo.db.collection('voies').findOne({_id})
+  t.deepEqual(numero._created, voie._updated)
+  const centroid = {
+    geometry: {
+      coordinates: [1, 1],
+      type: 'Point',
+    },
+    properties: {},
+    type: 'Feature',
+  }
+  const centroidTiles = [
+    '13/4118/4073',
+    '14/8237/8146',
+    '15/16475/16292',
+    '16/32950/32585',
+    '17/65900/65171',
+    '18/131800/130343',
+    '19/263600/260687'
+  ]
+  t.deepEqual(voie.centroid, centroid)
+  t.deepEqual(voie.centroidTiles, centroidTiles)
 })
 
 test('create a numero / invalid numero type', t => {
@@ -62,7 +119,7 @@ test('create a numero / minimal', async t => {
   await mongo.db.collection('voies').insertOne({_id})
   const numero = await Numero.create(_id, {numero: 42})
 
-  const keys = ['_id', '_bal', 'commune', '_updated', '_created', 'voie', 'numero', 'suffixe', 'positions', 'comment', 'toponyme', 'parcelles', 'certifie']
+  const keys = ['_id', '_bal', 'commune', '_updated', '_created', 'voie', 'numero', 'suffixe', 'positions', 'comment', 'toponyme', 'parcelles', 'certifie', 'tiles']
   t.true(keys.every(k => k in numero))
   t.is(Object.keys(numero).length, keys.length)
 })
@@ -209,6 +266,62 @@ test('importMany', async t => {
   t.true(n55.certifie)
 })
 
+test('importMany with position', async t => {
+  const idBal = new mongo.ObjectId()
+  const idVoie = new mongo.ObjectId()
+
+  await mongo.db.collection('voies').insertOne({
+    _id: idVoie,
+  })
+
+  const numeros = [{
+    numero: 42,
+    voie: idVoie,
+    commune: '55500',
+    suffixe: 'foo',
+    comment: 'bar',
+    positions: [{
+      source: 'inconnue',
+      type: 'entrée',
+      point: {type: 'Point', coordinates: [1, 1]}
+    }]
+  }]
+
+  await Numero.importMany(idBal, numeros, {validate: false})
+  const numeroRes = await mongo.db.collection('numeros').findOne({voie: idVoie})
+  const tiles = [
+    '13/4118/4073',
+    '14/8237/8146',
+    '15/16475/16292',
+    '16/32950/32585',
+    '17/65900/65171',
+    '18/131800/130343',
+    '19/263600/260687'
+  ]
+  t.deepEqual(numeroRes.tiles, tiles)
+  // CHECK VOIE
+  const voie = await mongo.db.collection('voies').findOne({_id: idVoie})
+  const centroid = {
+    geometry: {
+      coordinates: [1, 1],
+      type: 'Point',
+    },
+    properties: {},
+    type: 'Feature',
+  }
+  const centroidTiles = [
+    '13/4118/4073',
+    '14/8237/8146',
+    '15/16475/16292',
+    '16/32950/32585',
+    '17/65900/65171',
+    '18/131800/130343',
+    '19/263600/260687'
+  ]
+  t.deepEqual(voie.centroid, centroid)
+  t.deepEqual(voie.centroidTiles, centroidTiles)
+})
+
 test('update a numero', async t => {
   const idBal = new mongo.ObjectId()
   const idVoie = new mongo.ObjectId()
@@ -225,7 +338,7 @@ test('update a numero', async t => {
     commune: '12345',
     _updated: referenceDate
   })
-  await mongo.db.collection('numeros').insertOne({
+  const numb = {
     _id,
     _bal: idBal,
     commune: '12345',
@@ -236,7 +349,8 @@ test('update a numero', async t => {
     parcelles: [],
     _created: referenceDate,
     _updated: referenceDate
-  })
+  }
+  await mongo.db.collection('numeros').insertOne(numb)
 
   const numero = await Numero.update(_id, {
     numero: 24,
@@ -248,19 +362,79 @@ test('update a numero', async t => {
       type: 'entrée'
     }],
     certifie: true
-  })
+  }, numb)
 
   t.is(numero.numero, 24)
   t.is(numero.suffixe, 'bar')
   t.is(numero.comment, 'Commentaire de numéro 123 !')
   t.is(numero.positions.length, 1)
   t.is(numero.certifie, true)
-  t.is(Object.keys(numero).length, 12)
+  t.is(Object.keys(numero).length, 13)
   t.deepEqual(numero.parcelles, [])
   t.deepEqual(numero.voie, idVoie)
 
   const bal = await mongo.db.collection('bases_locales').findOne({_id: idBal})
   t.notDeepEqual(numero._created, bal._updated)
+})
+
+test('update a numero with position', async t => {
+  const idVoie = new mongo.ObjectId()
+  const _id = new mongo.ObjectId()
+
+  await mongo.db.collection('voies').insertOne({
+    _id: idVoie,
+    commune: '12345',
+  })
+  const numero = {
+    _id,
+    commune: '12345',
+    voie: idVoie,
+    numero: 42,
+    suffixe: 'foo',
+    positions: [],
+  }
+  await mongo.db.collection('numeros').insertOne(numero)
+
+  await Numero.update(_id, {
+    positions: [{
+      source: 'inconnue',
+      type: 'entrée',
+      point: {type: 'Point', coordinates: [1, 1]}
+    }]
+  }, numero)
+
+  const numeroRes = await mongo.db.collection('numeros').findOne({voie: idVoie})
+  const tiles = [
+    '13/4118/4073',
+    '14/8237/8146',
+    '15/16475/16292',
+    '16/32950/32585',
+    '17/65900/65171',
+    '18/131800/130343',
+    '19/263600/260687'
+  ]
+  t.deepEqual(numeroRes.tiles, tiles)
+  // CHECK VOIE
+  const voie = await mongo.db.collection('voies').findOne({_id: idVoie})
+  const centroid = {
+    geometry: {
+      coordinates: [1, 1],
+      type: 'Point',
+    },
+    properties: {},
+    type: 'Feature',
+  }
+  const centroidTiles = [
+    '13/4118/4073',
+    '14/8237/8146',
+    '15/16475/16292',
+    '16/32950/32585',
+    '17/65900/65171',
+    '18/131800/130343',
+    '19/263600/260687'
+  ]
+  t.deepEqual(voie.centroid, centroid)
+  t.deepEqual(voie.centroidTiles, centroidTiles)
 })
 
 test('update a numero / voie null', async t => {
@@ -366,18 +540,19 @@ test('update a numero / no suffixe', async t => {
     commune: '12345',
     _updated: referenceDate
   })
-  await mongo.db.collection('numeros').insertOne({
+  const numb = {
     _id,
     _bal: idBal,
     commune: '12345',
     voie: idVoie,
     numero: 42,
     suffixe: 'foo'
-  })
+  }
+  await mongo.db.collection('numeros').insertOne(numb)
 
   const numero = await Numero.update(_id, {
     numero: 24
-  })
+  }, numb)
 
   t.is(numero.numero, 24)
   t.is(numero.suffixe, 'foo')
@@ -399,17 +574,18 @@ test('update a numero / without suffixe', async t => {
     commune: '12345',
     _updated: referenceDate
   })
-  await mongo.db.collection('numeros').insertOne({
+  const numb = {
     _id,
     _bal: idBal,
     commune: '12345',
     voie: idVoie,
     numero: 42
-  })
+  }
+  await mongo.db.collection('numeros').insertOne(numb)
 
   const numero = await Numero.update(_id, {
     numero: 24
-  })
+  }, numb)
 
   t.is(numero.numero, 24)
   t.is(numero.suffixe, undefined)
@@ -437,7 +613,7 @@ test('update a numero / change voie', async t => {
     commune: '12345',
     _updated: referenceDate
   }])
-  await mongo.db.collection('numeros').insertOne({
+  const numb = {
     _id,
     _bal: idBal,
     commune: '12345',
@@ -448,7 +624,8 @@ test('update a numero / change voie', async t => {
     parcelles: [],
     _created: referenceDate,
     _updated: referenceDate
-  })
+  }
+  await mongo.db.collection('numeros').insertOne(numb)
 
   const numero = await Numero.update(_id, {
     numero: 24,
@@ -461,13 +638,13 @@ test('update a numero / change voie', async t => {
       type: 'entrée'
     }],
     certifie: false
-  })
+  }, numb)
 
   t.is(numero.numero, 24)
   t.is(numero.suffixe, 'bar')
   t.is(numero.comment, 'Commentaire de numéro 123 !')
   t.is(numero.positions.length, 1)
-  t.is(Object.keys(numero).length, 12)
+  t.is(Object.keys(numero).length, 13)
 
   t.deepEqual(numero.voie, idVoieB)
 })
@@ -495,7 +672,7 @@ test('update a numero / add toponyme', async t => {
     nom: 'foo',
     commune: '12345'
   })
-  await mongo.db.collection('numeros').insertOne({
+  const numb = {
     _id,
     _bal: idBal,
     commune: '12345',
@@ -505,7 +682,8 @@ test('update a numero / add toponyme', async t => {
     parcelles: [],
     _created: referenceDate,
     _updated: referenceDate
-  })
+  }
+  await mongo.db.collection('numeros').insertOne(numb)
 
   const numero = await Numero.update(_id, {
     numero: 24,
@@ -517,11 +695,11 @@ test('update a numero / add toponyme', async t => {
       type: 'entrée'
     }],
     certifie: false
-  })
+  }, numb)
 
   t.is(numero.numero, 24)
   t.is(numero.positions.length, 1)
-  t.is(Object.keys(numero).length, 11)
+  t.is(Object.keys(numero).length, 12)
   t.deepEqual(numero.toponyme, idToponyme)
 })
 
@@ -554,7 +732,7 @@ test('update a numero / change toponyme', async t => {
     nom: 'foo',
     commune: '12345'
   }])
-  await mongo.db.collection('numeros').insertOne({
+  const numb = {
     _id,
     _bal: idBal,
     commune: '12345',
@@ -565,7 +743,8 @@ test('update a numero / change toponyme', async t => {
     certifie: false,
     _created: referenceDate,
     _updated: referenceDate
-  })
+  }
+  await mongo.db.collection('numeros').insertOne(numb)
 
   const numero = await Numero.update(_id, {
     numero: 42,
@@ -577,11 +756,11 @@ test('update a numero / change toponyme', async t => {
       source: 'source',
       type: 'entrée'
     }]
-  })
+  }, numb)
 
   t.is(numero.numero, 42)
   t.is(numero.positions.length, 1)
-  t.is(Object.keys(numero).length, 11)
+  t.is(Object.keys(numero).length, 12)
   t.deepEqual(numero.toponyme, idToponymeB)
 })
 
@@ -711,6 +890,64 @@ test('softdelete a numero', async t => {
   t.notDeepEqual(referenceDate, voie._updated)
 })
 
+test('softdelete a numero with position', async t => {
+  const idVoie = new mongo.ObjectId()
+  await mongo.db.collection('voies').insertOne({
+    _id: idVoie,
+    commune: '12345',
+  })
+  const numeros = [
+    {
+      _id: new mongo.ObjectId(),
+      voie: idVoie,
+      commune: '12345',
+      numero: 42,
+      suffixe: 'foo',
+      positions: [{
+        source: 'inconnue',
+        type: 'entrée',
+        point: {type: 'Point', coordinates: [1, 1]}
+      }]
+    },
+    {
+      _id: new mongo.ObjectId(),
+      voie: idVoie,
+      commune: '12345',
+      numero: 42,
+      suffixe: 'foo',
+      positions: [{
+        source: 'inconnue',
+        type: 'entrée',
+        point: {type: 'Point', coordinates: [1, 1]}
+      }]
+    }
+  ]
+
+  await mongo.db.collection('numeros').insertMany(numeros)
+  await Numero.softRemove(numeros[0]._id)
+  // CHECK VOIE
+  const voie = await mongo.db.collection('voies').findOne({_id: idVoie})
+  const centroid = {
+    geometry: {
+      coordinates: [1, 1],
+      type: 'Point',
+    },
+    properties: {},
+    type: 'Feature',
+  }
+  const centroidTiles = [
+    '13/4118/4073',
+    '14/8237/8146',
+    '15/16475/16292',
+    '16/32950/32585',
+    '17/65900/65171',
+    '18/131800/130343',
+    '19/263600/260687'
+  ]
+  t.deepEqual(voie.centroid, centroid)
+  t.deepEqual(voie.centroidTiles, centroidTiles)
+})
+
 test('batch numeros', async t => {
   const idBal = new mongo.ObjectId()
   const idVoieA = new mongo.ObjectId()
@@ -770,7 +1007,7 @@ test('batch numeros', async t => {
   t.notDeepEqual(baseLocale._updated, referenceDate)
 
   const voies = await mongo.db.collection('voies').find({_bal: idBal}).toArray()
-  t.deepEqual(voies[0]._updated, referenceDate)
+  t.notDeepEqual(voies[0]._updated, referenceDate)
   t.notDeepEqual(voies[1]._updated, referenceDate)
 
   const numeros = await mongo.db.collection('numeros').find({_bal: idBal}).toArray()
@@ -1113,4 +1350,127 @@ test('batch numeros / toponyme is deleted', async t => {
       certifie: true
     }
   }), {message: 'Toponyme not found'})
+})
+
+test('batch numeros with positions / change voie', async t => {
+  const idBal = new mongo.ObjectId()
+  const voies = [
+    {_bal: idBal, _id: new mongo.ObjectId()},
+    {_bal: idBal, _id: new mongo.ObjectId()},
+  ]
+  await mongo.db.collection('voies').insertMany(voies)
+
+  const numeros = [
+    {
+      _id: new mongo.ObjectId(),
+      _bal: idBal,
+      voie: voies[0]._id,
+      positions: [{
+        source: 'inconnue',
+        type: 'entrée',
+        point: {type: 'Point', coordinates: [0.5, 0.5]}
+      }]
+    },
+    {
+      _id: new mongo.ObjectId(),
+      _bal: idBal,
+      voie: voies[0]._id,
+      positions: [{
+        source: 'inconnue',
+        type: 'entrée',
+        point: {type: 'Point', coordinates: [1.5, 1.5]}
+      }]
+    }
+  ]
+  await mongo.db.collection('numeros').insertMany(numeros)
+
+  await Numero.batchUpdateNumeros(idBal, {
+    numerosIds: numeros.map(n => n._id.toHexString()),
+    changes: {voie: voies[1]._id.toString()}
+  })
+
+  const voie1 = await mongo.db.collection('voies').findOne({_id: voies[0]._id})
+  t.is(voie1.centroid, null)
+  t.is(voie1.centroidTiles, null)
+  t.is(voie1.traceTiles, null)
+
+  const voie2 = await mongo.db.collection('voies').findOne({_id: voies[1]._id})
+  const centroid = {
+    geometry: {
+      coordinates: [1, 1],
+      type: 'Point',
+    },
+    properties: {},
+    type: 'Feature',
+  }
+  const centroidTiles = [
+    '13/4118/4073',
+    '14/8237/8146',
+    '15/16475/16292',
+    '16/32950/32585',
+    '17/65900/65171',
+    '18/131800/130343',
+    '19/263600/260687'
+  ]
+  t.deepEqual(voie2.centroid, centroid)
+  t.deepEqual(voie2.centroidTiles, centroidTiles)
+})
+
+test('batchSoftRemoveNumeros with positions', async t => {
+  const idBal = new mongo.ObjectId()
+  const voie = {_bal: idBal, _id: new mongo.ObjectId()}
+  await mongo.db.collection('voies').insertOne(voie)
+
+  const numeros = [
+    {
+      _id: new mongo.ObjectId(),
+      _bal: idBal,
+      voie: voie._id,
+      commune: '12345',
+      numero: 42,
+      suffixe: 'foo',
+      positions: [{
+        source: 'inconnue',
+        type: 'entrée',
+        point: {type: 'Point', coordinates: [1, 1]}
+      }]
+    },
+    {
+      _id: new mongo.ObjectId(),
+      _bal: idBal,
+      voie: voie._id,
+      commune: '12345',
+      numero: 42,
+      suffixe: 'foo',
+      positions: [{
+        source: 'inconnue',
+        type: 'entrée',
+        point: {type: 'Point', coordinates: [1, 1]}
+      }]
+    }
+  ]
+  await mongo.db.collection('numeros').insertMany(numeros)
+
+  await Numero.batchSoftRemoveNumeros(idBal, {numerosIds: [numeros[0]._id]})
+
+  const voieRes = await mongo.db.collection('voies').findOne({_id: voie._id})
+  const centroid = {
+    geometry: {
+      coordinates: [1, 1],
+      type: 'Point',
+    },
+    properties: {},
+    type: 'Feature',
+  }
+  const centroidTiles = [
+    '13/4118/4073',
+    '14/8237/8146',
+    '15/16475/16292',
+    '16/32950/32585',
+    '17/65900/65171',
+    '18/131800/130343',
+    '19/263600/260687'
+  ]
+  t.deepEqual(voieRes.centroid, centroid)
+  t.deepEqual(voieRes.centroidTiles, centroidTiles)
 })

--- a/lib/models/__tests__/voie.mongo.js
+++ b/lib/models/__tests__/voie.mongo.js
@@ -37,11 +37,52 @@ test('create a Voie', async t => {
   t.deepEqual(voie.nomAlt, {bre: 'ba r'})
   t.truthy(voie._created)
   t.truthy(voie._updated)
+  t.is(voie.centroid, null)
+  t.is(voie.centroidTiles, null)
+  t.is(voie.traceTiles, null)
 
-  t.is(Object.keys(voie).length, 10)
+  t.is(Object.keys(voie).length, 13)
 
   const bal = await mongo.db.collection('bases_locales').findOne({_id})
   t.deepEqual(voie._created, bal._updated)
+})
+
+test('create a Voie with trace', async t => {
+  const baseLocale = {
+    _id: new mongo.ObjectId(),
+    commune: '12345',
+  }
+  await mongo.db.collection('bases_locales').insertOne(baseLocale)
+  const voie = {
+    nom: 'foo',
+    typeNumerotation: 'metrique',
+    trace: {type: 'LineString', coordinates: [[0.9999, 0.9999], [1.0001, 1.0001]]}
+  }
+  const voieRes = await Voie.create(baseLocale, voie)
+
+  const centroid = {
+    geometry: {
+      coordinates: [1, 1],
+      type: 'Point',
+    },
+    properties: {},
+    type: 'Feature',
+  }
+  const centroidTiles = [
+    '13/4118/4073',
+    '14/8237/8146',
+    '15/16475/16292',
+    '16/32950/32585',
+    '17/65900/65171',
+    '18/131800/130343',
+    '19/263600/260687'
+  ]
+  const traceTiles = [
+    '13/4118/4073'
+  ]
+  t.deepEqual(voieRes.centroid, centroid)
+  t.deepEqual(voieRes.centroidTiles, centroidTiles)
+  t.deepEqual(voieRes.traceTiles, traceTiles)
 })
 
 test('create a Voie / with unsupported nomAlt', async t => {
@@ -149,6 +190,55 @@ test('update a Voie', async t => {
 
   const bal = await mongo.db.collection('bases_locales').findOne({_id: _idBal})
   t.deepEqual(bal._updated, voie._updated)
+})
+
+test('update a Voie with trace', async t => {
+  const _idBal = new mongo.ObjectId()
+  const _id = new mongo.ObjectId()
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: _idBal,
+    _updated: new Date('2019-01-01')
+  })
+  await mongo.db.collection('voies').insertOne({
+    _id,
+    _bal: _idBal,
+    nom: 'foo',
+    commune: '97125'
+  })
+
+  const voie = await Voie.update(_id, {
+    nom: 'la Pointe des Châteaux',
+    nomAlt: {
+      gcf: 'Lapwent'
+    },
+    typeNumerotation: 'metrique',
+    trace: {type: 'LineString', coordinates: [[0.9999, 0.9999], [1.0001, 1.0001]]}
+  })
+
+  const centroid = {
+    geometry: {
+      coordinates: [1, 1],
+      type: 'Point',
+    },
+    properties: {},
+    type: 'Feature',
+  }
+  const centroidTiles = [
+    '13/4118/4073',
+    '14/8237/8146',
+    '15/16475/16292',
+    '16/32950/32585',
+    '17/65900/65171',
+    '18/131800/130343',
+    '19/263600/260687'
+  ]
+  const traceTiles = [
+    '13/4118/4073'
+  ]
+  t.deepEqual(voie.centroid, centroid)
+  t.deepEqual(voie.centroidTiles, centroidTiles)
+  t.deepEqual(voie.traceTiles, traceTiles)
 })
 
 test('update a Voie / voie deleted', async t => {
@@ -308,6 +398,74 @@ test('restore a Voie', async t => {
   t.not(numero2._deleted, null)
   const bal = await mongo.db.collection('bases_locales').findOne({_id: _idBal})
   t.notDeepEqual(bal._updated, referenceDate)
+})
+
+test('restore Numero with position', async t => {
+  const _idBal = new mongo.ObjectId()
+  const _id = new mongo.ObjectId()
+  const _numeroId1 = new mongo.ObjectId()
+  const _numeroId2 = new mongo.ObjectId()
+  const referenceDate = new Date('2019-01-01')
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: _idBal,
+    _updated: referenceDate
+  })
+  await mongo.db.collection('voies').insertOne({
+    _id,
+    _bal: _idBal,
+    nom: 'foo',
+    _deleted: null,
+    positions: [{
+      source: 'inconnue',
+      type: 'entrée',
+      point: {type: 'Point', coordinates: [1, 1]}
+    }]
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _id: _numeroId1,
+    _bal: _idBal,
+    voie: _id,
+    numero: 1,
+    _deleted: null,
+    positions: [{
+      source: 'inconnue',
+      type: 'entrée',
+      point: {type: 'Point', coordinates: [1, 1]}
+    }]
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _id: _numeroId2,
+    _bal: _idBal,
+    voie: _id,
+    numero: 1,
+    _deleted: referenceDate
+  })
+
+  await Voie.restore(_id, {numerosIds: [_numeroId2]})
+
+  const voie = await mongo.db.collection('voies').findOne({_id})
+
+  const centroid = {
+    geometry: {
+      coordinates: [1, 1],
+      type: 'Point',
+    },
+    properties: {},
+    type: 'Feature',
+  }
+  const centroidTiles = [
+    '13/4118/4073',
+    '14/8237/8146',
+    '15/16475/16292',
+    '16/32950/32585',
+    '17/65900/65171',
+    '18/131800/130343',
+    '19/263600/260687'
+  ]
+  t.deepEqual(voie.centroid, centroid)
+  t.deepEqual(voie.centroidTiles, centroidTiles)
+  t.is(voie.traceTiles, null)
 })
 
 test('fetchAllDelete a Voie', async t => {

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -1,4 +1,5 @@
 const createHttpError = require('http-errors')
+const geojsonvt = require('geojson-vt')
 const subMonths = require('date-fns/subMonths')
 const {omit, difference, uniq, keyBy, union} = require('lodash')
 const {generateBase62String} = require('../util/base62')
@@ -13,9 +14,10 @@ const createRecoveryNotificationEmail = require('../emails/recovery-notification
 const {extract} = require('../populate/extract-ban')
 const {extractFromCsv} = require('../populate/extract-csv')
 const adressesToCsv = require('../export/csv-bal').exportAsCsv
-const {transformToGeoJSON} = require('../export/geojson')
 const {getCommune: getCommuneCOG} = require('../util/cog')
+const {ZOOM} = require('../util/tiles')
 const {getCommunesSummary} = require('../util/api-ban')
+const GeoJson = require('../export/geojson')
 const Voie = require('./voie')
 const Numero = require('./numero')
 const Toponyme = require('./toponyme')
@@ -367,13 +369,6 @@ async function exportAsCsv(id) {
   const toponymes = await mongo.db.collection('toponymes').find({_bal: mongo.parseObjectID(id), _deleted: null}).toArray()
   const numeros = await mongo.db.collection('numeros').find({_bal: mongo.parseObjectID(id), _deleted: null}).toArray()
   return adressesToCsv({voies, toponymes, numeros})
-}
-
-async function streamToGeoJSON(id) {
-  const voiesCursor = mongo.db.collection('voies').find({_bal: id, _deleted: null})
-  const numerosCursor = mongo.db.collection('numeros').find({_bal: id, 'positions.point': {$exists: true}, _deleted: null})
-  const toponymesCursor = mongo.db.collection('toponymes').find({_bal: id, _deleted: null})
-  return transformToGeoJSON({voiesCursor, numerosCursor, toponymesCursor})
 }
 
 async function importFile(baseLocale, file) {
@@ -743,6 +738,57 @@ async function removeDemoBALsOlderThanAMonth() {
   console.log(`\n${demoBALsIDs.length} BALs de démonstration supprimées définitivement\n`)
 }
 
+function getTiles(geojson, {z, x, y}) {
+  const options = {maxZoom: 20}
+  const tiles = {
+    'numeros-points': geojsonvt(geojson.numerosPoints, options).getTile(z, x, y),
+    'voies-points': geojsonvt(geojson.voiesPoints, options).getTile(z, x, y),
+    'voies-linestrings': geojsonvt(geojson.voiesLineStrings, options).getTile(z, x, y),
+  }
+
+  if (!tiles['numeros-points'] && !tiles['voies-points'] && !tiles['voies-linestrings']) {
+    return null
+  }
+
+  for (const key in tiles) {
+    if (Object.hasOwnProperty.call(tiles, key) && !tiles[key]) {
+      delete tiles[key]
+    }
+  }
+
+  return tiles
+}
+
+async function getGeoJsonByTile(id, {z, x, y}) {
+  const fetch = {
+    numeros: [],
+    voies: [],
+    trace: [],
+  }
+
+  if (z >= ZOOM.NUMEROS_ZOOM.minZoom && z <= ZOOM.NUMEROS_ZOOM.maxZoom) {
+    fetch.numeros = await Numero.fetchByTileAndBal(id, {z, x, y})
+  }
+
+  if (z >= ZOOM.VOIE_ZOOM.minZoom && z <= ZOOM.VOIE_ZOOM.maxZoom) {
+    fetch.voies = await Voie.fetchByCentroidTileAndBal(id, {z, x, y})
+  }
+
+  if (z >= ZOOM.TRACE_DISPLAY_ZOOM.minZoom && z <= ZOOM.TRACE_DISPLAY_ZOOM.maxZoom) {
+    fetch.trace = await Voie.fetchByTraceTileAndBal(id, {z, x, y})
+  }
+
+  const numerosPointsGeoJson = GeoJson.numerosPointsToGeoJSON(fetch.numeros)
+  const voiesPointsGeoJson = GeoJson.voiesPointsToGeoJSON(fetch.voies)
+  const voieLineStringsGeoJson = GeoJson.voiesLineStringsToGeoJSON(fetch.trace)
+
+  return {
+    numerosPoints: numerosPointsGeoJson,
+    voiesPoints: voiesPointsGeoJson,
+    voiesLineStrings: voieLineStringsGeoJson,
+  }
+}
+
 module.exports = {
   create,
   createSchema,
@@ -762,7 +808,6 @@ module.exports = {
   cleanCommune,
   populateCommune,
   exportAsCsv,
-  streamToGeoJSON,
   cleanContent,
   importFile,
   filterSensitiveFields,
@@ -776,5 +821,7 @@ module.exports = {
   updateHabilitation,
   removeSoftDeletedBALsOlderThanOneYear,
   removeDemoBALsOlderThanAMonth,
-  getBasesLocalesCreatedBetweenDate
+  getBasesLocalesCreatedBetweenDate,
+  getGeoJsonByTile,
+  getTiles
 }

--- a/lib/models/numero.js
+++ b/lib/models/numero.js
@@ -1,9 +1,10 @@
-const {uniqBy, omit, assign} = require('lodash')
+const {uniqBy, uniq, omit, assign} = require('lodash')
 const createError = require('http-errors')
 const {getFilteredPayload, addError, validSchema} = require('../util/payload')
 const mongo = require('../util/mongo')
 const {validPayload} = require('../util/payload')
 const {validateurBAL} = require('../validateur-bal')
+const {updateVoieTile, updateVoiesTile, calcMetaTilesNumero} = require('../util/tiles')
 const positionModel = require('./position')
 
 function validObjectID(id) {
@@ -122,9 +123,7 @@ async function create(idVoie, payload) {
   numero._bal = voie._bal
   numero.commune = voie.commune
   numero.voie = idVoie
-
   numero.suffixe = numero.suffixe ? normalizeSuffixe(numero.suffixe) : null
-
   numero.positions = numero.positions || []
   numero.comment = numero.comment || null
   numero.parcelles = numero.parcelles || []
@@ -145,9 +144,15 @@ async function create(idVoie, payload) {
     numero.toponyme = null
   }
 
+  // ADD TILE TO NUMERO
+  calcMetaTilesNumero(numero)
+
   mongo.decorateCreation(numero)
 
   await mongo.db.collection('numeros').insertOne(numero)
+
+  // UPDATE TILES OF VOIE
+  await updateVoieTile(voie)
 
   await Promise.all([
     mongo.touchDocument('bases_locales', numero._bal, numero._created),
@@ -188,6 +193,8 @@ async function importMany(idBal, rawNumeros, options = {}) {
 
       numero.certifie = n.certifie || false
 
+      calcMetaTilesNumero(numero)
+
       if (n._updated && n._created) {
         numero._created = n._created
         numero._updated = n._updated
@@ -204,15 +211,18 @@ async function importMany(idBal, rawNumeros, options = {}) {
   }
 
   await mongo.db.collection('numeros').insertMany(numeros)
+
+  // UPDATE TILES OF VOIES
+  const voieIds = uniq(numeros.map(n => n.voie))
+  await updateVoiesTile(voieIds)
 }
 
 function filterSensitiveFields(numero) {
   return omit(numero, 'comment')
 }
 
-async function update(id, payload) {
+async function update(id, payload, originalNumero) {
   const numeroChanges = await validPayload(payload, updateSchema)
-
   if (numeroChanges.voie) {
     const voie = await mongo.db.collection('voies').findOne({
       _id: mongo.parseObjectID(numeroChanges.voie),
@@ -243,6 +253,11 @@ async function update(id, payload) {
     numeroChanges.suffixe = normalizeSuffixe(numeroChanges.suffixe)
   }
 
+  // ADD TILE TO NUMERO IF POSITIONS CHANGE
+  if (numeroChanges.positions) {
+    calcMetaTilesNumero(numeroChanges)
+  }
+
   mongo.decorateModification(numeroChanges)
 
   const {value} = await mongo.db.collection('numeros').findOneAndUpdate(
@@ -255,6 +270,13 @@ async function update(id, payload) {
     throw new Error('Numero not found')
   }
 
+  // UPDATE TILES OF VOIE IF POSITION CHANGE
+  if (value.voie.toHexString() !== originalNumero.voie.toHexString()) {
+    await updateVoiesTile([value.voie, originalNumero.voie])
+  } else if (numeroChanges.positions) {
+    await updateVoiesTile([value.voie])
+  }
+
   await Promise.all([
     mongo.touchDocument('bases_locales', value._bal, value._updated),
     mongo.touchDocument('voies', value.voie, value._updated)
@@ -265,6 +287,14 @@ async function update(id, payload) {
 
 async function fetchOne(id) {
   return mongo.db.collection('numeros').findOne({_id: mongo.parseObjectID(id)})
+}
+
+async function fetchByTileAndBal(id, {z, x, y}) {
+  return mongo.db.collection('numeros').find({
+    _bal: mongo.parseObjectID(id),
+    tiles: `${z}/${x}/${y}`,
+    _deleted: null
+  }).toArray()
 }
 
 async function fetchAll(idVoie) {
@@ -304,6 +334,9 @@ async function softRemove(id) {
   if (!value) {
     throw new Error('Numero not found')
   }
+
+  // UPDATE TILES OF VOIE
+  await updateVoiesTile([value.voie])
 
   await Promise.all([
     mongo.touchDocument('bases_locales', value._bal, now),
@@ -396,10 +429,12 @@ async function batchUpdateNumeros(idBal, body) {
   const batchConditions = []
 
   // Now we build conditions and changes according to batch update parameters
-
+  let oldVoiesIds = []
   if (voie) {
     batchConditions.push({voie: {$ne: voie}})
     batchChanges.voie = voie
+    oldVoiesIds = await mongo.db.collection('numeros')
+      .distinct('voie', {_id: {$in: numeros}, _bal: idBal, _deleted: null})
   }
 
   if (certifie !== undefined) {
@@ -435,24 +470,17 @@ async function batchUpdateNumeros(idBal, body) {
   }, {$set: {...batchChanges, _updated: now}})
 
   if (modifiedCount > 0) {
-    // Now we want to update Voie._updated when necessary
-    // We collect related Voie._id
-    const updatedVoies = await mongo.db.collection('numeros').distinct('voie', {
-      _id: {$in: numeros},
-      _bal: idBal,
-      _updated: now,
-      _deleted: null,
-    })
-
     // We update Voie._updated when older than 'now'
     await mongo.db.collection('voies').updateMany({
-      _id: {$in: updatedVoies},
+      _id: {$in: [...oldVoiesIds, voie]},
       _updated: {$lt: now}
     },
     {$set: {
       _updated: now
     }})
 
+    // UPDATE TILES OF VOIES IF VOIE OF NUMERO CHANGE
+    await updateVoiesTile([...oldVoiesIds, voie])
     // And now we update BaseLocale._updated
     await mongo.touchDocument('bases_locales', idBal, now)
   }
@@ -488,6 +516,9 @@ async function batchSoftRemoveNumeros(idBal, body) {
       _updated: now
     }}
   )
+
+  // UPDATE TILES OF VOIES
+  await updateVoiesTile(voieIds)
 
   await Promise.all([
     mongo.touchDocument('bases_locales', idBal),
@@ -538,6 +569,7 @@ module.exports = {
   updateSchema,
   fetchOne,
   fetchAll,
+  fetchByTileAndBal,
   fetchByToponyme,
   remove,
   softRemove,

--- a/lib/models/voie.js
+++ b/lib/models/voie.js
@@ -4,6 +4,7 @@ const mongo = require('../util/mongo')
 const {validPayload} = require('../util/payload')
 const {validateurBAL} = require('../validateur-bal')
 const {cleanNom} = require('../util/string')
+const {getParentTile, ZOOM, updateVoieTile} = require('../util/tiles')
 const Numero = require('./numero')
 const Toponyme = require('./toponyme')
 const nomAltSchema = require('./nom-alt')
@@ -81,6 +82,10 @@ async function create(baseLocale, payload) {
   mongo.decorateCreation(voie)
 
   await mongo.db.collection('voies').insertOne(voie)
+
+  // UPDATE TILES OF VOIE IF TRACE EXIST
+  await updateVoieTile(voie)
+
   await mongo.touchDocument('bases_locales', voie._bal, voie._created)
 
   return voie
@@ -160,6 +165,9 @@ async function update(id, payload) {
     throw new Error('Voie not found')
   }
 
+  // UPDATE TILES OF VOIE IF TRACE CHANGE
+  await updateVoieTile(value)
+
   await mongo.touchDocument('bases_locales', value._bal, value._updated)
 
   return value
@@ -174,6 +182,40 @@ async function fetchAll(idBal) {
     _bal: idBal,
     _deleted: null
   }).toArray()
+}
+
+async function fetchByCentroidTileAndBal(id, {z, x, y}) {
+  return mongo.db.collection('voies')
+    .find({
+      _bal: mongo.parseObjectID(id),
+      centroidTiles: `${z}/${x}/${y}`,
+      _deleted: null
+    })
+    .toArray()
+}
+
+async function fetchByPolygonTileAndBal(id, {z, x, y}) {
+  return mongo.db.collection('voies')
+    .find({
+      _bal: mongo.parseObjectID(id),
+      polygonTiles: `${z}/${x}/${y}`,
+      _deleted: null
+    })
+    .toArray()
+}
+
+async function fetchByTraceTileAndBal(id, {z, x, y}) {
+  const tile = [x, y, z]
+  const [xx, yy, zz] = getParentTile(tile, ZOOM.TRACE_MONGO_ZOOM.zoom)
+  return mongo.db.collection('voies')
+    .find({
+      _bal: mongo.parseObjectID(id),
+      typeNumerotation: 'metrique',
+      trace: {$ne: null},
+      traceTiles: `${zz}/${xx}/${yy}`,
+      _deleted: null
+    })
+    .toArray()
 }
 
 async function fetchAllDeleted(idBal) {
@@ -237,9 +279,8 @@ async function restore(voieId, body) {
   })
 
   if (modifiedCount > 0) {
-    await Promise.all([
-      mongo.touchDocument('bases_locales', value._bal, now),
-    ])
+    await updateVoieTile(value)
+    await mongo.touchDocument('bases_locales', value._bal, now)
   }
 
   return {modifiedCount}
@@ -357,6 +398,9 @@ module.exports = {
   updateSchema,
   fetchOne,
   fetchAll,
+  fetchByCentroidTileAndBal,
+  fetchByPolygonTileAndBal,
+  fetchByTraceTileAndBal,
   remove,
   batchUpdateNumeros,
   convertToToponyme,

--- a/lib/routes/__tests__/base-locale.js
+++ b/lib/routes/__tests__/base-locale.js
@@ -465,20 +465,6 @@ test('export as CSV', async t => {
   t.is(text.split('\r\n').length, 488)
 })
 
-test('Export as GeoJSON', async t => {
-  mockBan54084()
-  const {_id} = await BaseLocale.create({nom: 'foo', commune: '54084', emails: ['toto@acme.co']})
-  await BaseLocale.populateCommune(_id, '54084')
-
-  const {status, headers, body} = await request(getApp())
-    .get(`/bases-locales/${_id}/geojson`)
-
-  t.is(status, 200)
-  t.is(headers['content-type'], 'application/json; charset=utf-8')
-  t.is(body.type, 'FeatureCollection')
-  t.is(body.features.length, 486)
-})
-
 test.serial('renew token / with admin token', async t => {
   const _id = new mongo.ObjectId()
   await mongo.db.collection('bases_locales').insertOne({

--- a/lib/routes/__tests__/numeros.js
+++ b/lib/routes/__tests__/numeros.js
@@ -8,7 +8,7 @@ const mongo = require('../../util/mongo')
 const routes = require('..')
 
 const GENERATED_VARS = ['_id', '_updated', '_created']
-const KEYS = ['_id', '_bal', 'commune', 'voie', 'numero', 'numeroComplet', 'positions', 'suffixe', '_created', '_updated', 'comment', 'toponyme', 'parcelles', 'certifie']
+const KEYS = ['_id', '_bal', 'commune', 'voie', 'numero', 'numeroComplet', 'positions', 'suffixe', '_created', '_updated', 'comment', 'toponyme', 'parcelles', 'certifie', 'tiles']
 
 let mongod
 
@@ -73,7 +73,8 @@ test.serial('create a numero', async t => {
     comment: null,
     toponyme: null,
     parcelles: [],
-    certifie: false
+    certifie: false,
+    tiles: null,
   })
   t.true(KEYS.every(k => k in body))
   t.is(Object.keys(body).length, KEYS.length)
@@ -334,7 +335,8 @@ test.serial('get all numeros from a toponyme', async t => {
     toponyme: _idToponyme,
     certifie: false,
     _created: new Date('2019-01-01'),
-    _updated: new Date('2019-01-01')
+    _updated: new Date('2019-01-01'),
+    tiles: ['0/0/0']
   })
   await mongo.db.collection('numeros').insertOne({
     _id: _idNumeroB,
@@ -366,7 +368,8 @@ test.serial('get all numeros from a toponyme', async t => {
       _id: _idVoie.toHexString(),
       nom: 'voie'
     },
-    certifie: false
+    certifie: false,
+    tiles: ['0/0/0']
   })
   t.true(KEYS.every(k => k in body[0]))
   t.is(Object.keys(body[0]).length, KEYS.length)
@@ -418,7 +421,8 @@ test.serial('get all numeros from a toponyme / without token', async t => {
     toponyme: _idToponyme,
     certifie: false,
     _created: new Date('2019-01-01'),
-    _updated: new Date('2019-01-01')
+    _updated: new Date('2019-01-01'),
+    tiles: ['0/0/0']
   })
   await mongo.db.collection('numeros').insertOne({
     _id: _idNumeroB,
@@ -448,7 +452,8 @@ test.serial('get all numeros from a toponyme / without token', async t => {
       _id: _idVoie.toHexString(),
       nom: 'voie'
     },
-    certifie: false
+    certifie: false,
+    tiles: ['0/0/0']
   })
   t.false(KEYS.every(k => k in body[0]))
   t.is(Object.keys(body[0]).length, KEYS.length - 1)
@@ -497,7 +502,8 @@ test.serial('get a numero / no token', async t => {
     toponyme: null,
     certifie: false,
     _created: new Date('2019-01-01'),
-    _updated: new Date('2019-01-01')
+    _updated: new Date('2019-01-01'),
+    tiles: ['0/0/0']
   })
 
   const {status, body} = await request(getApp())
@@ -514,7 +520,8 @@ test.serial('get a numero / no token', async t => {
     positions: [],
     parcelles: [],
     toponyme: null,
-    certifie: false
+    certifie: false,
+    tiles: ['0/0/0']
   })
   t.false(KEYS.every(k => k in body))
   t.is(Object.keys(body).length, KEYS.length - 1)
@@ -556,7 +563,8 @@ test.serial('get a numero / with token', async t => {
     toponyme: null,
     certifie: false,
     _created: new Date('2019-01-01'),
-    _updated: new Date('2019-01-01')
+    _updated: new Date('2019-01-01'),
+    tiles: ['0/0/0']
   })
 
   const {status, body} = await request(getApp())
@@ -575,7 +583,8 @@ test.serial('get a numero / with token', async t => {
     positions: [],
     parcelles: [],
     toponyme: null,
-    certifie: false
+    certifie: false,
+    tiles: ['0/0/0']
   })
   t.true(KEYS.every(k => k in body))
   t.is(Object.keys(body).length, KEYS.length)

--- a/lib/routes/__tests__/voies.js
+++ b/lib/routes/__tests__/voies.js
@@ -7,7 +7,7 @@ const mongo = require('../../util/mongo')
 const routes = require('..')
 
 const GENERATED_VARS = ['_id', '_updated', '_created']
-const KEYS = ['_id', '_bal', 'commune', 'nom', 'code', '_created', '_updated', 'nomAlt', 'typeNumerotation', 'trace', 'nbNumeros', 'nbNumerosCertifies', 'isAllCertified', 'commentedNumeros']
+const KEYS = ['_id', '_bal', 'commune', 'nom', 'code', '_created', '_updated', 'nomAlt', 'typeNumerotation', 'trace', 'nbNumeros', 'nbNumerosCertifies', 'isAllCertified', 'commentedNumeros', 'centroid', 'centroidTiles', 'traceTiles']
 
 let mongod
 
@@ -61,7 +61,10 @@ test.serial('create a voie', async t => {
     commentedNumeros: [],
     isAllCertified: false,
     typeNumerotation: 'numerique',
-    trace: null
+    trace: null,
+    centroid: null,
+    centroidTiles: null,
+    traceTiles: null,
   })
   t.true(KEYS.every(k => k in body))
   t.is(Object.keys(body).length, KEYS.length)
@@ -96,7 +99,10 @@ test.serial('create a voie / with 2 nomAlt', async t => {
     isAllCertified: false,
     commentedNumeros: [],
     typeNumerotation: 'numerique',
-    trace: null
+    trace: null,
+    centroid: null,
+    centroidTiles: null,
+    traceTiles: null,
   })
   t.true(KEYS.every(k => k in body))
   t.is(Object.keys(body).length, KEYS.length)

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -1,6 +1,9 @@
+const zlib = require('zlib')
+const {promisify} = require('util')
 const express = require('express')
 const bodyParser = require('body-parser')
 const createError = require('http-errors')
+const vtpbf = require('vt-pbf')
 const w = require('../util/w')
 const BaseLocale = require('../models/base-locale')
 const Voie = require('../models/voie')
@@ -8,7 +11,7 @@ const Numero = require('../models/numero')
 const Toponyme = require('../models/toponyme')
 const errorHandler = require('../util/error-handler')
 const {getCommune} = require('../util/cog')
-const {expandModelWithNumeros} = require('../util/models')
+const {expandModelWithNumeros, expandVoiesOrToponymes, expandVoieOrToponyme} = require('../util/models')
 const {getEditorUrl} = require('../emails/util')
 const sync = require('../sync')
 const {createHabilitation, sendPinCode, validatePinCode, fetchHabilitation} = require('../habilitations')
@@ -18,6 +21,8 @@ const stats = require('./stats')
 const adminRoutes = require('./admin')
 
 const app = new express.Router()
+
+const gzip = promisify(zlib.gzip)
 
 app.use(express.json())
 
@@ -294,11 +299,26 @@ app.route('/bases-locales/:baseLocaleId/habilitation/email/validate-pin-code')
     }
   }))
 
-app.route('/bases-locales/:baseLocaleId/geojson')
+app.route('/bases-locales/:baseLocaleId/tiles/:z/:x/:y.pbf')
   .get(w(async (req, res) => {
-    const geojsonStream = await BaseLocale.streamToGeoJSON(req.baseLocale._id)
-    res.type('json')
-    geojsonStream.pipe(res)
+    const y = Number.parseInt(req.params.y, 10)
+    const x = Number.parseInt(req.params.x, 10)
+    const z = Number.parseInt(req.params.z, 10)
+
+    const geoJson = await BaseLocale.getGeoJsonByTile(req.baseLocale._id, {z, x, y})
+    const tiles = BaseLocale.getTiles(geoJson, {z, x, y})
+    if (tiles === null) {
+      return res.status(204).send()
+    }
+
+    const pbf = vtpbf.fromGeojsonVt(tiles)
+
+    res.set({
+      'Content-Type': 'application/x-protobuf',
+      'Content-Encoding': 'gzip'
+    })
+
+    res.send(await gzip(Buffer.from(pbf)))
   }))
 
 app.route('/bases-locales/:baseLocaleId/populate')
@@ -320,9 +340,7 @@ app.route('/bases-locales/:baseLocaleId/voies')
   }))
   .get(w(async (req, res) => {
     const voies = await Voie.fetchAll(req.baseLocale._id)
-    const voiesExpanded = await Promise.all(
-      voies.map(voie => expandModelWithNumeros(voie, 'voie'))
-    )
+    const voiesExpanded = await expandVoiesOrToponymes(req.baseLocale._id, voies, 'voie')
     res.send(voiesExpanded)
   }))
 
@@ -340,9 +358,7 @@ app.route('/bases-locales/:baseLocaleId/toponymes')
   }))
   .get(w(async (req, res) => {
     const toponymes = await Toponyme.fetchAll(req.baseLocale._id)
-    const toponymesExpanded = await Promise.all(
-      toponymes.map(toponyme => expandModelWithNumeros(toponyme, 'toponyme'))
-    )
+    const toponymesExpanded = await expandVoiesOrToponymes(req.baseLocale._id, toponymes, 'toponyme')
     res.send(toponymesExpanded)
   }))
 
@@ -366,7 +382,7 @@ app.route('/bases-locales/:baseLocaleId/batch')
 
 app.route('/voies/:voieId')
   .get(w(async (req, res) => {
-    const voie = await expandModelWithNumeros(req.voie, 'voie')
+    const voie = await expandVoieOrToponyme(req.voie, 'voie')
     res.send(voie)
   }))
   .put(ensureIsAdmin, w(async (req, res) => {
@@ -432,7 +448,7 @@ app.route('/numeros/:numeroId')
     }
   }))
   .put(ensureIsAdmin, w(async (req, res) => {
-    const numero = await Numero.update(req.numero._id, req.body)
+    const numero = await Numero.update(req.numero._id, req.body, req.numero)
     res.send(Numero.expandModel(numero))
   }))
   .delete(ensureIsAdmin, w(async (req, res) => {
@@ -448,7 +464,7 @@ app.route('/numeros/:numeroId/soft-delete')
 
 app.route('/toponymes/:toponymeId')
   .get(w(async (req, res) => {
-    const toponyme = await expandModelWithNumeros(req.toponyme, 'toponyme')
+    const toponyme = await expandVoieOrToponyme(req.toponyme, 'toponyme')
     res.send(toponyme)
   }))
   .put(ensureIsAdmin, w(async (req, res) => {

--- a/lib/sync/api-depot.js
+++ b/lib/sync/api-depot.js
@@ -59,8 +59,8 @@ async function publishNewRevision(codeCommune, balId, balFile, habilitationId) {
   ).json()
 
   if (!computedRevision.validation.valid) {
-    console.log(`Export BAL non valide : ${balId}`)
-    console.log(computedRevision.validation.errors)
+    console.warn(`Export BAL non valide : ${balId}`)
+    console.warn(computedRevision.validation.errors)
     throw createError(417, 'La fichier BAL n’est pas valide. Merci de contacter le support.')
   }
 

--- a/lib/util/__tests__/model.js
+++ b/lib/util/__tests__/model.js
@@ -1,0 +1,209 @@
+const test = require('ava')
+const {MongoMemoryServer} = require('mongodb-memory-server')
+const {expandVoiesOrToponymes} = require('../models')
+const mongo = require('../../util/mongo')
+
+let mongod
+
+test.before('start server', async () => {
+  mongod = await MongoMemoryServer.create()
+  await mongo.connect(mongod.getUri())
+})
+
+test.after.always('cleanup', async () => {
+  await mongo.disconnect()
+  await mongod.stop()
+})
+
+test('expandVoiesOrToponymes voie', async t => {
+  const _bal = new mongo.ObjectId()
+  const trace = {
+    type: 'LineString',
+    coordinates: [[-122.09, 37.42], [-122.08, 37.43]]
+  }
+  const voies = [
+    {
+      _bal,
+      _id: new mongo.ObjectId(),
+      nom: 'voie1',
+      trace,
+      typeNumerotation: 'metrique'
+    },
+    {
+      _bal,
+      _id: new mongo.ObjectId(),
+      nom: 'voie2',
+    }
+  ]
+  await mongo.db.collection('voies').insertMany(voies)
+  const numeros = [
+    {
+      _bal,
+      _id: new mongo.ObjectId(),
+      voie: voies[1]._id,
+      numero: 1,
+      positions: [{
+        type: 'entrée',
+        point: {
+          type: 'Point',
+          coordinates: [1, 1]
+        }
+      }],
+      parcelles: ['1', '2', '3'],
+      certifie: true,
+    },
+    {
+      _bal,
+      _id: new mongo.ObjectId(),
+      voie: voies[1]._id,
+      numero: 2,
+      positions: [{
+        type: 'entrée',
+        point: {
+          type: 'Point',
+          coordinates: [2, 2]
+        }
+      }],
+      comment: 'titi'
+    },
+  ]
+  await mongo.db.collection('numeros').insertMany(numeros)
+  const funcRes = await expandVoiesOrToponymes(_bal, voies, 'voie')
+  const expectedRes = [
+    {
+      _bal,
+      _id: voies[0]._id,
+      nom: 'voie1',
+      bbox: [-122.09, 37.42, -122.08, 37.43],
+      trace,
+      typeNumerotation: 'metrique',
+      nbNumeros: 0,
+      nbNumerosCertifies: 0,
+      isAllCertified: false,
+      commentedNumeros: [],
+    },
+    {
+      _bal,
+      _id: voies[1]._id,
+      nom: 'voie2',
+      bbox: [1, 1, 2, 2],
+      nbNumeros: 2,
+      nbNumerosCertifies: 1,
+      isAllCertified: false,
+      commentedNumeros: [{
+        _id: numeros[1]._id,
+        voie: voies[1]._id,
+        numero: 2,
+        positions: [{
+          type: 'entrée',
+          point: {
+            type: 'Point',
+            coordinates: [2, 2]
+          }
+        }],
+        comment: 'titi'
+      }],
+    }
+  ]
+  t.deepEqual(funcRes, expectedRes)
+})
+
+test('expandVoiesOrToponymes toponyme', async t => {
+  const _bal = new mongo.ObjectId()
+  const toponymes = [
+    {
+      _bal,
+      _id: new mongo.ObjectId(),
+      nom: 'toponyme1',
+      positions: [{
+        type: 'entrée',
+        point: {
+          type: 'Point',
+          coordinates: [1, 1]
+        }
+      }],
+    },
+    {
+      _bal,
+      _id: new mongo.ObjectId(),
+      nom: 'toponyme2',
+    }
+  ]
+  await mongo.db.collection('toponymes').insertMany(toponymes)
+  const numeros = [
+    {
+      _bal,
+      _id: new mongo.ObjectId(),
+      toponyme: toponymes[1]._id,
+      numero: 1,
+      positions: [{
+        type: 'entrée',
+        point: {
+          type: 'Point',
+          coordinates: [1, 1]
+        }
+      }],
+      certifie: true,
+    },
+    {
+      _bal,
+      _id: new mongo.ObjectId(),
+      toponyme: toponymes[1]._id,
+      numero: 2,
+      positions: [{
+        type: 'entrée',
+        point: {
+          type: 'Point',
+          coordinates: [2, 2]
+        }
+      }],
+      comment: 'titi',
+      certifie: true,
+    },
+  ]
+  await mongo.db.collection('numeros').insertMany(numeros)
+  const funcRes = await expandVoiesOrToponymes(_bal, toponymes, 'toponyme')
+  const expectedRes = [
+    {
+      _bal,
+      _id: toponymes[0]._id,
+      nom: 'toponyme1',
+      bbox: [1, 1, 1, 1],
+      nbNumeros: 0,
+      nbNumerosCertifies: 0,
+      isAllCertified: false,
+      commentedNumeros: [],
+      positions: [{
+        type: 'entrée',
+        point: {
+          type: 'Point',
+          coordinates: [1, 1]
+        }
+      }],
+    },
+    {
+      _bal,
+      _id: toponymes[1]._id,
+      nom: 'toponyme2',
+      bbox: [1, 1, 2, 2],
+      nbNumeros: 2,
+      nbNumerosCertifies: 2,
+      isAllCertified: true,
+      commentedNumeros: [{
+        _id: numeros[1]._id,
+        toponyme: toponymes[1]._id,
+        numero: 2,
+        certifie: true,
+        positions: [{
+          type: 'entrée',
+          point: {
+            type: 'Point',
+            coordinates: [2, 2]
+          }
+        }],
+        comment: 'titi'
+      }],
+    }
+  ]
+  t.deepEqual(funcRes, expectedRes)
+})

--- a/lib/util/__tests__/tiles.js
+++ b/lib/util/__tests__/tiles.js
@@ -1,0 +1,213 @@
+const test = require('ava')
+const {MongoMemoryServer} = require('mongodb-memory-server')
+const mongo = require('../../util/mongo')
+const {calcMetaTilesVoie, calcMetaTilesNumero} = require('../tiles')
+
+let mongod
+
+test.before('start server', async () => {
+  mongod = await MongoMemoryServer.create()
+  await mongo.connect(mongod.getUri())
+})
+
+test.after.always('cleanup', async () => {
+  await mongo.disconnect()
+  await mongod.stop()
+})
+
+test.beforeEach('clean database', async () => {
+  await mongo.db.collection('voies').deleteMany({})
+  await mongo.db.collection('numeros').deleteMany({})
+})
+
+test.serial('calcMetaTilesNumero without position', t => {
+  const numeros = {
+    _id: new mongo.ObjectId(),
+  }
+  const res = calcMetaTilesNumero(numeros)
+  t.is(res.tiles, null)
+})
+
+test.serial('calcMetaTilesNumero', t => {
+  const numeros = {
+    _id: new mongo.ObjectId(),
+    positions: [{
+      source: 'inconnue',
+      type: 'entrée',
+      point: {type: 'Point', coordinates: [1, 1]}
+    }]
+  }
+  const res = calcMetaTilesNumero(numeros)
+  const tiles = [
+    '13/4118/4073',
+    '14/8237/8146',
+    '15/16475/16292',
+    '16/32950/32585',
+    '17/65900/65171',
+    '18/131800/130343',
+    '19/263600/260687'
+  ]
+  t.deepEqual(res.tiles, tiles)
+})
+
+test.serial('calcMetaTilesVoie without positions numeros', async t => {
+  const voie = {
+    _id: new mongo.ObjectId(),
+  }
+  const numeros = [
+    {
+      _id: new mongo.ObjectId(),
+      voie: voie._id,
+      positions: null
+    },
+    {
+      _id: new mongo.ObjectId(),
+      voie: voie._id,
+      positions: []
+    }
+  ]
+  await mongo.db.collection('numeros').insertMany(numeros)
+  const res = await calcMetaTilesVoie(voie)
+  t.is(res.centroid, null)
+  t.is(res.centroidTiles, null)
+  t.is(res.traceTiles, null)
+})
+
+test.serial('calcMetaTilesVoie without numeros', async t => {
+  const voie = {
+    _id: new mongo.ObjectId(),
+  }
+  const res = await calcMetaTilesVoie(voie)
+  t.is(res.centroid, null)
+  t.is(res.centroidTiles, null)
+  t.is(res.traceTiles, null)
+})
+
+test.serial('calcMetaTilesVoie', async t => {
+  const voie = {
+    _id: new mongo.ObjectId(),
+  }
+  const numeros = [
+    {
+      _id: new mongo.ObjectId(),
+      voie: voie._id,
+      positions: [{
+        source: 'inconnue',
+        type: 'entrée',
+        point: {type: 'Point', coordinates: [0.5, 0.5]}
+      }]
+    },
+    {
+      _id: new mongo.ObjectId(),
+      voie: voie._id,
+      positions: [{
+        source: 'inconnue',
+        type: 'entrée',
+        point: {type: 'Point', coordinates: [1.5, 1.5]}
+      }]
+    }
+  ]
+  await mongo.db.collection('numeros').insertMany(numeros)
+  const res = await calcMetaTilesVoie(voie)
+  const centroid = {
+    geometry: {
+      coordinates: [1, 1],
+      type: 'Point',
+    },
+    properties: {},
+    type: 'Feature',
+  }
+  const centroidTiles = [
+    '13/4118/4073',
+    '14/8237/8146',
+    '15/16475/16292',
+    '16/32950/32585',
+    '17/65900/65171',
+    '18/131800/130343',
+    '19/263600/260687'
+  ]
+  t.deepEqual(res.centroid, centroid)
+  t.deepEqual(res.centroidTiles, centroidTiles)
+  t.is(res.traceTiles, null)
+})
+
+test.serial('calcMetaTilesVoie with no trace', async t => {
+  const voie = {
+    _id: new mongo.ObjectId(),
+    typeNumerotation: 'metrique'
+  }
+  const numeros = [
+    {
+      _id: new mongo.ObjectId(),
+      voie: voie._id,
+      positions: [{
+        source: 'inconnue',
+        type: 'entrée',
+        point: {type: 'Point', coordinates: [0.5, 0.5]}
+      }]
+    },
+    {
+      _id: new mongo.ObjectId(),
+      voie: voie._id,
+      positions: [{
+        source: 'inconnue',
+        type: 'entrée',
+        point: {type: 'Point', coordinates: [1.5, 1.5]}
+      }]
+    }
+  ]
+  await mongo.db.collection('numeros').insertMany(numeros)
+  const res = await calcMetaTilesVoie(voie)
+  const centroid = {
+    geometry: {
+      coordinates: [1, 1],
+      type: 'Point',
+    },
+    properties: {},
+    type: 'Feature',
+  }
+  const centroidTiles = [
+    '13/4118/4073',
+    '14/8237/8146',
+    '15/16475/16292',
+    '16/32950/32585',
+    '17/65900/65171',
+    '18/131800/130343',
+    '19/263600/260687'
+  ]
+  t.deepEqual(res.centroid, centroid)
+  t.deepEqual(res.centroidTiles, centroidTiles)
+  t.is(res.traceTiles, null)
+})
+
+test.serial('calcMetaTilesVoie with trace', async t => {
+  const voie = {
+    _id: new mongo.ObjectId(),
+    typeNumerotation: 'metrique',
+    trace: {type: 'LineString', coordinates: [[0.9999, 0.9999], [1.0001, 1.0001]]}
+  }
+  const res = await calcMetaTilesVoie(voie)
+  const centroid = {
+    geometry: {
+      coordinates: [1, 1],
+      type: 'Point',
+    },
+    properties: {},
+    type: 'Feature',
+  }
+  const centroidTiles = [
+    '13/4118/4073',
+    '14/8237/8146',
+    '15/16475/16292',
+    '16/32950/32585',
+    '17/65900/65171',
+    '18/131800/130343',
+    '19/263600/260687'
+  ]
+  const traceTiles = [
+    '13/4118/4073'
+  ]
+  t.deepEqual(res.centroid, centroid)
+  t.deepEqual(res.centroidTiles, centroidTiles)
+  t.deepEqual(res.traceTiles, traceTiles)
+})

--- a/lib/util/models.js
+++ b/lib/util/models.js
@@ -1,3 +1,5 @@
+const bbox = require('@turf/bbox').default
+const {groupBy} = require('lodash')
 const mongo = require('../util/mongo')
 
 async function expandModelWithNumeros(model, idProperty) {
@@ -25,4 +27,58 @@ async function expandModelWithNumeros(model, idProperty) {
   return model
 }
 
-module.exports = {expandModelWithNumeros}
+async function expandVoieOrToponyme(model, idProperty) {
+  const numeros = await mongo.db.collection('numeros')
+    .find({[idProperty]: mongo.parseObjectID(model._id), _deleted: null})
+    .project({voie: 1, toponyme: 1, positions: 1, certifie: 1, numero: 1, suffixe: 1, comment: 1})
+    .toArray()
+
+  const numerosByModel = groupBy(numeros, idProperty)
+  expandVoieOrToponymeWithHisNumeros(model, numerosByModel[model._id])
+  return model
+}
+
+async function expandVoiesOrToponymes(balId, models, idProperty) {
+  const numeros = await mongo.db.collection('numeros')
+    .find({_bal: mongo.parseObjectID(balId), _deleted: null})
+    .project({voie: 1, toponyme: 1, positions: 1, certifie: 1, numero: 1, suffixe: 1, comment: 1})
+    .toArray()
+
+  const numerosByModel = groupBy(numeros, idProperty)
+  models.forEach(m => {
+    expandVoieOrToponymeWithHisNumeros(m, numerosByModel[m._id])
+  })
+  return models
+}
+
+function positionToFeatureCollection(positions) {
+  return {
+    type: 'FeatureCollection',
+    features: positions.map(p => ({
+      type: 'Feature',
+      geometry: p.point,
+    }))
+  }
+}
+
+async function expandVoieOrToponymeWithHisNumeros(model, numeros = []) {
+  model.nbNumeros = numeros.length
+  model.nbNumerosCertifies = numeros.filter(n => n.certifie === true).length
+  model.isAllCertified = model.nbNumeros > 0 && model.nbNumeros === model.nbNumerosCertifies
+  model.commentedNumeros = numeros.filter(n => n.comment !== undefined && n.comment !== null && n.comment !== '')
+
+  const positions = numeros
+    .filter(n => n.positions && n.positions.length > 0)
+    .reduce((acc, n) => [...acc, ...n.positions], [])
+  if (positions.length > 0) {
+    const featuresCollection = positionToFeatureCollection(positions)
+    model.bbox = bbox(featuresCollection)
+  } else if (model.positions && model.positions.length > 0) {
+    const featuresCollection = positionToFeatureCollection(model.positions)
+    model.bbox = bbox(featuresCollection)
+  } else if (model.trace) {
+    model.bbox = bbox(model.trace)
+  }
+}
+
+module.exports = {expandModelWithNumeros, expandVoiesOrToponymes, expandVoieOrToponyme}

--- a/lib/util/mongo.js
+++ b/lib/util/mongo.js
@@ -25,6 +25,8 @@ class Mongo {
     await this.db.collection('voies').createIndex({_bal: 1})
     await this.db.collection('voies').createIndex({_bal: 1, commune: 1})
     await this.db.collection('voies').createIndex({_deleted: 1})
+    await this.db.collection('numeros').createIndex({centroidTiles: 1})
+    await this.db.collection('numeros').createIndex({traceTiles: 1})
 
     await this.db.collection('toponymes').createIndex({_bal: 1})
     await this.db.collection('toponymes').createIndex({_bal: 1, commune: 1})
@@ -35,6 +37,7 @@ class Mongo {
     await this.db.collection('numeros').createIndex({voie: 1})
     await this.db.collection('numeros').createIndex({toponyme: 1})
     await this.db.collection('numeros').createIndex({_deleted: 1})
+    await this.db.collection('numeros').createIndex({tiles: 1})
   }
 
   disconnect(force) {

--- a/lib/util/tiles.js
+++ b/lib/util/tiles.js
@@ -1,0 +1,148 @@
+const turf = require('@turf/turf')
+const {range, union} = require('lodash')
+const {pointToTile, bboxToTile, getParent, getChildren, tileToBBOX} = require('@mapbox/tilebelt')
+const mongo = require('../util/mongo')
+const {getPriorityPosition} = require('../export/geojson')
+
+const ZOOM = {
+  NUMEROS_ZOOM: {
+    minZoom: 13,
+    maxZoom: 19
+  },
+  VOIE_ZOOM: {
+    minZoom: 13,
+    maxZoom: 19
+  },
+  TRACE_DISPLAY_ZOOM: {
+    minZoom: 13,
+    maxZoom: 19
+  },
+  TRACE_MONGO_ZOOM: {
+    zoom: 13,
+  }
+}
+
+async function updateVoiesTile(voieIds) {
+  const voies = await mongo.db.collection('voies')
+    .find({_id: {$in: voieIds.map(id => mongo.parseObjectID(id))}, _deleted: null})
+    .project({_id: 1, typeNumerotation: 1, trace: 1})
+    .toArray()
+  return Promise.all(voies.map(v => updateVoieTile(v)))
+}
+
+async function updateVoieTile(voie) {
+  const _id = mongo.parseObjectID(voie._id)
+  const voieSet = await calcMetaTilesVoie(voie)
+  return mongo.db.collection('voies').updateOne({_id}, {$set: voieSet})
+}
+
+function roundCoordinate(coordinate, precision = 6) {
+  return Number.parseFloat(coordinate.toFixed(precision))
+}
+
+function calcMetaTilesNumero(numero) {
+  numero.tiles = null
+  try {
+    if (numero.positions && numero.positions.length > 0) {
+      const position = getPriorityPosition(numero.positions)
+      numero.tiles = getTilesByPosition(position.point, ZOOM.NUMEROS_ZOOM)
+    }
+  } catch (error) {
+    console.error(error, numero)
+  }
+
+  return numero
+}
+
+async function calcMetaTilesVoie(voie) {
+  voie.centroid = null
+  voie.centroidTiles = null
+  voie.traceTiles = null
+
+  try {
+    if (voie.typeNumerotation === 'metrique' && voie.trace) {
+      voie.centroid = turf.centroid(voie.trace)
+      voie.centroidTiles = getTilesByPosition(voie.centroid.geometry, ZOOM.VOIE_ZOOM)
+      voie.traceTiles = getTilesByLineString(voie.trace)
+    } else {
+      const numeros = await mongo.db.collection('numeros')
+        .find({voie: voie._id, _deleted: null})
+        .project({positions: 1, voie: 1})
+        .toArray()
+      if (numeros.length > 0) {
+        const coordinatesNumeros = numeros
+          .filter(n => n.positions && n.positions.length > 0)
+          .map(n => getPriorityPosition(n.positions)?.point?.coordinates)
+        // CALC CENTROID
+        if (coordinatesNumeros.length > 0) {
+          const featureCollection = turf.featureCollection(coordinatesNumeros.map(n => turf.point(n)))
+          voie.centroid = turf.centroid(featureCollection)
+          voie.centroidTiles = getTilesByPosition(voie.centroid.geometry, ZOOM.VOIE_ZOOM)
+        }
+      }
+    }
+  } catch (error) {
+    console.error(error, voie)
+  }
+
+  return voie
+}
+
+function getParentTile(tile, zoomFind) {
+  return tile[2] <= zoomFind ? tile : getParentTile(getParent(tile), zoomFind)
+}
+
+function getTilesByPosition(position, {minZoom, maxZoom} = ZOOM.NUMEROS_ZOOM) {
+  if (!position || (!minZoom || !maxZoom)) {
+    return null
+  }
+
+  const lon = roundCoordinate(position.coordinates[0], 6)
+  const lat = roundCoordinate(position.coordinates[1], 6)
+
+  const tiles = range(minZoom, maxZoom + 1).map(zoom => {
+    const [x, y, z] = pointToTile(lon, lat, zoom)
+    return `${z}/${x}/${y}`
+  })
+
+  return tiles
+}
+
+function getTilesByLineString(lineString, {zoom} = ZOOM.TRACE_MONGO_ZOOM) {
+  const bboxFeature = turf.bbox(lineString)
+  const [x, y, z] = bboxToTile(bboxFeature)
+  const tiles = getTilesByBbox([x, y, z], lineString, zoom)
+  return tiles
+}
+
+function getTilesByBbox([x, y, z], geojson, zoom) {
+  const tiles = []
+  if (z === zoom) {
+    return [`${z}/${x}/${y}`]
+  }
+
+  if (z < zoom) {
+    const childTiles = getChildren([x, y, z])
+    for (const childTile of childTiles) {
+      const childTileBbox = tileToBBOX(childTile)
+      const bboxPolygon = turf.bboxPolygon(childTileBbox)
+      if (turf.booleanIntersects(geojson, bboxPolygon)) {
+        tiles.push(...getTilesByBbox(childTile, geojson, zoom))
+      }
+    }
+  } else {
+    const parentTile = getParent([x, y, z])
+    tiles.push(...getTilesByBbox(parentTile, geojson, zoom))
+  }
+
+  return union(tiles)
+}
+
+module.exports = {
+  calcMetaTilesVoie,
+  calcMetaTilesNumero,
+  getParentTile,
+  updateVoieTile,
+  updateVoiesTile,
+  ZOOM,
+}

--- a/migrations/2023-06-16-add-tile.js
+++ b/migrations/2023-06-16-add-tile.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/* eslint no-await-in-loop: off */
+require('dotenv').config()
+const mongo = require('../lib/util/mongo')
+const {calcMetaTilesNumero, calcMetaTilesVoie} = require('../lib/util/tiles')
+
+async function addTilesToVoies() {
+  let index = 0
+  const limit = 1000
+  let bulk = []
+
+  const total = await mongo.db.collection('voies').countDocuments({centroid: null})
+  const cursor = mongo.db.collection('voies').find({centroid: null}).project({_id: 1, typeNumerotation: 1, trace: 1})
+  console.log('TOTAL :', total)
+  for await (const v of cursor) {
+    const {centroid, centroidTiles, traceTiles} = await calcMetaTilesVoie(v)
+    bulk.push({updateOne: {
+      filter: {_id: v._id},
+      update: {$set: {centroid, centroidTiles, traceTiles}}
+    }})
+
+    index += 1
+    if (bulk.length >= limit || index >= total) {
+      console.log(index)
+      await mongo.db.collection('voies').bulkWrite(bulk)
+      bulk = []
+    }
+  }
+
+  console.log('TOTAL UPDATE', index)
+}
+
+async function addTilesToNumeros() {
+  let index = 0
+  const limit = 10000
+  let bulk = []
+
+  const total = await mongo.db.collection('numeros').countDocuments({tiles: null})
+  const cursor = mongo.db.collection('numeros').find({tiles: null}).project({_id: 1, positions: 1})
+  console.log('TOTAL :', total)
+  for await (const n of cursor) {
+    const {tiles} = calcMetaTilesNumero(n)
+    bulk.push({updateOne: {
+      filter: {_id: n._id},
+      update: {$set: {tiles}}
+    }})
+
+    index += 1
+    if (bulk.length >= limit || index >= total) {
+      console.log(index)
+      await mongo.db.collection('numeros').bulkWrite(bulk)
+      bulk = []
+    }
+  }
+
+  console.log('TOTAL UPDATE', index)
+}
+
+async function main() {
+  await mongo.connect()
+  console.log('START numeros')
+  await addTilesToNumeros()
+  console.log('Tiles are added to numeros')
+  console.log('START voies')
+  await addTilesToVoies()
+  console.log('Tiles are added to voies')
+  await mongo.disconnect()
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exit(1)
+}).then(() => {
+  process.exit(0)
+})

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "@ban-team/validateur-bal": "^2.13.0",
     "@etalab/decoupage-administratif": "^3.0.0",
     "@etalab/project-legal": "^0.6.0",
+    "@mapbox/tilebelt": "^1.0.2",
+    "@turf/turf": "^6.5.0",
     "bluebird": "^3.7.2",
     "body-parser": "^1.20.0",
     "cors": "^2.8.5",
@@ -46,6 +48,7 @@
     "ms": "^2.1.3",
     "nodemailer": "^6.7.5",
     "pumpify": "^2.0.1",
+    "randomcolor": "^0.6.2",
     "vt-pbf": "^3.1.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -300,6 +300,11 @@
   resolved "https://registry.yarnpkg.com/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz#8a83f9335c7860effa2eeeca254332aa0aeed8f2"
   integrity sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI=
 
+"@mapbox/tilebelt@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@mapbox/tilebelt/-/tilebelt-1.0.2.tgz#32936c3acad3ea3e669bb083a598bcc7d74b4ec9"
+  integrity sha512-tGJN2VIgWrXqBTPIxFVklklIpcy6ss8W5ouq+cjNLXPXFraRaDR4Ice+5Q8/uLX+6aH23lWBMydOIn8PcdVcpA==
+
 "@mapbox/vector-tile@^1.3.1":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz#d3a74c90402d06e89ec66de49ec817ff53409666"
@@ -357,7 +362,375 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@turf/distance@^6.3.0":
+"@turf/along@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/along/-/along-6.5.0.tgz#ab12eec58a14de60fe243a62d31a474f415c8fef"
+  integrity sha512-LLyWQ0AARqJCmMcIEAXF4GEu8usmd4Kbz3qk1Oy5HoRNpZX47+i5exQtmIWKdqJ1MMhW26fCTXgpsEs5zgJ5gw==
+  dependencies:
+    "@turf/bearing" "^6.5.0"
+    "@turf/destination" "^6.5.0"
+    "@turf/distance" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+
+"@turf/angle@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/angle/-/angle-6.5.0.tgz#985934171284e109d41e19ed48ad91cf9709a928"
+  integrity sha512-4pXMbWhFofJJAOvTMCns6N4C8CMd5Ih4O2jSAG9b3dDHakj3O4yN1+Zbm+NUei+eVEZ9gFeVp9svE3aMDenIkw==
+  dependencies:
+    "@turf/bearing" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/rhumb-bearing" "^6.5.0"
+
+"@turf/area@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/area/-/area-6.5.0.tgz#1d0d7aee01d8a4a3d4c91663ed35cc615f36ad56"
+  integrity sha512-xCZdiuojokLbQ+29qR6qoMD89hv+JAgWjLrwSEWL+3JV8IXKeNFl6XkEJz9HGkVpnXvQKJoRz4/liT+8ZZ5Jyg==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/bbox-clip@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/bbox-clip/-/bbox-clip-6.5.0.tgz#8e07d51ef8c875f9490d5c8699a2e51918587c94"
+  integrity sha512-F6PaIRF8WMp8EmgU/Ke5B1Y6/pia14UAYB5TiBC668w5rVVjy5L8rTm/m2lEkkDMHlzoP9vNY4pxpNthE7rLcQ==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+
+"@turf/bbox-polygon@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/bbox-polygon/-/bbox-polygon-6.5.0.tgz#f18128b012eedfa860a521d8f2b3779cc0801032"
+  integrity sha512-+/r0NyL1lOG3zKZmmf6L8ommU07HliP4dgYToMoTxqzsWzyLjaj/OzgQ8rBmv703WJX+aS6yCmLuIhYqyufyuw==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+
+"@turf/bbox@*", "@turf/bbox@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/bbox/-/bbox-6.5.0.tgz#bec30a744019eae420dac9ea46fb75caa44d8dc5"
+  integrity sha512-RBbLaao5hXTYyyg577iuMtDB8ehxMlUqHEJiMs8jT1GHkFhr6sYre3lmLsPeYEi/ZKj5TP5tt7fkzNdJ4GIVyw==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/bearing@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/bearing/-/bearing-6.5.0.tgz#462a053c6c644434bdb636b39f8f43fb0cd857b0"
+  integrity sha512-dxINYhIEMzgDOztyMZc20I7ssYVNEpSv04VbMo5YPQsqa80KO3TFvbuCahMsCAW5z8Tncc8dwBlEFrmRjJG33A==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+
+"@turf/bezier-spline@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/bezier-spline/-/bezier-spline-6.5.0.tgz#d1b1764948b0fa3d9aa6e4895aebeba24048b11f"
+  integrity sha512-vokPaurTd4PF96rRgGVm6zYYC5r1u98ZsG+wZEv9y3kJTuJRX/O3xIY2QnTGTdbVmAJN1ouOsD0RoZYaVoXORQ==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+
+"@turf/boolean-clockwise@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-clockwise/-/boolean-clockwise-6.5.0.tgz#34573ecc18f900080f00e4ff364631a8b1135794"
+  integrity sha512-45+C7LC5RMbRWrxh3Z0Eihsc8db1VGBO5d9BLTOAwU4jR6SgsunTfRWR16X7JUwIDYlCVEmnjcXJNi/kIU3VIw==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+
+"@turf/boolean-contains@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-contains/-/boolean-contains-6.5.0.tgz#f802e7432fb53109242d5bf57393ef2f53849bbf"
+  integrity sha512-4m8cJpbw+YQcKVGi8y0cHhBUnYT+QRfx6wzM4GI1IdtYH3p4oh/DOBJKrepQyiDzFDaNIjxuWXBh0ai1zVwOQQ==
+  dependencies:
+    "@turf/bbox" "^6.5.0"
+    "@turf/boolean-point-in-polygon" "^6.5.0"
+    "@turf/boolean-point-on-line" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+
+"@turf/boolean-crosses@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-crosses/-/boolean-crosses-6.5.0.tgz#4a1981475b9d6e23b25721f9fb8ef20696ff1648"
+  integrity sha512-gvshbTPhAHporTlQwBJqyfW+2yV8q/mOTxG6PzRVl6ARsqNoqYQWkd4MLug7OmAqVyBzLK3201uAeBjxbGw0Ng==
+  dependencies:
+    "@turf/boolean-point-in-polygon" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/line-intersect" "^6.5.0"
+    "@turf/polygon-to-line" "^6.5.0"
+
+"@turf/boolean-disjoint@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-disjoint/-/boolean-disjoint-6.5.0.tgz#e291d8f8f8cce7f7bb3c11e23059156a49afc5e4"
+  integrity sha512-rZ2ozlrRLIAGo2bjQ/ZUu4oZ/+ZjGvLkN5CKXSKBcu6xFO6k2bgqeM8a1836tAW+Pqp/ZFsTA5fZHsJZvP2D5g==
+  dependencies:
+    "@turf/boolean-point-in-polygon" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/line-intersect" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+    "@turf/polygon-to-line" "^6.5.0"
+
+"@turf/boolean-equal@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-equal/-/boolean-equal-6.5.0.tgz#b1c0ce14e9d9fb7778cddcf22558c9f523fe9141"
+  integrity sha512-cY0M3yoLC26mhAnjv1gyYNQjn7wxIXmL2hBmI/qs8g5uKuC2hRWi13ydufE3k4x0aNRjFGlg41fjoYLwaVF+9Q==
+  dependencies:
+    "@turf/clean-coords" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    geojson-equality "0.1.6"
+
+"@turf/boolean-intersects@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-intersects/-/boolean-intersects-6.5.0.tgz#df2b831ea31a4574af6b2fefe391f097a926b9d6"
+  integrity sha512-nIxkizjRdjKCYFQMnml6cjPsDOBCThrt+nkqtSEcxkKMhAQj5OO7o2CecioNTaX8EayqwMGVKcsz27oP4mKPTw==
+  dependencies:
+    "@turf/boolean-disjoint" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/boolean-overlap@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-overlap/-/boolean-overlap-6.5.0.tgz#f27c85888c3665d42d613a91a83adf1657cd1385"
+  integrity sha512-8btMIdnbXVWUa1M7D4shyaSGxLRw6NjMcqKBcsTXcZdnaixl22k7ar7BvIzkaRYN3SFECk9VGXfLncNS3ckQUw==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/line-intersect" "^6.5.0"
+    "@turf/line-overlap" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+    geojson-equality "0.1.6"
+
+"@turf/boolean-parallel@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-parallel/-/boolean-parallel-6.5.0.tgz#4e8a9dafdccaf18aca95f1265a5eade3f330173f"
+  integrity sha512-aSHJsr1nq9e5TthZGZ9CZYeXklJyRgR5kCLm5X4urz7+MotMOp/LsGOsvKvK9NeUl9+8OUmfMn8EFTT8LkcvIQ==
+  dependencies:
+    "@turf/clean-coords" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/line-segment" "^6.5.0"
+    "@turf/rhumb-bearing" "^6.5.0"
+
+"@turf/boolean-point-in-polygon@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.5.0.tgz#6d2e9c89de4cd2e4365004c1e51490b7795a63cf"
+  integrity sha512-DtSuVFB26SI+hj0SjrvXowGTUCHlgevPAIsukssW6BG5MlNSBQAo70wpICBNJL6RjukXg8d2eXaAWuD/CqL00A==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+
+"@turf/boolean-point-on-line@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-point-on-line/-/boolean-point-on-line-6.5.0.tgz#a8efa7bad88760676f395afb9980746bc5b376e9"
+  integrity sha512-A1BbuQ0LceLHvq7F/P7w3QvfpmZqbmViIUPHdNLvZimFNLo4e6IQunmzbe+8aSStH9QRZm3VOflyvNeXvvpZEQ==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+
+"@turf/boolean-within@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-within/-/boolean-within-6.5.0.tgz#31a749d3be51065da8c470a1e5613f4d2efdee06"
+  integrity sha512-YQB3oU18Inx35C/LU930D36RAVe7LDXk1kWsQ8mLmuqYn9YdPsDQTMTkLJMhoQ8EbN7QTdy333xRQ4MYgToteQ==
+  dependencies:
+    "@turf/bbox" "^6.5.0"
+    "@turf/boolean-point-in-polygon" "^6.5.0"
+    "@turf/boolean-point-on-line" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+
+"@turf/buffer@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/buffer/-/buffer-6.5.0.tgz#22bd0d05b4e1e73eaebc69b8f574a410ff704842"
+  integrity sha512-qeX4N6+PPWbKqp1AVkBVWFerGjMYMUyencwfnkCesoznU6qvfugFHNAngNqIBVnJjZ5n8IFyOf+akcxnrt9sNg==
+  dependencies:
+    "@turf/bbox" "^6.5.0"
+    "@turf/center" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+    "@turf/projection" "^6.5.0"
+    d3-geo "1.7.1"
+    turf-jsts "*"
+
+"@turf/center-mean@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/center-mean/-/center-mean-6.5.0.tgz#2dc329c003f8012ba9ae7812a61b5647e1ae86a2"
+  integrity sha512-AAX6f4bVn12pTVrMUiB9KrnV94BgeBKpyg3YpfnEbBpkN/znfVhL8dG8IxMAxAoSZ61Zt9WLY34HfENveuOZ7Q==
+  dependencies:
+    "@turf/bbox" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/center-median@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/center-median/-/center-median-6.5.0.tgz#1b68e3f288af47f76c247d6bf671f30d8c25c974"
+  integrity sha512-dT8Ndu5CiZkPrj15PBvslpuf01ky41DEYEPxS01LOxp5HOUHXp1oJxsPxvc+i/wK4BwccPNzU1vzJ0S4emd1KQ==
+  dependencies:
+    "@turf/center-mean" "^6.5.0"
+    "@turf/centroid" "^6.5.0"
+    "@turf/distance" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/center-of-mass@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/center-of-mass/-/center-of-mass-6.5.0.tgz#f9e6988bc296b7f763a0137ad6095f54843cf06a"
+  integrity sha512-EWrriU6LraOfPN7m1jZi+1NLTKNkuIsGLZc2+Y8zbGruvUW+QV7K0nhf7iZWutlxHXTBqEXHbKue/o79IumAsQ==
+  dependencies:
+    "@turf/centroid" "^6.5.0"
+    "@turf/convex" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/center@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/center/-/center-6.5.0.tgz#3bcb6bffcb8ba147430cfea84aabaed5dbdd4f07"
+  integrity sha512-T8KtMTfSATWcAX088rEDKjyvQCBkUsLnK/Txb6/8WUXIeOZyHu42G7MkdkHRoHtwieLdduDdmPLFyTdG5/e7ZQ==
+  dependencies:
+    "@turf/bbox" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+
+"@turf/centroid@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/centroid/-/centroid-6.5.0.tgz#ecaa365412e5a4d595bb448e7dcdacfb49eb0009"
+  integrity sha512-MwE1oq5E3isewPprEClbfU5pXljIK/GUOMbn22UM3IFPDJX0KeoyLNwghszkdmFp/qMGL/M13MMWvU+GNLXP/A==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/circle@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/circle/-/circle-6.5.0.tgz#dc017d8c0131d1d212b7c06f76510c22bbeb093c"
+  integrity sha512-oU1+Kq9DgRnoSbWFHKnnUdTmtcRUMmHoV9DjTXu9vOLNV5OWtAAh1VZ+mzsioGGzoDNT/V5igbFOkMfBQc0B6A==
+  dependencies:
+    "@turf/destination" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+
+"@turf/clean-coords@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/clean-coords/-/clean-coords-6.5.0.tgz#6690adf764ec4b649710a8a20dab7005efbea53f"
+  integrity sha512-EMX7gyZz0WTH/ET7xV8MyrExywfm9qUi0/MY89yNffzGIEHuFfqwhcCqZ8O00rZIPZHUTxpmsxQSTfzJJA1CPw==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+
+"@turf/clone@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/clone/-/clone-6.5.0.tgz#895860573881ae10a02dfff95f274388b1cda51a"
+  integrity sha512-mzVtTFj/QycXOn6ig+annKrM6ZlimreKYz6f/GSERytOpgzodbQyOgkfwru100O1KQhhjSudKK4DsQ0oyi9cTw==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+
+"@turf/clusters-dbscan@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/clusters-dbscan/-/clusters-dbscan-6.5.0.tgz#e01f854d24fac4899009fc6811854424ea8f0985"
+  integrity sha512-SxZEE4kADU9DqLRiT53QZBBhu8EP9skviSyl+FGj08Y01xfICM/RR9ACUdM0aEQimhpu+ZpRVcUK+2jtiCGrYQ==
+  dependencies:
+    "@turf/clone" "^6.5.0"
+    "@turf/distance" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+    density-clustering "1.3.0"
+
+"@turf/clusters-kmeans@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/clusters-kmeans/-/clusters-kmeans-6.5.0.tgz#aca6f66858af6476b7352a2bbbb392f9ddb7f5b4"
+  integrity sha512-DwacD5+YO8kwDPKaXwT9DV46tMBVNsbi1IzdajZu1JDSWoN7yc7N9Qt88oi+p30583O0UPVkAK+A10WAQv4mUw==
+  dependencies:
+    "@turf/clone" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+    skmeans "0.9.7"
+
+"@turf/clusters@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/clusters/-/clusters-6.5.0.tgz#a5ee7b62cdf345db2f1eafe2eb382adc186163e1"
+  integrity sha512-Y6gfnTJzQ1hdLfCsyd5zApNbfLIxYEpmDibHUqR5z03Lpe02pa78JtgrgUNt1seeO/aJ4TG1NLN8V5gOrHk04g==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/collect@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/collect/-/collect-6.5.0.tgz#3749ca7d4b91fbcbe1b9b8858ed70df8b6290910"
+  integrity sha512-4dN/T6LNnRg099m97BJeOcTA5fSI8cu87Ydgfibewd2KQwBexO69AnjEFqfPX3Wj+Zvisj1uAVIZbPmSSrZkjg==
+  dependencies:
+    "@turf/bbox" "^6.5.0"
+    "@turf/boolean-point-in-polygon" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    rbush "2.x"
+
+"@turf/combine@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/combine/-/combine-6.5.0.tgz#e0f3468ac9c09c24fa7184ebbd8a79d2e595ef81"
+  integrity sha512-Q8EIC4OtAcHiJB3C4R+FpB4LANiT90t17uOd851qkM2/o6m39bfN5Mv0PWqMZIHWrrosZqRqoY9dJnzz/rJxYQ==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/concave@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/concave/-/concave-6.5.0.tgz#19ab1a3f04087c478cebc5e631293f3eeb2e7ce4"
+  integrity sha512-I/sUmUC8TC5h/E2vPwxVht+nRt+TnXIPRoztDFvS8/Y0+cBDple9inLSo9nnPXMXidrBlGXZ9vQx/BjZUJgsRQ==
+  dependencies:
+    "@turf/clone" "^6.5.0"
+    "@turf/distance" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+    "@turf/tin" "^6.5.0"
+    topojson-client "3.x"
+    topojson-server "3.x"
+
+"@turf/convex@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/convex/-/convex-6.5.0.tgz#a7613e0d3795e2f5b9ce79a39271e86f54a3d354"
+  integrity sha512-x7ZwC5z7PJB0SBwNh7JCeCNx7Iu+QSrH7fYgK0RhhNop13TqUlvHMirMLRgf2db1DqUetrAO2qHJeIuasquUWg==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+    concaveman "*"
+
+"@turf/destination@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/destination/-/destination-6.5.0.tgz#30a84702f9677d076130e0440d3223ae503fdae1"
+  integrity sha512-4cnWQlNC8d1tItOz9B4pmJdWpXqS0vEvv65bI/Pj/genJnsL7evI0/Xw42RvEGROS481MPiU80xzvwxEvhQiMQ==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+
+"@turf/difference@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/difference/-/difference-6.5.0.tgz#677b0d5641a93bba2e82f2c683f0d880105b3197"
+  integrity sha512-l8iR5uJqvI+5Fs6leNbhPY5t/a3vipUF/3AeVLpwPQcgmedNXyheYuy07PcMGH5Jdpi5gItOiTqwiU/bUH4b3A==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    polygon-clipping "^0.15.3"
+
+"@turf/dissolve@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/dissolve/-/dissolve-6.5.0.tgz#65debed7ef185087d842b450ebd01e81cc2e80f6"
+  integrity sha512-WBVbpm9zLTp0Bl9CE35NomTaOL1c4TQCtEoO43YaAhNEWJOOIhZMFJyr8mbvYruKl817KinT3x7aYjjCMjTAsQ==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+    polygon-clipping "^0.15.3"
+
+"@turf/distance-weight@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/distance-weight/-/distance-weight-6.5.0.tgz#fe1fb45b5ae5ca4e09a898cb0a15c6c79ed0849e"
+  integrity sha512-a8qBKkgVNvPKBfZfEJZnC3DV7dfIsC3UIdpRci/iap/wZLH41EmS90nM+BokAJflUHYy8PqE44wySGWHN1FXrQ==
+  dependencies:
+    "@turf/centroid" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/distance@^6.3.0", "@turf/distance@^6.5.0":
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/@turf/distance/-/distance-6.5.0.tgz#21f04d5f86e864d54e2abde16f35c15b4f36149a"
   integrity sha512-xzykSLfoURec5qvQJcfifw/1mJa+5UwByZZ5TZ8iaqjGYN0vomhV9aiSLeYdUGtYRESZ+DYC/OzY+4RclZYgMg==
@@ -365,10 +738,98 @@
     "@turf/helpers" "^6.5.0"
     "@turf/invariant" "^6.5.0"
 
-"@turf/helpers@^6.5.0":
+"@turf/ellipse@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/ellipse/-/ellipse-6.5.0.tgz#1e20cc9eb968f35ab891572892a0bffcef5e552a"
+  integrity sha512-kuXtwFviw/JqnyJXF1mrR/cb496zDTSbGKtSiolWMNImYzGGkbsAsFTjwJYgD7+4FixHjp0uQPzo70KDf3AIBw==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/rhumb-destination" "^6.5.0"
+    "@turf/transform-rotate" "^6.5.0"
+
+"@turf/envelope@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/envelope/-/envelope-6.5.0.tgz#73e81b9b7ed519bd8a614d36322d6f9fbeeb0579"
+  integrity sha512-9Z+FnBWvOGOU4X+fMZxYFs1HjFlkKqsddLuMknRaqcJd6t+NIv5DWvPtDL8ATD2GEExYDiFLwMdckfr1yqJgHA==
+  dependencies:
+    "@turf/bbox" "^6.5.0"
+    "@turf/bbox-polygon" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+
+"@turf/explode@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/explode/-/explode-6.5.0.tgz#02c292cc143dd629643da5b70bb5b19b9f0f1c6b"
+  integrity sha512-6cSvMrnHm2qAsace6pw9cDmK2buAlw8+tjeJVXMfMyY+w7ZUi1rprWMsY92J7s2Dar63Bv09n56/1V7+tcj52Q==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/flatten@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/flatten/-/flatten-6.5.0.tgz#0bd26161f4f1759bbad6ba9485e8ee65f3fa72a7"
+  integrity sha512-IBZVwoNLVNT6U/bcUUllubgElzpMsNoCw8tLqBw6dfYg9ObGmpEjf9BIYLr7a2Yn5ZR4l7YIj2T7kD5uJjZADQ==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/flip@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/flip/-/flip-6.5.0.tgz#04b38eae8a78f2cf9240140b25401b16b37d20e2"
+  integrity sha512-oyikJFNjt2LmIXQqgOGLvt70RgE2lyzPMloYWM7OR5oIFGRiBvqVD2hA6MNw6JewIm30fWZ8DQJw1NHXJTJPbg==
+  dependencies:
+    "@turf/clone" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/great-circle@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/great-circle/-/great-circle-6.5.0.tgz#2daccbdd1c609a13b00d566ea0ad95457cfc87c2"
+  integrity sha512-7ovyi3HaKOXdFyN7yy1yOMa8IyOvV46RC1QOQTT+RYUN8ke10eyqExwBpL9RFUPvlpoTzoYbM/+lWPogQlFncg==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+
+"@turf/helpers@6.x", "@turf/helpers@^6.5.0":
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-6.5.0.tgz#f79af094bd6b8ce7ed2bd3e089a8493ee6cae82e"
   integrity sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==
+
+"@turf/hex-grid@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/hex-grid/-/hex-grid-6.5.0.tgz#aa5ee46e291839d4405db74b7516c6da89ee56f7"
+  integrity sha512-Ln3tc2tgZT8etDOldgc6e741Smg1CsMKAz1/Mlel+MEL5Ynv2mhx3m0q4J9IB1F3a4MNjDeVvm8drAaf9SF33g==
+  dependencies:
+    "@turf/distance" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/intersect" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+
+"@turf/interpolate@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/interpolate/-/interpolate-6.5.0.tgz#9120def5d4498dd7b7d5e92a263aac3e1fd92886"
+  integrity sha512-LSH5fMeiGyuDZ4WrDJNgh81d2DnNDUVJtuFryJFup8PV8jbs46lQGfI3r1DJ2p1IlEJIz3pmAZYeTfMMoeeohw==
+  dependencies:
+    "@turf/bbox" "^6.5.0"
+    "@turf/centroid" "^6.5.0"
+    "@turf/clone" "^6.5.0"
+    "@turf/distance" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/hex-grid" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+    "@turf/point-grid" "^6.5.0"
+    "@turf/square-grid" "^6.5.0"
+    "@turf/triangle-grid" "^6.5.0"
+
+"@turf/intersect@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/intersect/-/intersect-6.5.0.tgz#a14e161ddd0264d0f07ac4e325553c70c421f9e6"
+  integrity sha512-2legGJeKrfFkzntcd4GouPugoqPUjexPZnOvfez+3SfIMrHvulw8qV8u7pfVyn2Yqs53yoVCEjS5sEpvQ5YRQg==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    polygon-clipping "^0.15.3"
 
 "@turf/invariant@^6.5.0":
   version "6.5.0"
@@ -376,6 +837,667 @@
   integrity sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==
   dependencies:
     "@turf/helpers" "^6.5.0"
+
+"@turf/isobands@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/isobands/-/isobands-6.5.0.tgz#5e0929d9d8d53147074a5cfe4533768782e2a2ce"
+  integrity sha512-4h6sjBPhRwMVuFaVBv70YB7eGz+iw0bhPRnp+8JBdX1UPJSXhoi/ZF2rACemRUr0HkdVB/a1r9gC32vn5IAEkw==
+  dependencies:
+    "@turf/area" "^6.5.0"
+    "@turf/bbox" "^6.5.0"
+    "@turf/boolean-point-in-polygon" "^6.5.0"
+    "@turf/explode" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+    object-assign "*"
+
+"@turf/isolines@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/isolines/-/isolines-6.5.0.tgz#3435c7cb5a79411207a5657aa4095357cfd35831"
+  integrity sha512-6ElhiLCopxWlv4tPoxiCzASWt/jMRvmp6mRYrpzOm3EUl75OhHKa/Pu6Y9nWtCMmVC/RcWtiiweUocbPLZLm0A==
+  dependencies:
+    "@turf/bbox" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+    object-assign "*"
+
+"@turf/kinks@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/kinks/-/kinks-6.5.0.tgz#80e7456367535365012f658cf1a988b39a2c920b"
+  integrity sha512-ViCngdPt1eEL7hYUHR2eHR662GvCgTc35ZJFaNR6kRtr6D8plLaDju0FILeFFWSc+o8e3fwxZEJKmFj9IzPiIQ==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+
+"@turf/length@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/length/-/length-6.5.0.tgz#ff4e9072d5f997e1c32a1311d214d184463f83fa"
+  integrity sha512-5pL5/pnw52fck3oRsHDcSGrj9HibvtlrZ0QNy2OcW8qBFDNgZ4jtl6U7eATVoyWPKBHszW3dWETW+iLV7UARig==
+  dependencies:
+    "@turf/distance" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/line-arc@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/line-arc/-/line-arc-6.5.0.tgz#5ca35516ccf1f3a01149889d9facb39a77b07431"
+  integrity sha512-I6c+V6mIyEwbtg9P9zSFF89T7QPe1DPTG3MJJ6Cm1MrAY0MdejwQKOpsvNl8LDU2ekHOlz2kHpPVR7VJsoMllA==
+  dependencies:
+    "@turf/circle" "^6.5.0"
+    "@turf/destination" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+
+"@turf/line-chunk@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/line-chunk/-/line-chunk-6.5.0.tgz#02cefa74564b9cf533a3ac8a5109c97cb7170d10"
+  integrity sha512-i1FGE6YJaaYa+IJesTfyRRQZP31QouS+wh/pa6O3CC0q4T7LtHigyBSYjrbjSLfn2EVPYGlPCMFEqNWCOkC6zg==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/length" "^6.5.0"
+    "@turf/line-slice-along" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/line-intersect@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/line-intersect/-/line-intersect-6.5.0.tgz#dea48348b30c093715d2195d2dd7524aee4cf020"
+  integrity sha512-CS6R1tZvVQD390G9Ea4pmpM6mJGPWoL82jD46y0q1KSor9s6HupMIo1kY4Ny+AEYQl9jd21V3Scz20eldpbTVA==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/line-segment" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+    geojson-rbush "3.x"
+
+"@turf/line-offset@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/line-offset/-/line-offset-6.5.0.tgz#2bbd8fcf9ff82009b72890863da444b190e53689"
+  integrity sha512-CEXZbKgyz8r72qRvPchK0dxqsq8IQBdH275FE6o4MrBkzMcoZsfSjghtXzKaz9vvro+HfIXal0sTk2mqV1lQTw==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/line-overlap@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/line-overlap/-/line-overlap-6.5.0.tgz#10ebb805c2d047463379fc1f997785fa8f3f4cc1"
+  integrity sha512-xHOaWLd0hkaC/1OLcStCpfq55lPHpPNadZySDXYiYjEz5HXr1oKmtMYpn0wGizsLwrOixRdEp+j7bL8dPt4ojQ==
+  dependencies:
+    "@turf/boolean-point-on-line" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/line-segment" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+    "@turf/nearest-point-on-line" "^6.5.0"
+    deep-equal "1.x"
+    geojson-rbush "3.x"
+
+"@turf/line-segment@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/line-segment/-/line-segment-6.5.0.tgz#ee73f3ffcb7c956203b64ed966d96af380a4dd65"
+  integrity sha512-jI625Ho4jSuJESNq66Mmi290ZJ5pPZiQZruPVpmHkUw257Pew0alMmb6YrqYNnLUuiVVONxAAKXUVeeUGtycfw==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/line-slice-along@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/line-slice-along/-/line-slice-along-6.5.0.tgz#6e7a861d72c6f80caba2c4418b69a776f0292953"
+  integrity sha512-KHJRU6KpHrAj+BTgTNqby6VCTnDzG6a1sJx/I3hNvqMBLvWVA2IrkR9L9DtsQsVY63IBwVdQDqiwCuZLDQh4Ng==
+  dependencies:
+    "@turf/bearing" "^6.5.0"
+    "@turf/destination" "^6.5.0"
+    "@turf/distance" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+
+"@turf/line-slice@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/line-slice/-/line-slice-6.5.0.tgz#7b6e0c8e8e93fdb4e65c3b9a123a2ec93a21bdb0"
+  integrity sha512-vDqJxve9tBHhOaVVFXqVjF5qDzGtKWviyjbyi2QnSnxyFAmLlLnBfMX8TLQCAf2GxHibB95RO5FBE6I2KVPRuw==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/nearest-point-on-line" "^6.5.0"
+
+"@turf/line-split@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/line-split/-/line-split-6.5.0.tgz#116d7fbf714457878225187f5820ef98db7b02c2"
+  integrity sha512-/rwUMVr9OI2ccJjw7/6eTN53URtGThNSD5I0GgxyFXMtxWiloRJ9MTff8jBbtPWrRka/Sh2GkwucVRAEakx9Sw==
+  dependencies:
+    "@turf/bbox" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/line-intersect" "^6.5.0"
+    "@turf/line-segment" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+    "@turf/nearest-point-on-line" "^6.5.0"
+    "@turf/square" "^6.5.0"
+    "@turf/truncate" "^6.5.0"
+    geojson-rbush "3.x"
+
+"@turf/line-to-polygon@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/line-to-polygon/-/line-to-polygon-6.5.0.tgz#c919a03064a1cd5cef4c4e4d98dc786e12ffbc89"
+  integrity sha512-qYBuRCJJL8Gx27OwCD1TMijM/9XjRgXH/m/TyuND4OXedBpIWlK5VbTIO2gJ8OCfznBBddpjiObLBrkuxTpN4Q==
+  dependencies:
+    "@turf/bbox" "^6.5.0"
+    "@turf/clone" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+
+"@turf/mask@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/mask/-/mask-6.5.0.tgz#a97f355ee071ac60d8d3782ae39e5bb4b4e26857"
+  integrity sha512-RQha4aU8LpBrmrkH8CPaaoAfk0Egj5OuXtv6HuCQnHeGNOQt3TQVibTA3Sh4iduq4EPxnZfDjgsOeKtrCA19lg==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    polygon-clipping "^0.15.3"
+
+"@turf/meta@6.x", "@turf/meta@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-6.5.0.tgz#b725c3653c9f432133eaa04d3421f7e51e0418ca"
+  integrity sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+
+"@turf/midpoint@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/midpoint/-/midpoint-6.5.0.tgz#5f9428959309feccaf3f55873a8de70d4121bdce"
+  integrity sha512-MyTzV44IwmVI6ec9fB2OgZ53JGNlgOpaYl9ArKoF49rXpL84F9rNATndbe0+MQIhdkw8IlzA6xVP4lZzfMNVCw==
+  dependencies:
+    "@turf/bearing" "^6.5.0"
+    "@turf/destination" "^6.5.0"
+    "@turf/distance" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+
+"@turf/moran-index@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/moran-index/-/moran-index-6.5.0.tgz#456264bfb014a7b5f527807c9dcf25df3c6b2efd"
+  integrity sha512-ItsnhrU2XYtTtTudrM8so4afBCYWNaB0Mfy28NZwLjB5jWuAsvyV+YW+J88+neK/ougKMTawkmjQqodNJaBeLQ==
+  dependencies:
+    "@turf/distance-weight" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/nearest-point-on-line@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/nearest-point-on-line/-/nearest-point-on-line-6.5.0.tgz#8e1cd2cdc0b5acaf4c8d8b3b33bb008d3cb99e7b"
+  integrity sha512-WthrvddddvmymnC+Vf7BrkHGbDOUu6Z3/6bFYUGv1kxw8tiZ6n83/VG6kHz4poHOfS0RaNflzXSkmCi64fLBlg==
+  dependencies:
+    "@turf/bearing" "^6.5.0"
+    "@turf/destination" "^6.5.0"
+    "@turf/distance" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/line-intersect" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/nearest-point-to-line@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/nearest-point-to-line/-/nearest-point-to-line-6.5.0.tgz#5549b48690d523f9af4765fe64a3cbebfbc6bb75"
+  integrity sha512-PXV7cN0BVzUZdjj6oeb/ESnzXSfWmEMrsfZSDRgqyZ9ytdiIj/eRsnOXLR13LkTdXVOJYDBuf7xt1mLhM4p6+Q==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+    "@turf/point-to-line-distance" "^6.5.0"
+    object-assign "*"
+
+"@turf/nearest-point@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/nearest-point/-/nearest-point-6.5.0.tgz#2f1781c26ff3f054005d4ff352042973318b92f1"
+  integrity sha512-fguV09QxilZv/p94s8SMsXILIAMiaXI5PATq9d7YWijLxWUj6Q/r43kxyoi78Zmwwh1Zfqz9w+bCYUAxZ5+euA==
+  dependencies:
+    "@turf/clone" "^6.5.0"
+    "@turf/distance" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/planepoint@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/planepoint/-/planepoint-6.5.0.tgz#5cb788670c31a6b064ae464180d51b4d550d87de"
+  integrity sha512-R3AahA6DUvtFbka1kcJHqZ7DMHmPXDEQpbU5WaglNn7NaCQg9HB0XM0ZfqWcd5u92YXV+Gg8QhC8x5XojfcM4Q==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+
+"@turf/point-grid@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/point-grid/-/point-grid-6.5.0.tgz#f628d30afe29d60dcbf54b195e46eab48a4fbfaa"
+  integrity sha512-Iq38lFokNNtQJnOj/RBKmyt6dlof0yhaHEDELaWHuECm1lIZLY3ZbVMwbs+nXkwTAHjKfS/OtMheUBkw+ee49w==
+  dependencies:
+    "@turf/boolean-within" "^6.5.0"
+    "@turf/distance" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+
+"@turf/point-on-feature@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/point-on-feature/-/point-on-feature-6.5.0.tgz#37d07afeb31896e53c0833aa404993ba7d500f0c"
+  integrity sha512-bDpuIlvugJhfcF/0awAQ+QI6Om1Y1FFYE8Y/YdxGRongivix850dTeXCo0mDylFdWFPGDo7Mmh9Vo4VxNwW/TA==
+  dependencies:
+    "@turf/boolean-point-in-polygon" "^6.5.0"
+    "@turf/center" "^6.5.0"
+    "@turf/explode" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/nearest-point" "^6.5.0"
+
+"@turf/point-to-line-distance@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/point-to-line-distance/-/point-to-line-distance-6.5.0.tgz#bc46fe09ea630aaf73f13c40b38a7df79050fff8"
+  integrity sha512-opHVQ4vjUhNBly1bob6RWy+F+hsZDH9SA0UW36pIRzfpu27qipU18xup0XXEePfY6+wvhF6yL/WgCO2IbrLqEA==
+  dependencies:
+    "@turf/bearing" "^6.5.0"
+    "@turf/distance" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+    "@turf/projection" "^6.5.0"
+    "@turf/rhumb-bearing" "^6.5.0"
+    "@turf/rhumb-distance" "^6.5.0"
+
+"@turf/points-within-polygon@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/points-within-polygon/-/points-within-polygon-6.5.0.tgz#d49f4d7cf19b7a440bf1e06f771ff4e1df13107f"
+  integrity sha512-YyuheKqjliDsBDt3Ho73QVZk1VXX1+zIA2gwWvuz8bR1HXOkcuwk/1J76HuFMOQI3WK78wyAi+xbkx268PkQzQ==
+  dependencies:
+    "@turf/boolean-point-in-polygon" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/polygon-smooth@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/polygon-smooth/-/polygon-smooth-6.5.0.tgz#00ca366871cb6ea3bee44ff3ea870aaf75711733"
+  integrity sha512-LO/X/5hfh/Rk4EfkDBpLlVwt3i6IXdtQccDT9rMjXEP32tRgy0VMFmdkNaXoGlSSKf/1mGqLl4y4wHd86DqKbg==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/polygon-tangents@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/polygon-tangents/-/polygon-tangents-6.5.0.tgz#dc025202727ba2f3347baa95dbca4e0ffdb2ddf5"
+  integrity sha512-sB4/IUqJMYRQH9jVBwqS/XDitkEfbyqRy+EH/cMRJURTg78eHunvJ708x5r6umXsbiUyQU4eqgPzEylWEQiunw==
+  dependencies:
+    "@turf/bbox" "^6.5.0"
+    "@turf/boolean-within" "^6.5.0"
+    "@turf/explode" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/nearest-point" "^6.5.0"
+
+"@turf/polygon-to-line@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/polygon-to-line/-/polygon-to-line-6.5.0.tgz#4dc86db66168b32bb83ce448cf966208a447d952"
+  integrity sha512-5p4n/ij97EIttAq+ewSnKt0ruvuM+LIDzuczSzuHTpq4oS7Oq8yqg5TQ4nzMVuK41r/tALCk7nAoBuw3Su4Gcw==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+
+"@turf/polygonize@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/polygonize/-/polygonize-6.5.0.tgz#8aa0f1e386e96c533a320c426aaf387020320fa3"
+  integrity sha512-a/3GzHRaCyzg7tVYHo43QUChCspa99oK4yPqooVIwTC61npFzdrmnywMv0S+WZjHZwK37BrFJGFrZGf6ocmY5w==
+  dependencies:
+    "@turf/boolean-point-in-polygon" "^6.5.0"
+    "@turf/envelope" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/projection@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/projection/-/projection-6.5.0.tgz#d2aad862370bf03f2270701115464a8406c144b2"
+  integrity sha512-/Pgh9mDvQWWu8HRxqpM+tKz8OzgauV+DiOcr3FCjD6ubDnrrmMJlsf6fFJmggw93mtVPrZRL6yyi9aYCQBOIvg==
+  dependencies:
+    "@turf/clone" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/random@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/random/-/random-6.5.0.tgz#b19672cf4549557660034d4a303911656df7747e"
+  integrity sha512-8Q25gQ/XbA7HJAe+eXp4UhcXM9aOOJFaxZ02+XSNwMvY8gtWSCBLVqRcW4OhqilgZ8PeuQDWgBxeo+BIqqFWFQ==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+
+"@turf/rectangle-grid@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/rectangle-grid/-/rectangle-grid-6.5.0.tgz#c3ef38e8cfdb763012beb1f22e2b77288a37a5cf"
+  integrity sha512-yQZ/1vbW68O2KsSB3OZYK+72aWz/Adnf7m2CMKcC+aq6TwjxZjAvlbCOsNUnMAuldRUVN1ph6RXMG4e9KEvKvg==
+  dependencies:
+    "@turf/boolean-intersects" "^6.5.0"
+    "@turf/distance" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+
+"@turf/rewind@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/rewind/-/rewind-6.5.0.tgz#bc0088f8ec56f00c8eacd902bbe51e3786cb73a0"
+  integrity sha512-IoUAMcHWotBWYwSYuYypw/LlqZmO+wcBpn8ysrBNbazkFNkLf3btSDZMkKJO/bvOzl55imr/Xj4fi3DdsLsbzQ==
+  dependencies:
+    "@turf/boolean-clockwise" "^6.5.0"
+    "@turf/clone" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/rhumb-bearing@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/rhumb-bearing/-/rhumb-bearing-6.5.0.tgz#8c41ad62b44fb4e57c14fe790488056684eee7b9"
+  integrity sha512-jMyqiMRK4hzREjQmnLXmkJ+VTNTx1ii8vuqRwJPcTlKbNWfjDz/5JqJlb5NaFDcdMpftWovkW5GevfnuzHnOYA==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+
+"@turf/rhumb-destination@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/rhumb-destination/-/rhumb-destination-6.5.0.tgz#12da8c85e674b182e8b0ec8ea9c5fe2186716dae"
+  integrity sha512-RHNP1Oy+7xTTdRrTt375jOZeHceFbjwohPHlr9Hf68VdHHPMAWgAKqiX2YgSWDcvECVmiGaBKWus1Df+N7eE4Q==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+
+"@turf/rhumb-distance@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/rhumb-distance/-/rhumb-distance-6.5.0.tgz#ed068004b1469512b857070fbf5cb7b7eabbe592"
+  integrity sha512-oKp8KFE8E4huC2Z1a1KNcFwjVOqa99isxNOwfo4g3SUABQ6NezjKDDrnvC4yI5YZ3/huDjULLBvhed45xdCrzg==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+
+"@turf/sample@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/sample/-/sample-6.5.0.tgz#00cca024514989448e57fb1bf34e9a33ed3f0755"
+  integrity sha512-kSdCwY7el15xQjnXYW520heKUrHwRvnzx8ka4eYxX9NFeOxaFITLW2G7UtXb6LJK8mmPXI8Aexv23F2ERqzGFg==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+
+"@turf/sector@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/sector/-/sector-6.5.0.tgz#599a87ebbe6ee613b4e04c5928e0ef1fc78fc16c"
+  integrity sha512-cYUOkgCTWqa23SOJBqxoFAc/yGCUsPRdn/ovbRTn1zNTm/Spmk6hVB84LCKOgHqvSF25i0d2kWqpZDzLDdAPbw==
+  dependencies:
+    "@turf/circle" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/line-arc" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/shortest-path@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/shortest-path/-/shortest-path-6.5.0.tgz#e1fdf9b4758bd20caf845fdc03d0dc2eede2ff0e"
+  integrity sha512-4de5+G7+P4hgSoPwn+SO9QSi9HY5NEV/xRJ+cmoFVRwv2CDsuOPDheHKeuIAhKyeKDvPvPt04XYWbac4insJMg==
+  dependencies:
+    "@turf/bbox" "^6.5.0"
+    "@turf/bbox-polygon" "^6.5.0"
+    "@turf/boolean-point-in-polygon" "^6.5.0"
+    "@turf/clean-coords" "^6.5.0"
+    "@turf/distance" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+    "@turf/transform-scale" "^6.5.0"
+
+"@turf/simplify@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/simplify/-/simplify-6.5.0.tgz#ec435460bde0985b781618b05d97146c32c8bc16"
+  integrity sha512-USas3QqffPHUY184dwQdP8qsvcVH/PWBYdXY5am7YTBACaQOMAlf6AKJs9FT8jiO6fQpxfgxuEtwmox+pBtlOg==
+  dependencies:
+    "@turf/clean-coords" "^6.5.0"
+    "@turf/clone" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/square-grid@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/square-grid/-/square-grid-6.5.0.tgz#3a517301b42ed98aa62d727786dc5290998ddbae"
+  integrity sha512-mlR0ayUdA+L4c9h7p4k3pX6gPWHNGuZkt2c5II1TJRmhLkW2557d6b/Vjfd1z9OVaajb1HinIs1FMSAPXuuUrA==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/rectangle-grid" "^6.5.0"
+
+"@turf/square@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/square/-/square-6.5.0.tgz#ab43eef99d39c36157ab5b80416bbeba1f6b2122"
+  integrity sha512-BM2UyWDmiuHCadVhHXKIx5CQQbNCpOxB6S/aCNOCLbhCeypKX5Q0Aosc5YcmCJgkwO5BERCC6Ee7NMbNB2vHmQ==
+  dependencies:
+    "@turf/distance" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+
+"@turf/standard-deviational-ellipse@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-6.5.0.tgz#775c7b9a2be6546bf64ea8ac08cdcd80563f2935"
+  integrity sha512-02CAlz8POvGPFK2BKK8uHGUk/LXb0MK459JVjKxLC2yJYieOBTqEbjP0qaWhiBhGzIxSMaqe8WxZ0KvqdnstHA==
+  dependencies:
+    "@turf/center-mean" "^6.5.0"
+    "@turf/ellipse" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+    "@turf/points-within-polygon" "^6.5.0"
+
+"@turf/tag@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/tag/-/tag-6.5.0.tgz#13eae85f36f9fd8c4e076714a894cb5b7716d381"
+  integrity sha512-XwlBvrOV38CQsrNfrxvBaAPBQgXMljeU0DV8ExOyGM7/hvuGHJw3y8kKnQ4lmEQcmcrycjDQhP7JqoRv8vFssg==
+  dependencies:
+    "@turf/boolean-point-in-polygon" "^6.5.0"
+    "@turf/clone" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/tesselate@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/tesselate/-/tesselate-6.5.0.tgz#de45b778f8e6a45535d8eb2aacea06f86c6b73fb"
+  integrity sha512-M1HXuyZFCfEIIKkglh/r5L9H3c5QTEsnMBoZOFQiRnGPGmJWcaBissGb7mTFX2+DKE7FNWXh4TDnZlaLABB0dQ==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    earcut "^2.0.0"
+
+"@turf/tin@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/tin/-/tin-6.5.0.tgz#b77bebb48237e6613ac6bc0e37a6658be8c17a09"
+  integrity sha512-YLYikRzKisfwj7+F+Tmyy/LE3d2H7D4kajajIfc9mlik2+esG7IolsX/+oUz1biguDYsG0DUA8kVYXDkobukfg==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+
+"@turf/transform-rotate@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/transform-rotate/-/transform-rotate-6.5.0.tgz#e50e96a8779af91d58149eedb00ffd7f6395c804"
+  integrity sha512-A2Ip1v4246ZmpssxpcL0hhiVBEf4L8lGnSPWTgSv5bWBEoya2fa/0SnFX9xJgP40rMP+ZzRaCN37vLHbv1Guag==
+  dependencies:
+    "@turf/centroid" "^6.5.0"
+    "@turf/clone" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+    "@turf/rhumb-bearing" "^6.5.0"
+    "@turf/rhumb-destination" "^6.5.0"
+    "@turf/rhumb-distance" "^6.5.0"
+
+"@turf/transform-scale@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/transform-scale/-/transform-scale-6.5.0.tgz#dcccd8b0f139de32e32225a29c107a1279137120"
+  integrity sha512-VsATGXC9rYM8qTjbQJ/P7BswKWXHdnSJ35JlV4OsZyHBMxJQHftvmZJsFbOqVtQnIQIzf2OAly6rfzVV9QLr7g==
+  dependencies:
+    "@turf/bbox" "^6.5.0"
+    "@turf/center" "^6.5.0"
+    "@turf/centroid" "^6.5.0"
+    "@turf/clone" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+    "@turf/rhumb-bearing" "^6.5.0"
+    "@turf/rhumb-destination" "^6.5.0"
+    "@turf/rhumb-distance" "^6.5.0"
+
+"@turf/transform-translate@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/transform-translate/-/transform-translate-6.5.0.tgz#631b13aca6402898029e03fc2d1f4bc1c667fc3e"
+  integrity sha512-NABLw5VdtJt/9vSstChp93pc6oel4qXEos56RBMsPlYB8hzNTEKYtC146XJvyF4twJeeYS8RVe1u7KhoFwEM5w==
+  dependencies:
+    "@turf/clone" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+    "@turf/rhumb-destination" "^6.5.0"
+
+"@turf/triangle-grid@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/triangle-grid/-/triangle-grid-6.5.0.tgz#75664e8b9d9c7ca4c845673134a1e0d82b5e6887"
+  integrity sha512-2jToUSAS1R1htq4TyLQYPTIsoy6wg3e3BQXjm2rANzw4wPQCXGOxrur1Fy9RtzwqwljlC7DF4tg0OnWr8RjmfA==
+  dependencies:
+    "@turf/distance" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/intersect" "^6.5.0"
+
+"@turf/truncate@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/truncate/-/truncate-6.5.0.tgz#c3a16cad959f1be1c5156157d5555c64b19185d8"
+  integrity sha512-pFxg71pLk+eJj134Z9yUoRhIi8vqnnKvCYwdT4x/DQl/19RVdq1tV3yqOT3gcTQNfniteylL5qV1uTBDV5sgrg==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/turf@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/turf/-/turf-6.5.0.tgz#49cd07b942a757f3ebbdba6cb294bbb864825a83"
+  integrity sha512-ipMCPnhu59bh92MNt8+pr1VZQhHVuTMHklciQURo54heoxRzt1neNYZOBR6jdL+hNsbDGAECMuIpAutX+a3Y+w==
+  dependencies:
+    "@turf/along" "^6.5.0"
+    "@turf/angle" "^6.5.0"
+    "@turf/area" "^6.5.0"
+    "@turf/bbox" "^6.5.0"
+    "@turf/bbox-clip" "^6.5.0"
+    "@turf/bbox-polygon" "^6.5.0"
+    "@turf/bearing" "^6.5.0"
+    "@turf/bezier-spline" "^6.5.0"
+    "@turf/boolean-clockwise" "^6.5.0"
+    "@turf/boolean-contains" "^6.5.0"
+    "@turf/boolean-crosses" "^6.5.0"
+    "@turf/boolean-disjoint" "^6.5.0"
+    "@turf/boolean-equal" "^6.5.0"
+    "@turf/boolean-intersects" "^6.5.0"
+    "@turf/boolean-overlap" "^6.5.0"
+    "@turf/boolean-parallel" "^6.5.0"
+    "@turf/boolean-point-in-polygon" "^6.5.0"
+    "@turf/boolean-point-on-line" "^6.5.0"
+    "@turf/boolean-within" "^6.5.0"
+    "@turf/buffer" "^6.5.0"
+    "@turf/center" "^6.5.0"
+    "@turf/center-mean" "^6.5.0"
+    "@turf/center-median" "^6.5.0"
+    "@turf/center-of-mass" "^6.5.0"
+    "@turf/centroid" "^6.5.0"
+    "@turf/circle" "^6.5.0"
+    "@turf/clean-coords" "^6.5.0"
+    "@turf/clone" "^6.5.0"
+    "@turf/clusters" "^6.5.0"
+    "@turf/clusters-dbscan" "^6.5.0"
+    "@turf/clusters-kmeans" "^6.5.0"
+    "@turf/collect" "^6.5.0"
+    "@turf/combine" "^6.5.0"
+    "@turf/concave" "^6.5.0"
+    "@turf/convex" "^6.5.0"
+    "@turf/destination" "^6.5.0"
+    "@turf/difference" "^6.5.0"
+    "@turf/dissolve" "^6.5.0"
+    "@turf/distance" "^6.5.0"
+    "@turf/distance-weight" "^6.5.0"
+    "@turf/ellipse" "^6.5.0"
+    "@turf/envelope" "^6.5.0"
+    "@turf/explode" "^6.5.0"
+    "@turf/flatten" "^6.5.0"
+    "@turf/flip" "^6.5.0"
+    "@turf/great-circle" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/hex-grid" "^6.5.0"
+    "@turf/interpolate" "^6.5.0"
+    "@turf/intersect" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/isobands" "^6.5.0"
+    "@turf/isolines" "^6.5.0"
+    "@turf/kinks" "^6.5.0"
+    "@turf/length" "^6.5.0"
+    "@turf/line-arc" "^6.5.0"
+    "@turf/line-chunk" "^6.5.0"
+    "@turf/line-intersect" "^6.5.0"
+    "@turf/line-offset" "^6.5.0"
+    "@turf/line-overlap" "^6.5.0"
+    "@turf/line-segment" "^6.5.0"
+    "@turf/line-slice" "^6.5.0"
+    "@turf/line-slice-along" "^6.5.0"
+    "@turf/line-split" "^6.5.0"
+    "@turf/line-to-polygon" "^6.5.0"
+    "@turf/mask" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+    "@turf/midpoint" "^6.5.0"
+    "@turf/moran-index" "^6.5.0"
+    "@turf/nearest-point" "^6.5.0"
+    "@turf/nearest-point-on-line" "^6.5.0"
+    "@turf/nearest-point-to-line" "^6.5.0"
+    "@turf/planepoint" "^6.5.0"
+    "@turf/point-grid" "^6.5.0"
+    "@turf/point-on-feature" "^6.5.0"
+    "@turf/point-to-line-distance" "^6.5.0"
+    "@turf/points-within-polygon" "^6.5.0"
+    "@turf/polygon-smooth" "^6.5.0"
+    "@turf/polygon-tangents" "^6.5.0"
+    "@turf/polygon-to-line" "^6.5.0"
+    "@turf/polygonize" "^6.5.0"
+    "@turf/projection" "^6.5.0"
+    "@turf/random" "^6.5.0"
+    "@turf/rewind" "^6.5.0"
+    "@turf/rhumb-bearing" "^6.5.0"
+    "@turf/rhumb-destination" "^6.5.0"
+    "@turf/rhumb-distance" "^6.5.0"
+    "@turf/sample" "^6.5.0"
+    "@turf/sector" "^6.5.0"
+    "@turf/shortest-path" "^6.5.0"
+    "@turf/simplify" "^6.5.0"
+    "@turf/square" "^6.5.0"
+    "@turf/square-grid" "^6.5.0"
+    "@turf/standard-deviational-ellipse" "^6.5.0"
+    "@turf/tag" "^6.5.0"
+    "@turf/tesselate" "^6.5.0"
+    "@turf/tin" "^6.5.0"
+    "@turf/transform-rotate" "^6.5.0"
+    "@turf/transform-scale" "^6.5.0"
+    "@turf/transform-translate" "^6.5.0"
+    "@turf/triangle-grid" "^6.5.0"
+    "@turf/truncate" "^6.5.0"
+    "@turf/union" "^6.5.0"
+    "@turf/unkink-polygon" "^6.5.0"
+    "@turf/voronoi" "^6.5.0"
+
+"@turf/union@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/union/-/union-6.5.0.tgz#82d28f55190608f9c7d39559b7f543393b03b82d"
+  integrity sha512-igYWCwP/f0RFHIlC2c0SKDuM/ObBaqSljI3IdV/x71805QbIvY/BYGcJdyNcgEA6cylIGl/0VSlIbpJHZ9ldhw==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    polygon-clipping "^0.15.3"
+
+"@turf/unkink-polygon@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/unkink-polygon/-/unkink-polygon-6.5.0.tgz#9e54186dcce08d7e62f608c8fa2d3f0342ebe826"
+  integrity sha512-8QswkzC0UqKmN1DT6HpA9upfa1HdAA5n6bbuzHy8NJOX8oVizVAqfEPY0wqqTgboDjmBR4yyImsdPGUl3gZ8JQ==
+  dependencies:
+    "@turf/area" "^6.5.0"
+    "@turf/boolean-point-in-polygon" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+    rbush "^2.0.1"
+
+"@turf/voronoi@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/voronoi/-/voronoi-6.5.0.tgz#afe6715a5c7eff687434010cde45cd4822489434"
+  integrity sha512-C/xUsywYX+7h1UyNqnydHXiun4UPjK88VDghtoRypR9cLlb7qozkiLRphQxxsCM0KxyxpVPHBVQXdAL3+Yurow==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    d3-voronoi "1.1.2"
 
 "@types/cacheable-request@^6.0.1":
   version "6.0.1"
@@ -399,6 +1521,11 @@
   version "0.0.50"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.50.tgz#1e0caa9364d3fccd2931c3ed96fdbeaa5d4cca83"
   integrity sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==
+
+"@types/geojson@7946.0.8":
+  version "7946.0.8"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.8.tgz#30744afdb385e2945e22f3b033f897f76b1f12ca"
+  integrity sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA==
 
 "@types/http-cache-semantics@*":
   version "4.0.0"
@@ -1277,6 +2404,11 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@2:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
 common-path-prefix@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/common-path-prefix/-/common-path-prefix-3.0.0.tgz#7d007a7e07c58c4b4d5f433131a19141b29f11e0"
@@ -1296,6 +2428,16 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+
+concaveman@*:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/concaveman/-/concaveman-1.2.1.tgz#47d20b4521125c15fabf453653c2696d9ee41e0b"
+  integrity sha512-PwZYKaM/ckQSa8peP5JpVr7IMJ4Nn/MHIaWUjP4be+KoZ7Botgs8seAZGpmaOM+UZXawcdYRao/px9ycrCihHw==
+  dependencies:
+    point-in-polygon "^1.1.0"
+    rbush "^3.0.1"
+    robust-predicates "^2.0.4"
+    tinyqueue "^2.0.3"
 
 concordance@^5.0.1:
   version "5.0.1"
@@ -1421,6 +2563,23 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
+d3-array@1:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
+  integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
+
+d3-geo@1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-1.7.1.tgz#44bbc7a218b1fd859f3d8fd7c443ca836569ce99"
+  integrity sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==
+  dependencies:
+    d3-array "1"
+
+d3-voronoi@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/d3-voronoi/-/d3-voronoi-1.1.2.tgz#1687667e8f13a2d158c80c1480c5a29cb0d8973c"
+  integrity sha512-RhGS1u2vavcO7ay7ZNAPo4xeDh/VYeGof3x5ZLJBQgYhLegxr3s5IykvWmJ94FTU6mcbtp4sloqZ54mP6R4Utw==
+
 date-fns@^2.28.0:
   version "2.28.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
@@ -1512,6 +2671,18 @@ decompress-response@^6.0.0:
   dependencies:
     mimic-response "^3.1.0"
 
+deep-equal@1.x, deep-equal@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
+  integrity sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==
+  dependencies:
+    is-arguments "^1.0.4"
+    is-date-object "^1.0.1"
+    is-regex "^1.0.4"
+    object-is "^1.0.1"
+    object-keys "^1.1.1"
+    regexp.prototype.flags "^1.2.0"
+
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
@@ -1563,6 +2734,14 @@ define-properties@^1.1.3:
   dependencies:
     object-keys "^1.0.12"
 
+define-properties@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.2.0.tgz#52988570670c9eacedd8064f4a990f2405849bd5"
+  integrity sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==
+  dependencies:
+    has-property-descriptors "^1.0.0"
+    object-keys "^1.1.1"
+
 del@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/del/-/del-6.0.0.tgz#0b40d0332cea743f1614f818be4feb717714c952"
@@ -1586,6 +2765,11 @@ denque@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/denque/-/denque-2.0.1.tgz#bcef4c1b80dc32efe97515744f21a4229ab8934a"
   integrity sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ==
+
+density-clustering@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/density-clustering/-/density-clustering-1.3.0.tgz#dc9f59c8f0ab97e1624ac64930fd3194817dcac5"
+  integrity sha512-icpmBubVTwLnsaor9qH/4tG5+7+f61VcqMN3V3pm9sxxSCt2Jcs0zWOgwZW9ARJYaKD3FumIgHiMOcIMRRAzFQ==
 
 depd@2.0.0, depd@~2.0.0:
   version "2.0.0"
@@ -1652,6 +2836,11 @@ duplexify@^4.1.1:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
     stream-shift "^1.0.0"
+
+earcut@^2.0.0:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.2.4.tgz#6d02fd4d68160c114825d06890a92ecaae60343a"
+  integrity sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -2430,6 +3619,11 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
+functions-have-names@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
+  integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
+
 generate-object-property@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/generate-object-property/-/generate-object-property-1.2.0.tgz#9c0e1c40308ce804f4783618b937fa88f99d50d0"
@@ -2441,6 +3635,24 @@ gensync@^1.0.0-beta.1:
   version "1.0.0-beta.1"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.1.tgz#58f4361ff987e5ff6e1e7a210827aa371eaac269"
   integrity sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==
+
+geojson-equality@0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/geojson-equality/-/geojson-equality-0.1.6.tgz#a171374ef043e5d4797995840bae4648e0752d72"
+  integrity sha512-TqG8YbqizP3EfwP5Uw4aLu6pKkg6JQK9uq/XZ1lXQntvTHD1BBKJWhNpJ2M0ax6TuWMP3oyx6Oq7FCIfznrgpQ==
+  dependencies:
+    deep-equal "^1.0.0"
+
+geojson-rbush@3.x:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/geojson-rbush/-/geojson-rbush-3.2.0.tgz#8b543cf0d56f99b78faf1da52bb66acad6dfc290"
+  integrity sha512-oVltQTXolxvsz1sZnutlSuLDEcQAKYC/uXt9zDzJJ6bu0W+baTI8LZBaTup5afzibEH4N3jlq2p+a152wlBJ7w==
+  dependencies:
+    "@turf/bbox" "*"
+    "@turf/helpers" "6.x"
+    "@turf/meta" "6.x"
+    "@types/geojson" "7946.0.8"
+    rbush "^3.0.1"
 
 geojson-vt@^3.2.1:
   version "3.2.1"
@@ -2679,6 +3891,13 @@ has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+has-property-descriptors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz#610708600606d36961ed04c196193b6a607fa861"
+  integrity sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==
+  dependencies:
+    get-intrinsic "^1.1.1"
 
 has-symbols@^1.0.0:
   version "1.0.0"
@@ -2981,6 +4200,14 @@ is-absolute@^1.0.0:
     is-relative "^1.0.0"
     is-windows "^1.0.1"
 
+is-arguments@^1.0.4:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
+  integrity sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -3217,7 +4444,7 @@ is-proto-prop@^2.0.0:
     lowercase-keys "^1.0.0"
     proto-props "^2.0.0"
 
-is-regex@^1.1.4:
+is-regex@^1.0.4, is-regex@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
   integrity sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==
@@ -4126,7 +5353,7 @@ obj-props@^1.0.0:
   resolved "https://registry.yarnpkg.com/obj-props/-/obj-props-1.1.0.tgz#626313faa442befd4a44e9a02c3cb6bde937b511"
   integrity sha1-YmMT+qRCvv1KROmgLDy2vek3tRE=
 
-object-assign@^4:
+object-assign@*, object-assign@^4:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -4135,6 +5362,14 @@ object-inspect@^1.11.0, object-inspect@^1.9.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.11.0.tgz#9dceb146cedd4148a0d9e51ab88d34cf509922b1"
   integrity sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==
+
+object-is@^1.0.1:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.5.tgz#b9deeaa5fc7f1846a0faecdceec138e5778f53ac"
+  integrity sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
 
 object-keys@^1.0.12:
   version "1.1.0"
@@ -4576,6 +5811,18 @@ pluralize@^8.0.0:
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
   integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
 
+point-in-polygon@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/point-in-polygon/-/point-in-polygon-1.1.0.tgz#b0af2616c01bdee341cbf2894df643387ca03357"
+  integrity sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw==
+
+polygon-clipping@^0.15.3:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/polygon-clipping/-/polygon-clipping-0.15.3.tgz#0215840438470ba2e9e6593625e4ea5c1087b4b7"
+  integrity sha512-ho0Xx5DLkgxRx/+n4O74XyJ67DcyN3Tu9bGYKsnTukGAW6ssnuak6Mwcyb1wHy9MZc9xsUWqIoiazkZB5weECg==
+  dependencies:
+    splaytree "^3.1.0"
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -4699,6 +5946,21 @@ quick-lru@^5.1.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
+quickselect@^1.0.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/quickselect/-/quickselect-1.1.1.tgz#852e412ce418f237ad5b660d70cffac647ae94c2"
+  integrity sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ==
+
+quickselect@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/quickselect/-/quickselect-2.0.0.tgz#f19680a486a5eefb581303e023e98faaf25dd018"
+  integrity sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==
+
+randomcolor@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/randomcolor/-/randomcolor-0.6.2.tgz#7a57362ae1a1278439aeed2c15e5deb8ea33f56d"
+  integrity sha512-Mn6TbyYpFgwFuQ8KJKqf3bqqY9O1y37/0jgSK/61PUxV4QfIMv0+K2ioq8DfOjkBslcjwSzRfIDEXfzA9aCx7A==
+
 range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
@@ -4713,6 +5975,20 @@ raw-body@2.5.1:
     http-errors "2.0.0"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
+
+rbush@2.x, rbush@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/rbush/-/rbush-2.0.2.tgz#bb6005c2731b7ba1d5a9a035772927d16a614605"
+  integrity sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==
+  dependencies:
+    quickselect "^1.0.1"
+
+rbush@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/rbush/-/rbush-3.0.1.tgz#5fafa8a79b3b9afdfe5008403a720cc1de882ecf"
+  integrity sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==
+  dependencies:
+    quickselect "^2.0.0"
 
 rc@^1.2.8:
   version "1.2.8"
@@ -4808,6 +6084,15 @@ regexp-tree@~0.1.1:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/regexp-tree/-/regexp-tree-0.1.5.tgz#7cd71fca17198d04b4176efd79713f2998009397"
   integrity sha512-nUmxvfJyAODw+0B13hj8CFVAxhe7fDEAgJgaotBu3nnR+IgGgZq59YedJP5VYTlkEfqjuK6TuRpnymKdatLZfQ==
+
+regexp.prototype.flags@^1.2.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz#fe7ce25e7e4cca8db37b6634c8a2c7009199b9cb"
+  integrity sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.2.0"
+    functions-have-names "^1.2.3"
 
 regexpp@^3.0.0:
   version "3.1.0"
@@ -4945,6 +6230,11 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
+
+robust-predicates@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/robust-predicates/-/robust-predicates-2.0.4.tgz#0a2367a93abd99676d075981707f29cfb402248b"
+  integrity sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg==
 
 run-parallel@^1.1.9:
   version "1.1.9"
@@ -5110,6 +6400,11 @@ signal-exit@^3.0.3:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
+skmeans@0.9.7:
+  version "0.9.7"
+  resolved "https://registry.yarnpkg.com/skmeans/-/skmeans-0.9.7.tgz#72670cebb728508f56e29c0e10d11e623529ce5d"
+  integrity sha512-hNj1/oZ7ygsfmPZ7ZfN5MUBRoGg1gtpnImuJBgLO0ljQ67DtJuiQaiYdS4lUA6s0KCwnPhGivtC/WRwIZLkHyg==
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
@@ -5204,6 +6499,11 @@ spdx-license-ids@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz#81c0ce8f21474756148bbb5f3bfc0f36bf15d76e"
   integrity sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==
+
+splaytree@^3.1.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/splaytree/-/splaytree-3.1.2.tgz#d1db2691665a3c69d630de98d55145a6546dc166"
+  integrity sha512-4OM2BJgC5UzrhVnnJA4BkHKGtjXNzzUfpQjCO8I05xYPsfS/VuQDwjCGGMi8rYQilHEV4j8NBqTFbls/PZEE7A==
 
 split2@^2.1.0:
   version "2.2.0"
@@ -5495,6 +6795,11 @@ time-zone@^1.0.0:
   resolved "https://registry.yarnpkg.com/time-zone/-/time-zone-1.0.0.tgz#99c5bf55958966af6d06d83bdf3800dc82faec5d"
   integrity sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=
 
+tinyqueue@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/tinyqueue/-/tinyqueue-2.0.3.tgz#64d8492ebf39e7801d7bd34062e29b45b2035f08"
+  integrity sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==
+
 tmp@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
@@ -5531,6 +6836,20 @@ toidentifier@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
+
+topojson-client@3.x:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/topojson-client/-/topojson-client-3.1.0.tgz#22e8b1ed08a2b922feeb4af6f53b6ef09a467b99"
+  integrity sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==
+  dependencies:
+    commander "2"
+
+topojson-server@3.x:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/topojson-server/-/topojson-server-3.0.1.tgz#d2b3ec095b6732299be76a48406111b3201a34f5"
+  integrity sha512-/VS9j/ffKr2XAOjlZ9CgyyeLmgJ9dMwq6Y0YEON8O7p/tGGk+dCWnrE03zEdu7i4L7YsFZLEPZPzCvcB7lEEXw==
+  dependencies:
+    commander "2"
 
 tr46@^3.0.0:
   version "3.0.0"
@@ -5580,6 +6899,11 @@ tsutils@^3.21.0:
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   dependencies:
     tslib "^1.8.1"
+
+turf-jsts@*:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/turf-jsts/-/turf-jsts-1.2.3.tgz#59757f542afbff9a577bbf411f183b8f48d38aa4"
+  integrity sha512-Ja03QIJlPuHt4IQ2FfGex4F4JAr8m3jpaHbFbQrgwr7s7L6U8ocrHiF3J1+wf9jzhGKxvDeaCAnGDot8OjGFyA==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
##Context

https://github.com/BaseAdresseNationale/mes-adresses/issues/520

## Fonctionnalité

- Ajout de la route `/bases-locales/:baseLocaleId/tiles/:z/:x/:y.pbf` qui renvoit une source de vectoriel tuilé avec trois layers: `voies`, `voies-traces` et `numeros`

- Ajout du champ `tiles` sur les `numeros` et des champs `centroid`, `centroidTiles` et `traceTiles` au `voies`, pour accélérer la recherche mongo lors d'une demande de tuile. C'est sont mise a jour au niveau des models de `voies`
 et `numeros`

- Changement des fonction `/export/geojson.js` pour renvoyé les nouveau geojson demandé

- Ajout du champ `bbox` aux `voies` et `toponyme`, auto-généré lors des `GET` de ces dernier

- Suppression de tout le code relatif a l'ancienne route `/bases-locales/:baseLocaleId/geojson`
