### PR TITLE
fix random colors features

### DIFF
--- a/lib/export/__tests__/geojson.js
+++ b/lib/export/__tests__/geojson.js
@@ -16,9 +16,11 @@ test('voiesLineStringsToGeoJSON', t => {
       typeNumerotation: 'metrique'
     },
   ]
+  const nb = Number.parseInt(voies[0]._id.toHexString().slice(19), 16)
+  const seed = Math.floor((Math.abs(Math.sin(nb) * 16777215)))
   const color = randomColor({
     luminosity: 'dark',
-    seed: voies[0]._id.toHexString()
+    seed,
   })
   const funcRes = voiesLineStringsToGeoJSON(voies)
   const expectedRes = {
@@ -61,14 +63,18 @@ test('voiesPointsToGeoJSON', t => {
     }
   ]
 
+  const nb = Number.parseInt(voies[0]._id.toHexString().slice(19), 16)
+  const seed = Math.floor((Math.abs(Math.sin(nb) * 16777215)))
   const color = randomColor({
     luminosity: 'dark',
-    seed: voies[0]._id.toHexString()
+    seed,
   })
 
+  const nb2 = Number.parseInt(voies[1]._id.toHexString().slice(19), 16)
+  const seed2 = Math.floor((Math.abs(Math.sin(nb2) * 16777215)))
   const color2 = randomColor({
     luminosity: 'dark',
-    seed: voies[1]._id.toHexString()
+    seed: seed2,
   })
 
   const funcRes = voiesPointsToGeoJSON(voies)
@@ -136,14 +142,20 @@ test('numerosPointsToGeoJSON', t => {
       }],
     },
   ]
+  const nb1 = Number.parseInt(voie1.toHexString().slice(19), 16)
+  const seed1 = Math.floor((Math.abs(Math.sin(nb1) * 16777215)))
   const color1 = randomColor({
     luminosity: 'dark',
-    seed: voie1.toHexString()
+    seed: seed1,
   })
+
+  const nb2 = Number.parseInt(voie2.toHexString().slice(19), 16)
+  const seed2 = Math.floor((Math.abs(Math.sin(nb2) * 16777215)))
   const color2 = randomColor({
     luminosity: 'dark',
-    seed: voie2.toHexString()
+    seed: seed2,
   })
+
   const funcRes = numerosPointsToGeoJSON(numeros)
   const expectedRes = {
     type: 'FeatureCollection',

--- a/lib/export/geojson.js
+++ b/lib/export/geojson.js
@@ -15,9 +15,11 @@ function getPriorityPosition(positions) {
 }
 
 function getColorById(id) {
+  const nb = Number.parseInt(id.toHexString().slice(19), 16)
+  const seed = Math.floor((Math.abs(Math.sin(nb) * 16777215)))
   return randomColor({
     luminosity: 'dark',
-    seed: id.toHexString()
+    seed
   })
 }
 


### PR DESCRIPTION
## Context

Les couleurs des features de la map (voie et numeros) sont trop similaire et on a du mal a les différentier.
La fonction randomcolor utilise comme seed l'id des voie pour générer la couleur, mais comme les ids sont trop proches, les couleurs aussi

## Fonctionnalité

Générer un nombre plus complexe a partir de l'id pour avoir des couleurs moins proches