### PR TITLE
Fix status conflict in exec publication

### DIFF
--- a/apps/api/src/modules/base_locale/base_locale.service.ts
+++ b/apps/api/src/modules/base_locale/base_locale.service.ts
@@ -206,7 +206,7 @@ export class BaseLocaleService {
     const updatedBaseLocale = await this.baseLocaleModel.findOneAndUpdate(
       { _id: baseLocale._id },
       { $set: update },
-      { returnDocument: 'after' },
+      { new: true },
     );
 
     // If emails fields is overrided, we compare with current array to send a notification to new email addresses
@@ -246,7 +246,7 @@ export class BaseLocaleService {
           status: StatusBaseLocalEnum.DRAFT,
         },
       },
-      { returnDocument: 'after' },
+      { new: true },
     );
 
     const templateEmail = createBalCreationNotificationEmail({
@@ -419,7 +419,7 @@ export class BaseLocaleService {
     const recoveredBaseLocale = await this.baseLocaleModel.findByIdAndUpdate(
       { _id: baseLocale._id },
       { $set: { _deleted: null, _updated: now } },
-      { returnDocument: 'after' },
+      { new: true },
     );
 
     return recoveredBaseLocale;
@@ -430,7 +430,7 @@ export class BaseLocaleService {
     const updatedBaseLocale = await this.baseLocaleModel.findByIdAndUpdate(
       { _id: baseLocale._id },
       { $set: { token } },
-      { returnDocument: 'after' },
+      { new: true },
     );
 
     const email = createTokenRenewalNotificationEmail({

--- a/apps/api/src/modules/numeros/numero.service.ts
+++ b/apps/api/src/modules/numeros/numero.service.ts
@@ -235,7 +235,7 @@ export class NumeroService {
     const numeroUpdated: Numero = await this.numeroModel.findOneAndUpdate(
       { _id: numero._id, _deleted: null },
       { $set: { ...updateNumeroDto, _updated: new Date() } },
-      { returnDocument: 'after' },
+      { new: true },
     );
 
     if (numeroUpdated) {
@@ -273,7 +273,7 @@ export class NumeroService {
     const numeroUpdated: Numero = await this.numeroModel.findOneAndUpdate(
       { _id: numero._id },
       { $set: { _deleted: new Date() } },
-      { returnDocument: 'after' },
+      { new: true },
     );
 
     // UPDATE TILES VOIE

--- a/apps/api/src/modules/toponyme/toponyme.service.ts
+++ b/apps/api/src/modules/toponyme/toponyme.service.ts
@@ -140,7 +140,7 @@ export class ToponymeService {
     const toponymeUpdated = await this.toponymeModel.findOneAndUpdate(
       { _id: toponyme._id, _deleted: null },
       { $set: { ...updateToponymeDto, _updated: new Date() } },
-      { returnDocument: 'after' },
+      { new: true },
     );
 
     // SET _updated BAL
@@ -156,7 +156,7 @@ export class ToponymeService {
     const toponymeUpdated: Toponyme = await this.toponymeModel.findOneAndUpdate(
       { _id: toponyme._id },
       { $set: { _deleted: new Date(), _updated: new Date() } },
-      { returnDocument: 'after' },
+      { new: true },
     );
 
     await this.numeroService.updateMany(
@@ -176,7 +176,7 @@ export class ToponymeService {
     const updatedToponyme = await this.toponymeModel.findOneAndUpdate(
       { _id: toponyme._id },
       { $set: { _deleted: null, _updated: new Date() } },
-      { returnDocument: 'after' },
+      { new: true },
     );
     // SET _updated OF TOPONYME
     await this.baseLocaleService.touch(toponyme._bal);

--- a/apps/api/src/modules/voie/voie.service.ts
+++ b/apps/api/src/modules/voie/voie.service.ts
@@ -272,7 +272,7 @@ export class VoieService {
     const voieUpdated: Voie = await this.voieModel.findOneAndUpdate(
       { _id: voie._id },
       { $set: { _deleted: new Date(), _updated: new Date() } },
-      { returnDocument: 'after' },
+      { new: true },
     );
 
     // SET _updated OF VOIE


### PR DESCRIPTION
## Context

- Lorsque le le JOB `sync_outdated` run, les BALS qui étaient `outdated` mais dont le `lastUploadedRevisionId` n'était pas la révision courante publiait normalement alors qu'elle devait normalement finir en `Conflict` a cause d'une coquille dans la fusion du sync.

- Remplacement des `returnDocument: after` par `new: true` comme préconisé par la doc mongoose

Cela a surement entrainé des problème de conflit