### PR TITLE
feat: add sensible field in route /search bal to super admin

### DIFF
--- a/apps/api/src/lib/utils/is-admin.utils.ts
+++ b/apps/api/src/lib/utils/is-admin.utils.ts
@@ -1,6 +1,10 @@
 import { CustomRequest } from '@/lib/types/request.type';
 import { BaseLocale } from '../../../../../libs/shared/src/schemas/base_locale/base_locale.schema';
 
+export function isSuperAdmin(req: CustomRequest) {
+  return req.headers.authorization === `Bearer ${process.env.ADMIN_TOKEN}`;
+}
+
 export function isAdmin(req: CustomRequest, baseLocale: BaseLocale) {
   return (
     req.headers.authorization === `Bearer ${baseLocale.token}` ||

--- a/apps/api/src/modules/base_locale/dto/page_base_locale.dto.ts
+++ b/apps/api/src/modules/base_locale/dto/page_base_locale.dto.ts
@@ -17,5 +17,7 @@ export class PageBaseLocaleDTO {
     type: () => ExtendedBaseLocaleDTO,
     isArray: true,
   })
-  results?: Omit<ExtendedBaseLocaleDTO, 'token' | 'emails'>[];
+  results?: Array<
+    ExtendedBaseLocaleDTO | Omit<ExtendedBaseLocaleDTO, 'token' | 'emails'>
+  >;
 }


### PR DESCRIPTION
## Context

Les emails ne sont pas affiché dans bal-admin

## Fonctionnalité

Ajouté la gestion du super token sur la route `/bases_locales/search` pour retourner les emails

## PR

- [ ] https://github.com/BaseAdresseNationale/bal-admin/pull/58