### PR TITLE
fix: findOneOrFail deleted null

### DIFF
--- a/apps/api/src/modules/base_locale/base_locale.service.ts
+++ b/apps/api/src/modules/base_locale/base_locale.service.ts
@@ -64,6 +64,7 @@ export class BaseLocaleService {
   async findOneOrFail(id: string): Promise<BaseLocale> {
     const filter = {
       _id: id,
+      _deleted: null,
     };
     const baseLocale = await this.baseLocaleModel.findOne(filter).lean().exec();
 

--- a/apps/api/src/modules/numeros/numero.service.ts
+++ b/apps/api/src/modules/numeros/numero.service.ts
@@ -43,6 +43,7 @@ export class NumeroService {
   async findOneOrFail(numeroId: string): Promise<Numero> {
     const filter = {
       _id: numeroId,
+      _deleted: null,
     };
     const numero = await this.numeroModel
       .findOne(filter)

--- a/apps/api/src/modules/toponyme/toponyme.service.ts
+++ b/apps/api/src/modules/toponyme/toponyme.service.ts
@@ -39,6 +39,7 @@ export class ToponymeService {
   async findOneOrFail(toponymeId: string): Promise<Toponyme> {
     const filter = {
       _id: toponymeId,
+      _deleted: null,
     };
     const toponyme = await this.toponymeModel.findOne(filter).lean().exec();
 

--- a/apps/api/src/modules/voie/voie.service.ts
+++ b/apps/api/src/modules/voie/voie.service.ts
@@ -55,6 +55,7 @@ export class VoieService {
   async findOneOrFail(voieId: string): Promise<Voie> {
     const filter = {
       _id: voieId,
+      _deleted: null,
     };
     const voie = await this.voieModel.findOne(filter).lean().exec();
 


### PR DESCRIPTION
## Context

Lorsque lon supprime une BAL sur BAL-ADMIN, celle ci reste visible sur l'accueille de mes-adresses des commune car la fonction findOneOrFail utilisé dans tous les middleware autorise les bal (et autre collection) a retourner des object deleted alors que ce n'est pas nécéssaire