### PR TITLE
fix: route send code pin

### DIFF
--- a/apps/api/src/modules/base_locale/sub_modules/habilitation/dto/send-pin-code.response.dto.ts
+++ b/apps/api/src/modules/base_locale/sub_modules/habilitation/dto/send-pin-code.response.dto.ts
@@ -1,9 +1,0 @@
-import { ApiProperty } from '@nestjs/swagger';
-
-export class SendPinCodeResponseDTO {
-  @ApiProperty({ required: true, nullable: false })
-  code: number;
-
-  @ApiProperty({ required: true, nullable: false })
-  message: string;
-}

--- a/apps/api/src/modules/base_locale/sub_modules/habilitation/habilitation.controller.ts
+++ b/apps/api/src/modules/base_locale/sub_modules/habilitation/habilitation.controller.ts
@@ -28,7 +28,6 @@ import { AdminGuard } from '@/lib/guards/admin.guard';
 import { HabilitationService } from './habilitation.service';
 import { ValidatePinCodeDTO } from './dto/validate-pin-code.dto';
 import { HabilitationDTO } from './dto/habilitation.dto';
-import { SendPinCodeResponseDTO } from './dto/send-pin-code.response.dto';
 import { ValidatePinCodeResponseDTO } from './dto/validate-pin-code.response.dto';
 
 @ApiTags('habilitation')
@@ -96,28 +95,11 @@ export class HabilitationController {
     operationId: 'sendPinCodeHabilitation',
   })
   @ApiParam({ name: 'baseLocaleId', required: true, type: String })
-  @ApiResponse({ status: 200, type: SendPinCodeResponseDTO })
   @ApiBearerAuth('admin-token')
   @UseGuards(AdminGuard)
   async sendPinCode(@Req() req: CustomRequest, @Res() res: Response) {
-    try {
-      const sendPinCodeResponse: SendPinCodeResponseDTO =
-        await this.habilitationService.sendPinCode(
-          req.baseLocale._habilitation,
-        );
-
-      return res.status(sendPinCodeResponse.code).send({
-        code: sendPinCodeResponse.code,
-        message: sendPinCodeResponse.message,
-      });
-    } catch (error) {
-      const statusCode = error.code || error.status || 500;
-
-      return res.status(statusCode).send({
-        statusCode,
-        message: error.message,
-      });
-    }
+    await this.habilitationService.sendPinCode(req.baseLocale._habilitation);
+    res.sendStatus(HttpStatus.OK);
   }
 
   @Post('/bases-locales/:baseLocaleId/habilitation/email/validate-pin-code')

--- a/apps/api/src/modules/base_locale/sub_modules/habilitation/habilitation.service.ts
+++ b/apps/api/src/modules/base_locale/sub_modules/habilitation/habilitation.service.ts
@@ -62,11 +62,8 @@ export class HabilitationService {
     return habilitation;
   }
 
-  async sendPinCode(
-    habilitationId: string,
-  ): Promise<{ code: number; message: string }> {
+  async sendPinCode(habilitationId: string): Promise<void> {
     const habilitation = await this.findOne(habilitationId);
-
     if (habilitation.status !== 'pending') {
       throw new HttpException(
         'Aucune demande d’habilitation en attente',
@@ -74,10 +71,12 @@ export class HabilitationService {
       );
     }
 
-    const data: { code: number; message: string } =
+    try {
       await this.apiDepotService.sendPinCodeHabiliation(habilitationId);
-
-    return data;
+    } catch (error) {
+      const { statusCode, message } = error.response.data;
+      throw new HttpException(message, statusCode);
+    }
   }
 
   async validatePinCode(habilitationId: string, code: string): Promise<any> {

--- a/apps/api/test/habilitation.e2e-spec.ts
+++ b/apps/api/test/habilitation.e2e-spec.ts
@@ -274,15 +274,10 @@ describe('HABILITATION MODULE', () => {
           message: 'OK',
         });
 
-      const response = await request(app.getHttpServer())
+      await request(app.getHttpServer())
         .post(`/bases-locales/${balId}/habilitation/email/send-pin-code`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
-
-      expect(response.body).toEqual({
-        code: 200,
-        message: 'OK',
-      });
     });
 
     it('expect 412 no pending habilitation', async () => {

--- a/libs/shared/src/modules/api_depot/api_depot.service.ts
+++ b/libs/shared/src/modules/api_depot/api_depot.service.ts
@@ -54,12 +54,10 @@ export class ApiDepotService {
     return habilitation;
   }
 
-  async sendPinCodeHabiliation(
-    habilitationId: string,
-  ): Promise<{ code: number; message: string }> {
-    const { data } = await firstValueFrom(
+  async sendPinCodeHabiliation(habilitationId: string): Promise<void> {
+    await firstValueFrom(
       this.httpService
-        .post<{ code: number; message: string }>(
+        .post<void>(
           `habilitations/${habilitationId}/authentication/email/send-pin-code`,
         )
         .pipe(
@@ -69,7 +67,6 @@ export class ApiDepotService {
           }),
         ),
     );
-    return data;
   }
 
   async validatePinCodeHabiliation(


### PR DESCRIPTION
## Context

La route `/bases-locales/:baseLocaleId/habilitation/email/send-pin-code` est beaucoup trop complexe et renvoie inutilement un résultat qu'elle réussise ou non

## Modification

La route renvoie juste le status 200 si elle réussi et une erreur si l'api-depot a un problème