### PR TITLE
feat: add ban ids

### DIFF
--- a/apps/api/src/lib/utils/csv.utils.ts
+++ b/apps/api/src/lib/utils/csv.utils.ts
@@ -19,8 +19,8 @@ export function extractIdBanAdresse({
   additionalValues,
 }: Row): string | null {
   return (
-    parsedValues.id_ban_adresse ||
-    additionalValues?.uid_adresse.idBanAdresse ||
+    parsedValues?.id_ban_adresse ||
+    additionalValues?.uid_adresse?.idBanAdresse ||
     null
   );
 }
@@ -30,8 +30,8 @@ export function extractIdBanToponyme({
   additionalValues,
 }: Row): string | null {
   return (
-    parsedValues.id_ban_toponyme ||
-    additionalValues?.uid_adresse.idBanToponyme ||
+    parsedValues?.id_ban_toponyme ||
+    additionalValues?.uid_adresse?.idBanToponyme ||
     null
   );
 }

--- a/apps/api/src/lib/utils/csv.utils.ts
+++ b/apps/api/src/lib/utils/csv.utils.ts
@@ -1,17 +1,51 @@
 import { validate } from '@ban-team/validateur-bal';
 import { normalize } from '@ban-team/adresses-util/lib/voies';
 import { chain, compact, keyBy, min, max } from 'lodash';
+
 import { beautifyUppercased, beautifyNomAlt } from './string.utils';
 import { ObjectId } from 'mongodb';
 import { PositionTypeEnum } from '@/shared/schemas/position_type.enum';
+import { Position } from '@/shared/schemas/position.schema';
 
-export function extractCodeCommune({ parsedValues, additionalValues }) {
+interface Row {
+  parsedValues: Record<string, any>;
+  additionalValues: any;
+  localizedValues: any;
+  isValid: boolean;
+}
+
+export function extractIdBanAdresse({
+  parsedValues,
+  additionalValues,
+}: Row): string | null {
+  return (
+    parsedValues.id_ban_adresse ||
+    additionalValues?.uid_adresse.idBanAdresse ||
+    null
+  );
+}
+
+export function extractIdBanToponyme({
+  parsedValues,
+  additionalValues,
+}: Row): string | null {
+  return (
+    parsedValues.id_ban_toponyme ||
+    additionalValues?.uid_adresse.idBanToponyme ||
+    null
+  );
+}
+
+export function extractCodeCommune({
+  parsedValues,
+  additionalValues,
+}: Row): string | null {
   return (
     parsedValues.commune_insee || additionalValues?.cle_interop?.codeCommune
   );
 }
 
-export function extractPosition(row) {
+export function extractPosition(row: Row): Position {
   return {
     source: row.parsedValues.source || null,
     type: row.parsedValues.position || PositionTypeEnum.INCONNUE,
@@ -22,27 +56,28 @@ export function extractPosition(row) {
   };
 }
 
-export function extractPositions(rows) {
+export function extractPositions(rows: Row[]): Position[] {
   return rows
     .filter((r) => r.parsedValues.long && r.parsedValues.lat)
     .map((r) => extractPosition(r));
 }
 
-export function extractDate(row) {
+export function extractDate(row: Row): Date | null {
   if (row.parsedValues.date_der_maj) {
     return new Date(row.parsedValues.date_der_maj);
   }
 }
 
-export function extractData(rows, codeCommune) {
+export function extractData(rows: Row[], codeCommune: string) {
   const toponymes = chain(rows)
-    .filter((r) => r.parsedValues.numero === 99999)
-    .groupBy((r) => normalize(r.parsedValues.voie_nom))
-    .map((toponymeRows) => {
+    .filter((r: Row) => r.parsedValues.numero === 99999)
+    .groupBy((r: Row) => normalize(r.parsedValues.voie_nom))
+    .map((toponymeRows: Row[]) => {
       const date = extractDate(toponymeRows[0]) || new Date();
 
       return {
         _id: new ObjectId(),
+        banId: extractIdBanToponyme(toponymeRows[0]),
         commune: codeCommune,
         nom: beautifyUppercased(toponymeRows[0].parsedValues.voie_nom),
         nomAlt: toponymeRows[0].localizedValues.voie_nom
@@ -58,13 +93,14 @@ export function extractData(rows, codeCommune) {
   const toponymesIndex = keyBy(toponymes, (t) => normalize(t.nom));
 
   const voies = chain(rows)
-    .filter((r) => r.parsedValues.numero !== 99999)
-    .groupBy((r) => normalize(r.parsedValues.voie_nom))
-    .map((voieRows) => {
+    .filter((r: Row) => r.parsedValues.numero !== 99999)
+    .groupBy((r: Row) => normalize(r.parsedValues.voie_nom))
+    .map((voieRows: Row[]) => {
       const dates = compact(voieRows.map((r) => r.parsedValues.date_der_maj));
 
       return {
         _id: new ObjectId(),
+        banId: extractIdBanToponyme(voieRows[0]),
         commune: codeCommune,
         nom: beautifyUppercased(voieRows[0].parsedValues.voie_nom),
         nomAlt: voieRows[0].localizedValues.voie_nom
@@ -79,14 +115,14 @@ export function extractData(rows, codeCommune) {
   const voiesIndex = keyBy(voies, (v) => normalize(v.nom));
 
   const numeros = chain(rows)
-    .filter((r) => r.parsedValues.numero !== 99999)
+    .filter((r: Row) => r.parsedValues.numero !== 99999)
     .groupBy(
-      (r) =>
+      (r: Row) =>
         `${r.parsedValues.numero}@@@${r.parsedValues.suffixe}@@@${normalize(
           r.parsedValues.voie_nom,
         )}`,
     )
-    .map((numeroRows) => {
+    .map((numeroRows: Row[]) => {
       const date = extractDate(numeroRows[0]) || new Date();
 
       const voieString = normalize(numeroRows[0].parsedValues.voie_nom);
@@ -100,6 +136,7 @@ export function extractData(rows, codeCommune) {
       if (toponymeString && !(toponymeString in toponymesIndex)) {
         const toponyme = {
           _id: new ObjectId(),
+          banId: extractIdBanToponyme(numeroRows[0]),
           commune: codeCommune,
           nom: beautifyUppercased(
             numeroRows[0].parsedValues.lieudit_complement_nom,
@@ -117,6 +154,7 @@ export function extractData(rows, codeCommune) {
 
       return {
         _id: new ObjectId(),
+        banId: extractIdBanAdresse(numeroRows[0]),
         commune: codeCommune,
         voie: voiesIndex[voieString]._id,
         toponyme: toponymeString ? toponymesIndex[toponymeString]._id : null,
@@ -136,17 +174,23 @@ export function extractData(rows, codeCommune) {
 
 export async function extractFromCsv(file: Buffer, codeCommune: string) {
   try {
-    const { rows, parseOk } = await validate(file, { profile: '1.3-relax' });
+    const {
+      rows,
+      parseOk,
+    }: {
+      rows: Row[];
+      parseOk: boolean;
+    } = await validate(file, { profile: '1.4-relax' });
 
     if (!parseOk) {
       return { isValid: false };
     }
 
-    const accepted = rows.filter(({ isValid }) => isValid);
-    const rejected = rows.filter(({ isValid }) => !isValid);
+    const accepted: Row[] = rows.filter(({ isValid }) => isValid);
+    const rejected: Row[] = rows.filter(({ isValid }) => !isValid);
 
     const communesData = extractData(
-      accepted.filter((r) => extractCodeCommune(r) === codeCommune),
+      accepted.filter((r: Row) => extractCodeCommune(r) === codeCommune),
       codeCommune,
     );
 
@@ -159,6 +203,7 @@ export async function extractFromCsv(file: Buffer, codeCommune: string) {
       toponymes: communesData.toponymes,
     };
   } catch (error) {
+    console.log(error);
     return { isValid: false, validationError: error.message };
   }
 }

--- a/apps/api/src/modules/base_locale/base_locale.module.ts
+++ b/apps/api/src/modules/base_locale/base_locale.module.ts
@@ -26,9 +26,13 @@ import { ToponymeModule } from '@/modules/toponyme/toponyme.module';
 import { CommuneModule } from './sub_modules/commune/commune.module';
 import { PopulateModule } from './sub_modules/populate/populate.module';
 import { SearchQueryPipe } from './pipe/search_query.pipe';
+import { HttpModule } from '@nestjs/axios';
+import { ConfigModule } from '@nestjs/config';
 
 @Module({
   imports: [
+    ConfigModule,
+    HttpModule,
     MongooseModule.forFeature([
       { name: BaseLocale.name, schema: BaseLocaleSchema },
     ]),

--- a/apps/api/src/modules/base_locale/base_locale.module.ts
+++ b/apps/api/src/modules/base_locale/base_locale.module.ts
@@ -26,18 +26,16 @@ import { ToponymeModule } from '@/modules/toponyme/toponyme.module';
 import { CommuneModule } from './sub_modules/commune/commune.module';
 import { PopulateModule } from './sub_modules/populate/populate.module';
 import { SearchQueryPipe } from './pipe/search_query.pipe';
-import { HttpModule } from '@nestjs/axios';
-import { ConfigModule } from '@nestjs/config';
+import { BanPlateformModule } from '@/shared/modules/ban_plateform/ban_plateform.module';
 
 @Module({
   imports: [
-    ConfigModule,
-    HttpModule,
     MongooseModule.forFeature([
       { name: BaseLocale.name, schema: BaseLocaleSchema },
     ]),
     MailerModule,
     PublicationModule,
+    forwardRef(() => BanPlateformModule),
     forwardRef(() => HabilitationModule),
     forwardRef(() => ExportCsvModule),
     forwardRef(() => TilesModule),

--- a/apps/api/src/modules/base_locale/sub_modules/populate/populate.module.ts
+++ b/apps/api/src/modules/base_locale/sub_modules/populate/populate.module.ts
@@ -1,16 +1,14 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { PopulateService } from './populate.service';
-import { ConfigModule } from '@nestjs/config';
-import { HttpModule } from '@nestjs/axios';
 import { BaseLocaleModule } from '../../base_locale.module';
 import { ApiDepotModule } from '@/shared/modules/api_depot/api_depot.module';
+import { BanPlateformModule } from '@/shared/modules/ban_plateform/ban_plateform.module';
 
 @Module({
   imports: [
-    ConfigModule,
-    HttpModule,
     forwardRef(() => BaseLocaleModule),
     forwardRef(() => ApiDepotModule),
+    forwardRef(() => BanPlateformModule),
   ],
   providers: [PopulateService],
   exports: [PopulateService],

--- a/apps/api/src/modules/base_locale/sub_modules/populate/populate.service.ts
+++ b/apps/api/src/modules/base_locale/sub_modules/populate/populate.service.ts
@@ -1,15 +1,14 @@
 import { extractFromCsv } from '@/lib/utils/csv.utils';
 import { ApiDepotService } from '@/shared/modules/api_depot/api_depot.service';
-import { HttpService } from '@nestjs/axios';
-import { Injectable } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
+import { BanPlateformService } from '@/shared/modules/ban_plateform/ban_plateform.service';
+import { Inject, Injectable, forwardRef } from '@nestjs/common';
 
 @Injectable()
 export class PopulateService {
   constructor(
-    private readonly httpService: HttpService,
-    private configService: ConfigService,
     private apiDepotService: ApiDepotService,
+    @Inject(forwardRef(() => BanPlateformService))
+    private banPlateformService: BanPlateformService,
   ) {}
 
   private async extractFromApiDepot(codeCommune: string) {
@@ -29,16 +28,10 @@ export class PopulateService {
 
   private async extractFromBAN(codeCommune: string) {
     try {
-      const banApiUrl = this.configService.get<string>('BAN_API_URL');
-      const balFileData = `${banApiUrl}/ban/communes/${codeCommune}/download/csv-bal/adresses`;
+      const file: Buffer =
+        await this.banPlateformService.getBanAssemblage(codeCommune);
 
-      const response = await this.httpService.axiosRef({
-        url: balFileData,
-        method: 'GET',
-        responseType: 'arraybuffer',
-      });
-
-      const result = await extractFromCsv(response.data, codeCommune);
+      const result = await extractFromCsv(file, codeCommune);
 
       if (!result.isValid) {
         throw new Error('Invalid CSV file');

--- a/apps/api/src/modules/numeros/numero.service.ts
+++ b/apps/api/src/modules/numeros/numero.service.ts
@@ -8,7 +8,7 @@ import {
 import { FilterQuery, Model, ProjectionType, SortOrder, Types } from 'mongoose';
 import { InjectModel } from '@nestjs/mongoose';
 import { omit, uniq } from 'lodash';
-import { uuid } from 'uuidv4';
+import { v4 as uuid } from 'uuid';
 
 import { Numero } from '@/shared/schemas/numero/numero.schema';
 import { NumeroPopulate } from '@/shared/schemas/numero/numero.populate';

--- a/apps/api/src/modules/numeros/numero.service.ts
+++ b/apps/api/src/modules/numeros/numero.service.ts
@@ -8,6 +8,7 @@ import {
 import { FilterQuery, Model, ProjectionType, SortOrder, Types } from 'mongoose';
 import { InjectModel } from '@nestjs/mongoose';
 import { omit, uniq } from 'lodash';
+import { uuid } from 'uuidv4';
 
 import { Numero } from '@/shared/schemas/numero/numero.schema';
 import { NumeroPopulate } from '@/shared/schemas/numero/numero.populate';
@@ -115,6 +116,7 @@ export class NumeroService {
 
         const numero = {
           _bal: baseLocale._id,
+          banId: rawNumero.banId || uuid(),
           numero: rawNumero.numero,
           comment: rawNumero.comment,
           toponyme: rawNumero.toponyme,
@@ -175,6 +177,7 @@ export class NumeroService {
     // CREATE NUMERO
     const numero: Partial<Numero> = {
       _bal: voie._bal,
+      banId: uuid(),
       commune: voie.commune,
       voie: voie._id,
       numero: createNumeroDto.numero,

--- a/apps/api/src/modules/toponyme/toponyme.service.ts
+++ b/apps/api/src/modules/toponyme/toponyme.service.ts
@@ -8,6 +8,7 @@ import {
 import { FilterQuery, Model, ProjectionType, Types } from 'mongoose';
 import { InjectModel } from '@nestjs/mongoose';
 import { groupBy } from 'lodash';
+import { uuid } from 'uuidv4';
 
 import { Toponyme } from '@/shared/schemas/toponyme/toponyme.schema';
 import { BaseLocale } from '@/shared/schemas/base_locale/base_locale.schema';
@@ -103,11 +104,12 @@ export class ToponymeService {
 
   public async create(
     bal: BaseLocale,
-    createToponymeDto: CreateToponymeDTO,
+    createToponymeDto: CreateToponymeDTO | Partial<Toponyme>,
   ): Promise<Toponyme> {
     // CREATE OBJECT TOPONYME
     const toponyme: Partial<Toponyme> = {
       _bal: bal._id,
+      banId: uuid(),
       commune: bal.commune,
       nom: createToponymeDto.nom,
       positions: createToponymeDto.positions || [],
@@ -206,6 +208,7 @@ export class ToponymeService {
         const toponyme = {
           _id: rawToponyme._id,
           _bal: baseLocale._id,
+          banId: rawToponyme.banId || uuid(),
           nom: cleanNom(rawToponyme.nom),
           positions: rawToponyme.positions || [],
           parcelles: rawToponyme.parcelles || [],

--- a/apps/api/src/modules/toponyme/toponyme.service.ts
+++ b/apps/api/src/modules/toponyme/toponyme.service.ts
@@ -8,7 +8,7 @@ import {
 import { FilterQuery, Model, ProjectionType, Types } from 'mongoose';
 import { InjectModel } from '@nestjs/mongoose';
 import { groupBy } from 'lodash';
-import { uuid } from 'uuidv4';
+import { v4 as uuid } from 'uuid';
 
 import { Toponyme } from '@/shared/schemas/toponyme/toponyme.schema';
 import { BaseLocale } from '@/shared/schemas/base_locale/base_locale.schema';

--- a/apps/api/src/modules/voie/voie.service.ts
+++ b/apps/api/src/modules/voie/voie.service.ts
@@ -8,6 +8,7 @@ import {
 import { InjectModel } from '@nestjs/mongoose';
 import { FilterQuery, Model, ProjectionType, Types } from 'mongoose';
 import { groupBy } from 'lodash';
+import { uuid } from 'uuidv4';
 
 import { Voie } from '@/shared/schemas/voie/voie.schema';
 import { TypeNumerotationEnum } from '@/shared/schemas/voie/type_numerotation.enum';
@@ -30,7 +31,6 @@ import { Numero } from '@/shared/schemas/numero/numero.schema';
 import { BBox as BboxTurf } from '@turf/helpers';
 import { Toponyme } from '@/shared/schemas/toponyme/toponyme.schema';
 import { ToponymeService } from '@/modules/toponyme/toponyme.service';
-import { CreateToponymeDTO } from '../toponyme/dto/create_toponyme.dto';
 import {
   getTilesByLineString,
   getTilesByPosition,
@@ -113,6 +113,7 @@ export class VoieService {
     // CREATE OBJECT VOIE
     const voie: Partial<Voie> = {
       _bal: bal._id,
+      banId: uuid(),
       commune: bal.commune,
       nom: createVoieDto.nom,
       typeNumerotation:
@@ -145,6 +146,7 @@ export class VoieService {
         const voie = {
           _id: rawVoie._id,
           _bal: baseLocale._id,
+          banId: rawVoie.banId || uuid(),
           nom: cleanNom(rawVoie.nom),
           code: rawVoie.code || null,
           commune: rawVoie.commune,
@@ -368,9 +370,10 @@ export class VoieService {
     );
 
     // CREATE TOPONYME
-    const payload: CreateToponymeDTO = {
+    const payload: Partial<Toponyme> = {
       nom: voie.nom,
       nomAlt: voie.nomAlt,
+      banId: voie.banId,
     };
     const toponyme: Toponyme = await this.toponymeService.create(
       baseLocale,

--- a/apps/api/src/modules/voie/voie.service.ts
+++ b/apps/api/src/modules/voie/voie.service.ts
@@ -8,7 +8,7 @@ import {
 import { InjectModel } from '@nestjs/mongoose';
 import { FilterQuery, Model, ProjectionType, Types } from 'mongoose';
 import { groupBy } from 'lodash';
-import { uuid } from 'uuidv4';
+import { v4 as uuid } from 'uuid';
 
 import { Voie } from '@/shared/schemas/voie/voie.schema';
 import { TypeNumerotationEnum } from '@/shared/schemas/voie/type_numerotation.enum';

--- a/apps/api/test/base_locale.e2e-spec.ts
+++ b/apps/api/test/base_locale.e2e-spec.ts
@@ -5,6 +5,9 @@ import { MongoMemoryServer } from 'mongodb-memory-server';
 import { MongooseModule, getModelToken } from '@nestjs/mongoose';
 import { Connection, connect, Model, Types } from 'mongoose';
 import * as nodemailer from 'nodemailer';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { uuid } from 'uuidv4';
 
 import { Numero } from '@/shared/schemas/numero/numero.schema';
 import { Voie } from '@/shared/schemas/voie/voie.schema';
@@ -20,6 +23,9 @@ import { StatusBaseLocalEnum } from '@/shared/schemas/base_locale/status.enum';
 import { CreateVoieDTO } from '@/modules/voie/dto/create_voie.dto';
 import { TypeNumerotationEnum } from '@/shared/schemas/voie/type_numerotation.enum';
 import { CreateToponymeDTO } from '@/modules/toponyme/dto/create_toponyme.dto';
+
+const BAN_API_URL = 'BAN_API_URL';
+process.env.BAN_API_URL = BAN_API_URL;
 
 const baseLocaleAdminProperties = ['token', 'emails'];
 const baseLocalePublicProperties = [
@@ -53,7 +59,8 @@ describe('BASE LOCAL MODULE', () => {
   const token = 'xxxx';
   const _created = new Date('2000-01-01');
   const _updated = new Date('2000-01-02');
-
+  // AXIOS
+  const axiosMock = new MockAdapter(axios);
   // NODEMAILER
   const sendMailMock = jest.fn();
   createTransport.mockReturnValue({ sendMail: sendMailMock });
@@ -72,8 +79,6 @@ describe('BASE LOCAL MODULE', () => {
     app.useGlobalPipes(new ValidationPipe());
     await app.init();
 
-    // const httpService = moduleFixture.get<HttpService>(HttpService);
-    // axiosMock = new MockAdapter(httpService.axiosRef as AxiosInstance);
     // INIT MODEL
     numeroModel = app.get<Model<Numero>>(getModelToken(Numero.name));
     voieModel = app.get<Model<Voie>>(getModelToken(Voie.name));
@@ -89,6 +94,7 @@ describe('BASE LOCAL MODULE', () => {
   });
 
   afterEach(async () => {
+    axiosMock.reset();
     await toponymeModel.deleteMany({});
     await voieModel.deleteMany({});
     await balModel.deleteMany({});
@@ -532,24 +538,35 @@ describe('BASE LOCAL MODULE', () => {
 
   describe('GET /bases-locales/csv', () => {
     it('Delete 204', async () => {
-      const balId = await createBal();
+      const communeUuid = uuid();
+      const balId = await createBal({
+        banId: communeUuid,
+      });
+      const voieUuid1 = uuid();
       const voieId1 = await createVoie({
         nom: 'rue de la paix',
         commune: '91534',
         _bal: balId,
+        banId: voieUuid1,
       });
+      const voieUuid2 = uuid();
       const voieId2 = await createVoie({
         nom: 'rue de paris',
         commune: '91534',
         _bal: balId,
+        banId: voieUuid2,
       });
+      const toponymeUuid1 = uuid();
       const toponymeId1 = await createToponyme({
         nom: 'allée',
         commune: '91534',
         _bal: balId,
+        banId: toponymeUuid1,
       });
+      const numeroUuid1 = uuid();
       const numeroId1 = await createNumero({
         _bal: balId,
+        banId: numeroUuid1,
         voie: voieId1,
         numero: 1,
         suffixe: 'bis',
@@ -558,8 +575,10 @@ describe('BASE LOCAL MODULE', () => {
         certifie: true,
         commune: '91534',
       });
+      const numeroUuid2 = uuid();
       const numeroId2 = await createNumero({
         _bal: balId,
+        banId: numeroUuid2,
         voie: voieId2,
         numero: 1,
         suffixe: 'ter',
@@ -586,10 +605,10 @@ describe('BASE LOCAL MODULE', () => {
         'text/csv; charset=utf-8',
       );
 
-      const csvFile = `cle_interop;uid_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;certification_commune;commune_insee;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj
-91534_xxxx_00001_bis;;rue de la paix;allée;1;bis;1;91534;Saclay;inconnue;8;42;1114835.92;6113076.85;;ban;2000-01-02
-91534_xxxx_00001_ter;;rue de paris;allée;1;ter;0;91534;Saclay;inconnue;8;42;1114835.92;6113076.85;;ban;2000-01-02
-91534_xxxx_99999;;allée;;99999;;;91534;Saclay;;;;;;;commune;2000-01-02`;
+      const csvFile = `cle_interop;id_ban_commune;id_ban_toponyme;id_ban_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;certification_commune;commune_insee;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj
+91534_xxxx_00001_bis;${communeUuid};${voieUuid1};${numeroUuid1};rue de la paix;allée;1;bis;1;91534;Saclay;inconnue;8;42;1114835.92;6113076.85;;ban;2000-01-02
+91534_xxxx_00001_ter;${communeUuid};${voieUuid2};${numeroUuid2};rue de paris;allée;1;ter;0;91534;Saclay;inconnue;8;42;1114835.92;6113076.85;;ban;2000-01-02
+91534_xxxx_99999;${communeUuid};${toponymeUuid1};;allée;;99999;;;91534;Saclay;;;;;;;commune;2000-01-02`;
       expect(response.text.replace(/\s/g, '')).toEqual(
         csvFile.replace(/\s/g, ''),
       );
@@ -698,6 +717,19 @@ voie;rue de paris;1;1ter`;
         commune: '27115',
         emails: ['me@domain.co'],
       };
+
+      const resBan = {
+        response: [
+          {
+            id: uuid(),
+          },
+        ],
+      };
+
+      axiosMock
+        .onGet(`${BAN_API_URL}/api/district/cog/27115`)
+        .reply(200, resBan);
+
       const response = await request(app.getHttpServer())
         .post(`/bases-locales`)
         .send(createBALDTO)

--- a/apps/api/test/publication.e2e-spec.ts
+++ b/apps/api/test/publication.e2e-spec.ts
@@ -8,6 +8,7 @@ import axios from 'axios';
 import { add, sub } from 'date-fns';
 import MockAdapter from 'axios-mock-adapter';
 import * as nodemailer from 'nodemailer';
+import { uuid } from 'uuidv4';
 
 import { Numero } from '@/shared/schemas/numero/numero.schema';
 import { Voie } from '@/shared/schemas/voie/voie.schema';
@@ -139,19 +140,25 @@ describe('PUBLICATION MODULE', () => {
     it('Publish 200 DRAFT', async () => {
       const commune = '91534';
       const habilitationId = new Types.ObjectId();
+      const communeUuid = uuid();
       const balId = await createBal({
         commune,
+        banId: communeUuid,
         _habilitation: habilitationId.toString(),
         status: StatusBaseLocalEnum.DRAFT,
         emails: ['test@test.fr'],
       });
+      const toponymeUuid = uuid();
       const voieId = await createVoie({
         nom: 'rue de la paix',
         commune,
         _bal: balId,
+        banId: toponymeUuid,
       });
+      const numeroUuid = uuid();
       await createNumero({
         _bal: balId,
+        banId: numeroUuid,
         voie: voieId,
         numero: 1,
         suffixe: 'bis',
@@ -190,8 +197,8 @@ describe('PUBLICATION MODULE', () => {
 
       axiosMock.onPost(`/revisions/${revisionId}/compute`).reply(200, revision);
 
-      const csvFile = `cle_interop;uid_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;certification_commune;commune_insee;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj
-    91534_xxxx_00001_bis;;rue de la paix;;1;bis;1;91534;Saclay;inconnue;8;42;1114835.92;6113076.85;;ban;2000-01-01`;
+      const csvFile = `cle_interop;id_ban_commune;id_ban_toponyme;id_ban_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;certification_commune;commune_insee;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj
+    91534_xxxx_00001_bis;${communeUuid};${toponymeUuid};${numeroUuid};rue de la paix;;1;bis;1;91534;Saclay;inconnue;8;42;1114835.92;6113076.85;;ban;2000-01-01`;
       axiosMock
         .onPut(`/revisions/${revisionId}/files/bal`)
         .reply(({ data }) => {
@@ -263,8 +270,10 @@ describe('PUBLICATION MODULE', () => {
       };
 
       // BAL
+      const communeUuid = uuid();
       const balId = await createBal({
         commune,
+        banId: communeUuid,
         _habilitation: habilitationId.toString(),
         status: StatusBaseLocalEnum.PUBLISHED,
         emails: ['test@test.fr'],
@@ -273,13 +282,17 @@ describe('PUBLICATION MODULE', () => {
           lastUploadedRevisionId: revisionId,
         },
       });
+      const toponymeUuid = uuid();
       const voieId = await createVoie({
         nom: 'rue de la paix',
         commune,
         _bal: balId,
+        banId: toponymeUuid,
       });
+      const numeroUuid = uuid();
       await createNumero({
         _bal: balId,
+        banId: numeroUuid,
         voie: voieId,
         numero: 1,
         suffixe: 'bis',
@@ -309,8 +322,8 @@ describe('PUBLICATION MODULE', () => {
 
       axiosMock.onPost(`/revisions/${revisionId}/compute`).reply(200, revision);
 
-      const csvFile = `cle_interop;uid_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;certification_commune;commune_insee;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj
-    91534_xxxx_00001_bis;;rue de la paix;;1;bis;1;91534;Saclay;inconnue;8;42;1114835.92;6113076.85;;ban;2000-01-01`;
+      const csvFile = `cle_interop;id_ban_commune;id_ban_toponyme;id_ban_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;certification_commune;commune_insee;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj
+    91534_xxxx_00001_bis;${communeUuid};${toponymeUuid};${numeroUuid};rue de la paix;;1;bis;1;91534;Saclay;inconnue;8;42;1114835.92;6113076.85;;ban;2000-01-01`;
       axiosMock
         .onPut(`/revisions/${revisionId}/files/bal`)
         .reply(({ data }) => {
@@ -377,7 +390,7 @@ describe('PUBLICATION MODULE', () => {
         files: [
           {
             type: 'bal',
-            hash: '64efb8a258712e11e6409b60fcd4b1fee8f748286101c52a63a81dfd5e106369',
+            hash: '8d0cda05e7b8b58a92a18cd40d0549c1d3f8ac1ac9586243aa0e3f885bb870c4',
           },
         ],
       };

--- a/apps/cron/test/task.e2e-spec.ts
+++ b/apps/cron/test/task.e2e-spec.ts
@@ -329,8 +329,8 @@ describe('TASK MODULE', () => {
 
     axiosMock.onPost(`/revisions/${revisionId}/compute`).reply(200, revision);
 
-    const csvFile = `cle_interop;uid_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;certification_commune;commune_insee;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj
-  91534_xxxx_00001_bis;;rue de la paix;;1;bis;1;91534;Saclay;inconnue;8;42;1114835.92;6113076.85;;ban;2000-01-01`;
+    const csvFile = `cle_interop;id_ban_commune;id_ban_toponyme;id_ban_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;certification_commune;commune_insee;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj
+  91534_xxxx_00001_bis;;;;rue de la paix;;1;bis;1;91534;Saclay;inconnue;8;42;1114835.92;6113076.85;;ban;2000-01-01`;
     axiosMock.onPut(`/revisions/${revisionId}/files/bal`).reply(({ data }) => {
       expect(data.replace(/\s/g, '')).toEqual(csvFile.replace(/\s/g, ''));
       return [200, null];
@@ -391,7 +391,7 @@ describe('TASK MODULE', () => {
       files: [
         {
           type: 'bal',
-          hash: '64efb8a258712e11e6409b60fcd4b1fee8f748286101c52a63a81dfd5e106369',
+          hash: '8d0cda05e7b8b58a92a18cd40d0549c1d3f8ac1ac9586243aa0e3f885bb870c4',
         },
       ],
     };

--- a/libs/shared/src/modules/ban_plateform/ban_plateform.module.ts
+++ b/libs/shared/src/modules/ban_plateform/ban_plateform.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { HttpModule } from '@nestjs/axios';
+
+import { BanPlateformService } from './ban_plateform.service';
+
+@Module({
+  imports: [
+    ConfigModule,
+    HttpModule.registerAsync({
+      imports: [ConfigModule],
+      useFactory: async (configService: ConfigService) => ({
+        baseURL: configService.get('BAN_API_URL'),
+      }),
+      inject: [ConfigService],
+    }),
+  ],
+  providers: [BanPlateformService],
+  exports: [BanPlateformService],
+})
+export class BanPlateformModule {}

--- a/libs/shared/src/modules/ban_plateform/ban_plateform.service.ts
+++ b/libs/shared/src/modules/ban_plateform/ban_plateform.service.ts
@@ -1,0 +1,40 @@
+import { HttpService } from '@nestjs/axios';
+import { Injectable } from '@nestjs/common';
+import { AxiosError } from 'axios';
+import { of, catchError, firstValueFrom } from 'rxjs';
+
+@Injectable()
+export class BanPlateformService {
+  constructor(private readonly httpService: HttpService) {}
+
+  public async getBanAssemblage(codeCommune: string): Promise<Buffer> {
+    const { data } = await firstValueFrom(
+      await this.httpService
+        .get<Buffer>(`/ban/communes/${codeCommune}/download/csv-bal/adresses`, {
+          responseType: 'arraybuffer',
+        })
+        .pipe(
+          catchError((error: AxiosError) => {
+            if (error.response && error.response.status === 404) {
+              return of({ data: null });
+            }
+            throw error;
+          }),
+        ),
+    );
+    return data;
+  }
+
+  public async getIdBanCommune(codeCommune: string): Promise<string> {
+    const { data } = await firstValueFrom(
+      await this.httpService.get<any>(`/api/district/cog/${codeCommune}`).pipe(
+        catchError((error: AxiosError) => {
+          console.error('error', error.response.data);
+          throw error;
+        }),
+      ),
+    );
+
+    return data.response[0].id;
+  }
+}

--- a/libs/shared/src/modules/ban_plateform/types/habilitation.type.ts
+++ b/libs/shared/src/modules/ban_plateform/types/habilitation.type.ts
@@ -1,0 +1,30 @@
+export type EmailStrategy = {
+  pinCode: string;
+  type: 'email';
+  pinCodeExpiration: Date;
+  remainingAttempts: number;
+  createdAt: Date;
+};
+
+export type FranceConnectStrategy = {
+  type: 'franceconnect';
+};
+
+export enum StatusHabiliation {
+  PENDING = 'pending',
+  ACCEPTED = 'accepted',
+  REJECTED = 'rejected',
+}
+
+export type Habilitation = {
+  _id: string;
+  codeCommune: string;
+  emailCommune: string;
+  franceconnectAuthenticationUrl?: string;
+  strategy?: EmailStrategy | FranceConnectStrategy;
+  client?: string;
+  status: StatusHabiliation;
+  createdAt?: Date;
+  updatedAt?: Date;
+  expiresAt?: Date;
+};

--- a/libs/shared/src/modules/ban_plateform/types/revision.type.ts
+++ b/libs/shared/src/modules/ban_plateform/types/revision.type.ts
@@ -1,0 +1,44 @@
+export type ValidationRevision = {
+  valid?: boolean;
+  validatorVersion?: string;
+  errors?: string[];
+  warnings?: string[];
+  infos?: string[];
+  rowsCount?: number;
+};
+
+export type ContextRevision = {
+  nomComplet: string;
+  organisation: string;
+  extras: any;
+};
+
+export enum StatusRevision {
+  PENDING = 'pending',
+  PUBLISHED = 'published',
+}
+
+export type FileRevision = {
+  _id?: string;
+  revisionId?: string;
+  name?: string;
+  type: string;
+  size?: number;
+  hash: string;
+  createdAt?: Date;
+};
+
+export type Revision = {
+  _id: string;
+  codeCommune: string;
+  context?: ContextRevision;
+  validation?: ValidationRevision;
+  client?: string;
+  status?: StatusRevision;
+  ready: boolean;
+  files?: FileRevision[];
+  createdAt: Date;
+  updatedAt: Date;
+  publishedAt?: Date;
+  current: boolean;
+};

--- a/libs/shared/src/modules/export_csv/export_csv.service.ts
+++ b/libs/shared/src/modules/export_csv/export_csv.service.ts
@@ -41,7 +41,7 @@ export class ExportCsvService {
       baseLocale._id,
     );
 
-    return exportBalToCsv(voies, toponymes, numeros, withComment);
+    return exportBalToCsv(baseLocale, voies, toponymes, numeros, withComment);
   }
 
   async exportVoiesToCsv(baseLocale: BaseLocale): Promise<string> {

--- a/libs/shared/src/modules/export_csv/utils/export_csv_bal.utils.ts
+++ b/libs/shared/src/modules/export_csv/utils/export_csv_bal.utils.ts
@@ -10,12 +10,20 @@ import { Numero } from '@/shared/schemas/numero/numero.schema';
 import { Voie } from '@/shared/schemas/voie/voie.schema';
 import { getCommune } from '@/shared/utils/cog.utils';
 import { roundCoordinate } from '@/shared/utils/coor.utils';
+import { BaseLocale } from '@/shared/schemas/base_locale/base_locale.schema';
 
 const DEFAULT_CODE_VOIE = 'xxxx';
 const DEFAULT_NUMERO_TOPONYME = 99999;
 const DEFAULT_SOURCE = 'commune';
 
+type BanIdsType = {
+  commune: string;
+  toponyme: string;
+  adresse?: string;
+};
+
 type RowType = {
+  banIds: BanIdsType;
   codeCommune: string;
   codeVoie: string;
   numero: number;
@@ -32,8 +40,10 @@ type RowType = {
 };
 
 type CsvRowType = {
+  id_ban_commune: string;
+  id_ban_toponyme: string;
+  id_ban_adresse: string;
   cle_interop: string;
-  uid_adresse: string;
   voie_nom: string;
   lieudit_complement_nom: string;
   numero: string;
@@ -99,7 +109,9 @@ function createRow(obj: RowType, withComment: boolean): CsvRowType {
       obj.numero,
       obj.suffixe,
     ),
-    uid_adresse: '',
+    id_ban_commune: obj.banIds.commune,
+    id_ban_toponyme: obj.banIds.toponyme,
+    id_ban_adresse: obj.banIds.adresse || '',
     voie_nom: obj.nomVoie,
     lieudit_complement_nom: obj.nomToponyme || '',
     numero: Number.isInteger(obj.numero) ? obj.numero.toString() : '',
@@ -150,6 +162,7 @@ function createRow(obj: RowType, withComment: boolean): CsvRowType {
 }
 
 export async function exportBalToCsv(
+  baseLocale: BaseLocale,
   voies: Voie[],
   toponymes: Toponyme[],
   numeros: Numero[],
@@ -178,6 +191,11 @@ export async function exportBalToCsv(
     if (n.positions && n.positions.length > 0) {
       n.positions.forEach((p) => {
         rows.push({
+          banIds: {
+            commune: baseLocale.banId,
+            toponyme: v.banId,
+            adresse: n.banId,
+          },
           codeCommune: n.commune,
           codeVoie: DEFAULT_CODE_VOIE,
           numero: n.numero,
@@ -200,6 +218,10 @@ export async function exportBalToCsv(
     if (t.positions.length > 0) {
       t.positions.forEach((p) => {
         rows.push({
+          banIds: {
+            commune: baseLocale.banId,
+            toponyme: t.banId,
+          },
           codeCommune: t.commune,
           codeVoie: DEFAULT_CODE_VOIE,
           numero: DEFAULT_NUMERO_TOPONYME,
@@ -212,6 +234,10 @@ export async function exportBalToCsv(
       });
     } else {
       rows.push({
+        banIds: {
+          commune: baseLocale.banId,
+          toponyme: t.banId,
+        },
         codeCommune: t.commune,
         codeVoie: DEFAULT_CODE_VOIE,
         numero: DEFAULT_NUMERO_TOPONYME,

--- a/libs/shared/src/schemas/base-entity.schema.ts
+++ b/libs/shared/src/schemas/base-entity.schema.ts
@@ -7,6 +7,10 @@ export class BaseEntity {
   @Prop({ type: SchemaTypes.ObjectId, auto: true })
   _id: Types.ObjectId;
 
+  @ApiProperty({ type: String })
+  @Prop({ type: SchemaTypes.UUID })
+  banId: string;
+
   @ApiProperty()
   @Prop({ type: SchemaTypes.Date, default: Date.now })
   _created: Date;

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "ts-loader": "^9.4.3",
-    "uuidv4": "^6.2.13",
+    "uuid": "^9.0.1",
     "vt-pbf": "^3.1.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@ban-team/adresses-util": "^0.9.0",
     "@ban-team/shared-data": "^1.2.0",
-    "@ban-team/validateur-bal": "^2.16.0",
+    "@ban-team/validateur-bal": "^2.18.4",
     "@etalab/decoupage-administratif": "^3.1.1",
     "@etalab/project-legal": "^0.6.0",
     "@mapbox/tilebelt": "^1.0.2",
@@ -79,6 +79,7 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "ts-loader": "^9.4.3",
+    "uuidv4": "^6.2.13",
     "vt-pbf": "^3.1.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -893,10 +893,10 @@
   resolved "https://registry.yarnpkg.com/@ban-team/shared-data/-/shared-data-1.2.0.tgz#0e29e84a00f7df3b17e5821bde1405a2bfa656b5"
   integrity sha512-35jz6ITHHufUKxXAfa8ReSMl6lZarnfVBkS++wgHpk27e9K52bXyAHo+n3X331n2mSzoIQXxFK7SEcPob7a5cA==
 
-"@ban-team/validateur-bal@^2.16.0":
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.16.0.tgz#0ef7754334e58dc9cc80a791731616b5cd82a896"
-  integrity sha512-OO/rpOfnU7VfzAH57v6pQttoMCNnHB5sKFmLUtFJ6AGGsgvZJoUJ32XAGvofK5QVHvT7QUv/Xrn21zpoo0Lx9A==
+"@ban-team/validateur-bal@^2.18.4":
+  version "2.18.4"
+  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.18.4.tgz#c8730ac6f0e13d93b733d7de8cf69213f2a93607"
+  integrity sha512-zarwT7lm6QoTDp2+Q9EohxXrVKkpn8o7WyOBMyj/racqpOvuemREmw0aEmUjalTY8ASYw86fbDuQD4K27cWW3w==
   dependencies:
     "@ban-team/shared-data" "^1.2.0"
     "@etalab/project-legal" "^0.6.0"
@@ -909,6 +909,7 @@
     iconv-lite "^0.6.3"
     lodash "^4.17.21"
     papaparse "^5.3.2"
+    uuidv4 "^6.2.13"
     yargs "^17.5.1"
 
 "@bcoe/v8-coverage@^0.2.3":

--- a/yarn.lock
+++ b/yarn.lock
@@ -9135,7 +9135,7 @@ uuid@9.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
   integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
-uuid@9.0.1, uuid@^9.0.0:
+uuid@9.0.1, uuid@^9.0.0, uuid@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3262,6 +3262,11 @@
   dependencies:
     "@types/superagent" "*"
 
+"@types/uuid@8.3.4":
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
+  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
+
 "@types/validator@^13.7.10":
   version "13.11.2"
   resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.11.2.tgz#a2502325a3c0bd29f36dbac3b763223edd801e17"
@@ -9119,6 +9124,11 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
+uuid@8.3.2, uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
 uuid@9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
@@ -9129,10 +9139,13 @@ uuid@9.0.1, uuid@^9.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuidv4@^6.2.13:
+  version "6.2.13"
+  resolved "https://registry.yarnpkg.com/uuidv4/-/uuidv4-6.2.13.tgz#8f95ec5ef22d1f92c8e5d4c70b735d1c89572cb7"
+  integrity sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==
+  dependencies:
+    "@types/uuid" "8.3.4"
+    uuid "8.3.2"
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
## Modification

- Ajout du champ `banId` dans les collections `voies`, `bases_locales`, `toponymes` et `numeros`
- intégration du validateur 2.18.4 avec les `AdditionnalValues` pour la colonne `uid_adresse` du format BAL 1.3
- Import du `banId` ou génération a la volé de `banId` lors des importMany du populate
- Génération a la volée du banId lors de la création d'une `voies`, `bases_locales`, `toponymes` et `numeros`
- Export des `banId` dans les colonnes `id_ban_commune`, `id_ban_toponyme`, `id_ban_adresse` du fihcier BAL format 1.4