### PR TITLE
fix: useless request api-depot

### DIFF
--- a/libs/shared/src/modules/api_depot/api_depot.service.ts
+++ b/libs/shared/src/modules/api_depot/api_depot.service.ts
@@ -8,6 +8,7 @@ import { Habilitation } from './types/habilitation.type';
 import { BaseLocale } from '@/shared/schemas/base_locale/base_locale.schema';
 import { Revision } from '@/shared/modules/api_depot/types/revision.type';
 import { ConfigService } from '@nestjs/config';
+import { ObjectId } from 'mongodb';
 
 @Injectable()
 export class ApiDepotService {
@@ -17,6 +18,13 @@ export class ApiDepotService {
   ) {}
 
   async findOneHabiliation(habilitationId: string): Promise<Habilitation> {
+    if (!ObjectId.isValid(habilitationId)) {
+      throw new HttpException(
+        'L’identifiant de l’habilitation est invalide',
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
     const { data } = await firstValueFrom(
       this.httpService
         .get<Habilitation>(`habilitations/${habilitationId}`)


### PR DESCRIPTION
## Context

En regardant les log datadog je me suis apercu qu'on avait l'erreur ` Mes Adresses Api Out error { code: 404, message: 'L’identifiant de l’habilitation est invalide' }` des milliers de fois par seconde au heure de pointe (exemple en image)


<img width="1484" alt="Capture d’écran 2024-04-11 à 12 57 56" src="https://github.com/BaseAdresseNationale/mes-adresses-api/assets/8143924/56776e19-16a9-4b52-bd8c-cfe66fe80c85">


Cette erreurs vient lorsque on appelle la route /habilitations/undefined, ce qui est le cas pour toutes les BAL de mes-adresses qui sont en brouillon par exemple.

Lorsque l'on arrive sur la page principal de mes-adresse, cela lance une requète /habilitation pour chaque bals, pour toutes celle qui sont en brouillons cela lance une /habilitations/undefined et donc le logs d'erreur.

Cela rend les log quasi illisible et plus chers

## Modification

Afin de ne pas faire des milliers d'appelle inutile par seconde, on fait le GET /habilitations/:habilitationId a l'api-depot seulement si l'habilitationId est un ObjectId valide