### PR TITLE
fix: import many numeros calc tiles

### DIFF
--- a/apps/api/src/modules/numeros/numero.service.ts
+++ b/apps/api/src/modules/numeros/numero.service.ts
@@ -7,7 +7,7 @@ import {
 } from '@nestjs/common';
 import { FilterQuery, Model, ProjectionType, SortOrder, Types } from 'mongoose';
 import { InjectModel } from '@nestjs/mongoose';
-import { omit, uniq } from 'lodash';
+import { omit, uniq, chunk } from 'lodash';
 
 import { Numero } from '@/shared/schemas/numero/numero.schema';
 import { NumeroPopulate } from '@/shared/schemas/numero/numero.populate';
@@ -145,13 +145,11 @@ export class NumeroService {
 
     // INSERT NUMEROS BY CHUNK OF 500
     // TO LIMIT MEMORY USAGE
-    do {
-      const numerosChunk = numeros.splice(0, 500);
+    for (const numerosChunk of chunk(numeros, 500)) {
       await this.numeroModel.insertMany(numerosChunk);
-    } while (numeros.length > 0);
-
+    }
     // UPDATE TILES OF VOIES
-    const voieIds = uniq(numeros.map((n) => n.voie));
+    const voieIds: string[] = uniq(numeros.map((n) => n.voie.toString()));
     await this.voieService.updateTiles(voieIds);
   }
 

--- a/apps/api/src/modules/voie/voie.service.ts
+++ b/apps/api/src/modules/voie/voie.service.ts
@@ -169,7 +169,8 @@ export class VoieService {
     await this.voieModel.insertMany(voies);
   }
 
-  async updateTiles(voies: Voie[]) {
+  async updateTiles(voieIds: string[]) {
+    const voies: Voie[] = await this.findMany({ _id: { $in: voieIds } });
     return Promise.all(
       voies.map(async (voie) => {
         const voieSet = await this.calcMetaTilesVoie(voie);

--- a/migrations/2024_04_26_fix_update_tiles_voies.ts
+++ b/migrations/2024_04_26_fix_update_tiles_voies.ts
@@ -1,0 +1,149 @@
+import { Schema, model, connect, disconnect } from 'mongoose';
+import * as turf from '@turf/turf';
+import { range, maxBy } from 'lodash';
+import { getPositionPriorityByType } from '@ban-team/adresses-util';
+import {
+  pointToTile,
+} from '@mapbox/tilebelt';
+import * as dotenv from 'dotenv';
+dotenv.config();
+
+// VOIE
+interface IVoie {
+  _id: any;
+  centroid: any;
+  centroidTiles: string[] | null;
+  typeNumerotation: string;
+  traceTiles: string[] | null;
+}
+const VoieSchema = new Schema<IVoie>({
+  _id: { type: Object },
+  centroid: { type: Object },
+  centroidTiles: { type: [String] },
+  typeNumerotation: { type: String },
+  traceTiles: { type: [String] },
+});
+const VoiesModel = model<IVoie>('voies', VoieSchema);
+
+// VOIE
+interface INumero {
+  positions: any[];
+}
+const NumeroSchema = new Schema<INumero>({
+  positions: { type: [Object] },
+});
+const NumeroModel = model<INumero>('numeros', NumeroSchema);
+
+const ZOOM = {
+  NUMEROS_ZOOM: {
+    minZoom: 13,
+    maxZoom: 19,
+  },
+  VOIE_ZOOM: {
+    minZoom: 13,
+    maxZoom: 19,
+  },
+  TRACE_DISPLAY_ZOOM: {
+    minZoom: 13,
+    maxZoom: 19,
+  },
+  TRACE_MONGO_ZOOM: {
+    zoom: 13,
+  },
+};
+
+export function getPriorityPosition(positions) {
+  return positions.length === 0
+    ? {}
+    : maxBy(positions, (p) => getPositionPriorityByType(p.type));
+}
+
+function roundCoordinate(
+  coordinate: number,
+  precision: number = 6,
+): number {
+  return Number.parseFloat(coordinate.toFixed(precision));
+}
+
+function getTilesByPosition(
+  point: any,
+  {
+    minZoom,
+    maxZoom,
+  }: { minZoom: number; maxZoom: number } = ZOOM.NUMEROS_ZOOM,
+): string[] | null {
+  if (!point || !minZoom || !maxZoom) {
+    return null;
+  }
+
+  const lon: number = roundCoordinate(point.coordinates[0], 6);
+  const lat: number = roundCoordinate(point.coordinates[1], 6);
+
+  const tiles: string[] = range(minZoom, maxZoom + 1).map((zoom) => {
+    const [x, y, z]: number[] = pointToTile(lon, lat, zoom);
+    return `${z}/${x}/${y}`;
+  });
+
+  return tiles;
+}
+
+async function calcMetaTilesVoie(voie: IVoie) {
+  voie.centroid = null;
+  voie.centroidTiles = null;
+  voie.traceTiles = null;
+
+  try {
+    const numeros = await NumeroModel.find(
+      { voie: voie._id, _deleted: null },
+      { positions: 1, voie: 1 },
+    );
+    if (numeros.length > 0) {
+      const coordinatesNumeros = numeros
+        .filter((n) => n.positions && n.positions.length > 0)
+        .map((n) => getPriorityPosition(n.positions)?.point?.coordinates);
+      // CALC CENTROID
+      if (coordinatesNumeros.length > 0) {
+        const featureCollection = turf.featureCollection(
+          coordinatesNumeros.map((n) => turf.point(n)),
+        );
+        voie.centroid = turf.centroid(featureCollection);
+        voie.centroidTiles = getTilesByPosition(
+          voie.centroid.geometry,
+          ZOOM.VOIE_ZOOM,
+        );
+      }
+    }
+  } catch (error) {
+    console.error(error, voie._id);
+  }
+
+  return voie;
+}
+
+async function run() {
+  await connect(`${process.env.MONGODB_URL}/${process.env.MONGODB_DBNAME}`);
+
+  const total = await VoiesModel.count({centroid: {$exists: false}, typeNumerotation: {$ne: 'metrique'}})
+  console.log(`START ${total} VOIES`)
+
+  const voiesCursor = VoiesModel.find({centroid: {$exists: false}, typeNumerotation: {$ne: 'metrique'}})
+  let count = 0
+
+  for await (const v of voiesCursor) {
+    count++
+
+    await calcMetaTilesVoie(v)
+    await VoiesModel.updateOne(
+      {_id: v._id},
+      { $set: { centroid: v.centroid, centroidTiles: v.centroidTiles, traceTiles: v.traceTiles }}
+    )
+    if (count % 100 === 0) {
+      console.log(`${count}/${total}`)
+    }
+  }
+
+  await disconnect()
+  process.exit(1);
+}
+
+run().catch((err) => console.log(err));


### PR DESCRIPTION
## Context

Toutes les nouvelles bal créer depuis la migration non pas de `centroid` et ont des `centroidTiles` et `traceTiles` vide.
Du coup on ne voit pas les libellés des voies

https://trello.com/c/k9vmPujV

## Fix

Correction de la fonction `updateTiles` pour bien calculer les tiles lors d'un importMany (de bal depuis api-depot / ban-plateforme)

## Migration

Besoin d'une migration pour corriger toutes les voies qui n'ont pas de tiles