### PR TITLE
disabled page /dashboard

### DIFF
--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -17,7 +17,7 @@ const sync = require('../sync')
 const {createHabilitation, sendPinCode, validatePinCode, fetchHabilitation} = require('../habilitations')
 const {checkHasCadastre} = require('../cadastre')
 const {checkIsCOM, checkHasMapsStyles} = require('../com')
-const stats = require('./stats')
+// DISBALED DASHBOARD const stats = require('./stats')
 const adminRoutes = require('./admin')
 
 const app = new express.Router()
@@ -521,7 +521,7 @@ app.route('/commune/:codeCommune')
     }
   }))
 
-app.use('/stats', stats)
+// DISBALED DASHBOARD app.use('/stats', stats)
 
 /* Admin routes */
 


### PR DESCRIPTION
## Context

Comme la route /couverture-tiles/:z/:x/:y.pbf contient toutes les geojson de toute les communes de france et qu'il y a plusieurs instance de mes-adresses-api en prod, cela fait exploser la RAM

Exemple après connection a la page https://mes-adresses.data.gouv.fr//dashboard

<img width="1452" alt="Capture d’écran 2023-08-02 à 14 32 39" src="https://github.com/BaseAdresseNationale/mes-adresses-api/assets/8143924/cc23028d-b9b9-41d2-9dc6-c615cdf59518">

## Fix

Désactivation de la route /couverture-tiles/:z/:x/:y.pbf avant fix final
