### PR TITLE
Add route get all bals

### DIFF
--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -262,6 +262,29 @@ async function fetchAll() {
   return mongo.db.collection('bases_locales').find({}).toArray()
 }
 
+async function fetchAllProjectFields(fields = [], codesCommunes = []) {
+  const filters = {
+    status: {$ne: 'demo'},
+    _deleted: null
+  }
+
+  if (codesCommunes.length > 0) {
+    filters.commune = {$in: codesCommunes}
+  }
+
+  const query = mongo.db.collection('bases_locales').find({...filters})
+
+  if (fields.length > 0) {
+    const selectFields = {}
+    fields.forEach(f => {
+      selectFields[f] = 1
+    })
+    query.project(selectFields)
+  }
+
+  return query.toArray()
+}
+
 async function fetchByQuery(query) {
   const {limit, offset, filters} = parseQueryFilters(query)
   const count = await mongo.db.collection('bases_locales').countDocuments(filters)
@@ -782,5 +805,6 @@ module.exports = {
   getBasesLocalesCreatedBetweenDate,
   getGeoJsonByTile,
   getTiles,
-  exportVoiesAsCsv
+  exportVoiesAsCsv,
+  fetchAllProjectFields
 }

--- a/lib/routes/stats.js
+++ b/lib/routes/stats.js
@@ -6,7 +6,6 @@ const BaseLocale = require('../models/base-locale')
 const {getCommunesByDepartement, getDepartement} = require('../util/cog')
 const {isValidDate, checkFromIsBeforeTo} = require('../util/date')
 const {getBALCreationsPerDay} = require('../services/stats')
-
 const {useCache} = require('../util/cache')
 
 const app = new express.Router()
@@ -41,6 +40,14 @@ app.route('/')
       }
     })
     res.send(stats)
+  }))
+
+app.route('/bals')
+  .post(w(async (req, res) => {
+    const {fields} = req.query
+    const codesCommunes = req.body
+    const bals = await BaseLocale.fetchAllProjectFields(typeof fields === 'string' ? [fields] : fields, codesCommunes)
+    res.status(201).send(bals)
   }))
 
 app.route('/creations')


### PR DESCRIPTION
## Context

Le /dashboard sur mes-adresses a été fermé
Il faut migrer la partie déploiement des BAL sur la page deploiement-bal

## Fonctionnalité

Ajout de la route `/stats/bals` qui retourne toutes les BALs, on peut filtrer les champs retourné pour optimiser la requète