### PR TITLE
Add route /stats/bals/status

### DIFF
--- a/lib/routes/stats.js
+++ b/lib/routes/stats.js
@@ -50,6 +50,12 @@ app.route('/bals')
     res.status(201).send(bals)
   }))
 
+app.route('/bals/status')
+  .get(w(async (req, res) => {
+    const status = await BaseLocale.statusRepartitionStats()
+    res.status(201).send(status)
+  }))
+
 app.route('/creations')
   .get(w(async (req, res) => {
     checkQueryDateFromTo(req)


### PR DESCRIPTION
## Context

Pour la page /deploiement-bal de adresse, nous avons besoin d'une route qui nous donne le compte de tous les status des bals de mes-adresse

## Fonctionnalité 

- Route GET /stats/bals/status
RESPONSE : [
{"status":"published","count":9062},
{"status":"ready-to-publish","count":2909},
{"status":"replaced","count":855},
{"status":"demo","count":1202},
{"status":"draft","count":12458}
]
