### PR TITLE
fix: delete position type inconnue

### DIFF
--- a/apps/api/src/lib/utils/csv.utils.ts
+++ b/apps/api/src/lib/utils/csv.utils.ts
@@ -48,7 +48,7 @@ export function extractCodeCommune({
 export function extractPosition(row: Row): Position {
   return {
     source: row.parsedValues.source || null,
-    type: row.parsedValues.position || PositionTypeEnum.INCONNUE,
+    type: row.parsedValues.position || PositionTypeEnum.ENTREE,
     point: {
       type: 'Point',
       coordinates: [row.parsedValues.long, row.parsedValues.lat],

--- a/apps/api/src/modules/numeros/dto/update_batch_numero_change.dto.ts
+++ b/apps/api/src/modules/numeros/dto/update_batch_numero_change.dto.ts
@@ -6,9 +6,11 @@ import {
   IsOptional,
   IsEnum,
   IsNotEmpty,
+  Validate,
 } from 'class-validator';
 
 import { PositionTypeEnum } from '@/shared/schemas/position_type.enum';
+import { ValidatorBal } from '@/shared/validators/validator_bal.validator';
 
 export class UpdateBatchNumeroChangeDTO {
   @IsOptional()
@@ -30,6 +32,7 @@ export class UpdateBatchNumeroChangeDTO {
   @IsOptional()
   @IsNotEmpty()
   @IsEnum(PositionTypeEnum)
+  @Validate(ValidatorBal, ['position'])
   @ApiProperty({ required: false, nullable: false })
   positionType?: PositionTypeEnum;
 

--- a/apps/api/test/base_locale.e2e-spec.ts
+++ b/apps/api/test/base_locale.e2e-spec.ts
@@ -155,7 +155,7 @@ describe('BASE LOCAL MODULE', () => {
   function createPositions(coordinates: number[] = [8, 42]): Position[] {
     return [
       {
-        type: PositionTypeEnum.INCONNUE,
+        type: PositionTypeEnum.ENTREE,
         source: 'ban',
         point: {
           type: 'Point',
@@ -606,8 +606,8 @@ describe('BASE LOCAL MODULE', () => {
       );
 
       const csvFile = `cle_interop;id_ban_commune;id_ban_toponyme;id_ban_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;certification_commune;commune_insee;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj
-91534_xxxx_00001_bis;${communeUuid};${voieUuid1};${numeroUuid1};rue de la paix;allée;1;bis;1;91534;Saclay;inconnue;8;42;1114835.92;6113076.85;;ban;2000-01-02
-91534_xxxx_00001_ter;${communeUuid};${voieUuid2};${numeroUuid2};rue de paris;allée;1;ter;0;91534;Saclay;inconnue;8;42;1114835.92;6113076.85;;ban;2000-01-02
+91534_xxxx_00001_bis;${communeUuid};${voieUuid1};${numeroUuid1};rue de la paix;allée;1;bis;1;91534;Saclay;entrée;8;42;1114835.92;6113076.85;;ban;2000-01-02
+91534_xxxx_00001_ter;${communeUuid};${voieUuid2};${numeroUuid2};rue de paris;allée;1;ter;0;91534;Saclay;entrée;8;42;1114835.92;6113076.85;;ban;2000-01-02
 91534_xxxx_99999;${communeUuid};${toponymeUuid1};;allée;;99999;;;91534;Saclay;;;;;;;commune;2000-01-02`;
       expect(response.text.replace(/\s/g, '')).toEqual(
         csvFile.replace(/\s/g, ''),

--- a/apps/api/test/numero.e2e-spec.ts
+++ b/apps/api/test/numero.e2e-spec.ts
@@ -374,7 +374,7 @@ describe('NUMERO', () => {
         numero: 99,
         positions: [
           {
-            type: PositionTypeEnum.INCONNUE,
+            type: PositionTypeEnum.ENTREE,
             source: 'ban',
             point: {
               type: 'Point',

--- a/apps/api/test/publication.e2e-spec.ts
+++ b/apps/api/test/publication.e2e-spec.ts
@@ -126,7 +126,7 @@ describe('PUBLICATION MODULE', () => {
   function createPositions(coordinates: number[] = [8, 42]): Position[] {
     return [
       {
-        type: PositionTypeEnum.INCONNUE,
+        type: PositionTypeEnum.ENTREE,
         source: 'ban',
         point: {
           type: 'Point',
@@ -198,7 +198,7 @@ describe('PUBLICATION MODULE', () => {
       axiosMock.onPost(`/revisions/${revisionId}/compute`).reply(200, revision);
 
       const csvFile = `cle_interop;id_ban_commune;id_ban_toponyme;id_ban_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;certification_commune;commune_insee;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj
-    91534_xxxx_00001_bis;${communeUuid};${toponymeUuid};${numeroUuid};rue de la paix;;1;bis;1;91534;Saclay;inconnue;8;42;1114835.92;6113076.85;;ban;2000-01-01`;
+    91534_xxxx_00001_bis;${communeUuid};${toponymeUuid};${numeroUuid};rue de la paix;;1;bis;1;91534;Saclay;entrée;8;42;1114835.92;6113076.85;;ban;2000-01-01`;
       axiosMock
         .onPut(`/revisions/${revisionId}/files/bal`)
         .reply(({ data }) => {
@@ -323,7 +323,7 @@ describe('PUBLICATION MODULE', () => {
       axiosMock.onPost(`/revisions/${revisionId}/compute`).reply(200, revision);
 
       const csvFile = `cle_interop;id_ban_commune;id_ban_toponyme;id_ban_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;certification_commune;commune_insee;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj
-    91534_xxxx_00001_bis;${communeUuid};${toponymeUuid};${numeroUuid};rue de la paix;;1;bis;1;91534;Saclay;inconnue;8;42;1114835.92;6113076.85;;ban;2000-01-01`;
+    91534_xxxx_00001_bis;${communeUuid};${toponymeUuid};${numeroUuid};rue de la paix;;1;bis;1;91534;Saclay;entrée;8;42;1114835.92;6113076.85;;ban;2000-01-01`;
       axiosMock
         .onPut(`/revisions/${revisionId}/files/bal`)
         .reply(({ data }) => {

--- a/apps/api/test/publication.e2e-spec.ts
+++ b/apps/api/test/publication.e2e-spec.ts
@@ -390,7 +390,7 @@ describe('PUBLICATION MODULE', () => {
         files: [
           {
             type: 'bal',
-            hash: '8d0cda05e7b8b58a92a18cd40d0549c1d3f8ac1ac9586243aa0e3f885bb870c4',
+            hash: '8e68ed7f8ca30946796fcbc6ebab92e1140e2daec87e1cc8314d497b1903605a',
           },
         ],
       };

--- a/apps/cron/test/task.e2e-spec.ts
+++ b/apps/cron/test/task.e2e-spec.ts
@@ -391,7 +391,7 @@ describe('TASK MODULE', () => {
       files: [
         {
           type: 'bal',
-          hash: '8d0cda05e7b8b58a92a18cd40d0549c1d3f8ac1ac9586243aa0e3f885bb870c4',
+          hash: '8e68ed7f8ca30946796fcbc6ebab92e1140e2daec87e1cc8314d497b1903605a',
         },
       ],
     };

--- a/apps/cron/test/task.e2e-spec.ts
+++ b/apps/cron/test/task.e2e-spec.ts
@@ -173,7 +173,7 @@ describe('TASK MODULE', () => {
   function createPositions(coordinates: number[] = [8, 42]): Position[] {
     return [
       {
-        type: PositionTypeEnum.INCONNUE,
+        type: PositionTypeEnum.ENTREE,
         source: 'ban',
         point: {
           type: 'Point',
@@ -330,7 +330,7 @@ describe('TASK MODULE', () => {
     axiosMock.onPost(`/revisions/${revisionId}/compute`).reply(200, revision);
 
     const csvFile = `cle_interop;id_ban_commune;id_ban_toponyme;id_ban_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;certification_commune;commune_insee;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj
-  91534_xxxx_00001_bis;;;;rue de la paix;;1;bis;1;91534;Saclay;inconnue;8;42;1114835.92;6113076.85;;ban;2000-01-01`;
+  91534_xxxx_00001_bis;;;;rue de la paix;;1;bis;1;91534;Saclay;entrée;8;42;1114835.92;6113076.85;;ban;2000-01-01`;
     axiosMock.onPut(`/revisions/${revisionId}/files/bal`).reply(({ data }) => {
       expect(data.replace(/\s/g, '')).toEqual(csvFile.replace(/\s/g, ''));
       return [200, null];

--- a/libs/shared/src/schemas/position.schema.ts
+++ b/libs/shared/src/schemas/position.schema.ts
@@ -14,6 +14,7 @@ export type PositionDocument = HydratedDocument<Position>;
 })
 export class Position {
   @IsEnum(PositionTypeEnum)
+  @Validate(ValidatorBal, ['position'])
   @ApiProperty({ enum: PositionTypeEnum })
   @Prop({ type: SchemaTypes.String, enum: PositionTypeEnum })
   type: PositionTypeEnum;

--- a/libs/shared/src/schemas/position_type.enum.ts
+++ b/libs/shared/src/schemas/position_type.enum.ts
@@ -7,5 +7,4 @@ export enum PositionTypeEnum {
   DELIVRANCE_POSTALE = 'délivrance postale',
   PARCELLE = 'parcelle',
   SEGMENT = 'segment',
-  INCONNUE = 'inconnue',
 }

--- a/migrations/2024_07_10_replace_position_type_inconnue.ts
+++ b/migrations/2024_07_10_replace_position_type_inconnue.ts
@@ -1,0 +1,82 @@
+import { Schema, model, connect } from 'mongoose';
+import * as dotenv from 'dotenv';
+dotenv.config();
+
+export enum StatusBaseLocalEnum {
+  DRAFT = 'draft',
+  PUBLISHED = 'published',
+  DEMO = 'demo',
+  REPLACED = 'replaced',
+  READY_TO_PUBLISH = 'ready-to-publish',
+}
+
+interface EntityWithPositionI {
+  _id: any;
+  positions: any;
+}
+const entityWithPosition = new Schema<EntityWithPositionI>({
+  _id: { type: Object },
+  positions: { type: Object },
+});
+
+const Numero = model<EntityWithPositionI>('numeros', entityWithPosition);
+const Toponyme = model<EntityWithPositionI>('toponymes', entityWithPosition);
+
+async function run() {
+  await connect(`${process.env.MONGODB_URL}/${process.env.MONGODB_DBNAME}`);
+
+  console.log(`START`);
+
+  let countNumero = 0;
+  const cursorNumero = Numero.find({
+    positions: { $elemMatch: { type: 'inconnue' } },
+  }).lean();
+  const totalNumero = await Numero.count({
+    positions: { $elemMatch: { type: 'inconnue' } },
+  });
+  console.log(`START ${totalNumero} numeros`);
+  for await (const entity of cursorNumero) {
+    countNumero++;
+    for (const position of entity.positions) {
+      if (position.type === 'inconnue') {
+        position.type = 'entrée';
+      }
+    }
+    await Numero.updateOne(
+      { _id: entity._id },
+      { $set: { positions: entity.positions } },
+    );
+    if (countNumero % 10000 === 0) {
+      console.log(`Upload OK, ${countNumero} / ${totalNumero} numeros`);
+    }
+  }
+
+  let countToponyme = 0;
+  const cursorToponyme = Toponyme.find({
+    positions: { $elemMatch: { type: 'inconnue' } },
+  }).lean();
+  const totalToponyme = await Toponyme.count({
+    positions: { $elemMatch: { type: 'inconnue' } },
+  });
+  console.log(`START ${totalToponyme} Toponymes`);
+  for await (const entity of cursorToponyme) {
+    countToponyme++;
+    for (const position of entity.positions) {
+      if (position.type === 'inconnue') {
+        position.type = 'entrée';
+      }
+    }
+    await Toponyme.updateOne(
+      { _id: entity._id },
+      { $set: { positions: entity.positions } },
+    );
+    if (countToponyme % 10000 === 0) {
+      console.log(`Upload OK, ${countToponyme} / ${totalToponyme} Toponymes`);
+    }
+  }
+  console.log(`END`);
+
+  process.exit(1);
+}
+
+run().catch((err) => console.log(err));

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.projectKey=incubateur-territoires_bal-mes-adresses-api
 sonar.organization=incubateur-territoires
 sonar.qualitygate.wait=true
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
-sonar.cpd.exclusions=apps/**/*.spec.ts
+sonar.cpd.exclusions=apps/**/*.e2e-spec.ts
 
 # This is the name and version displayed in the SonarCloud UI.
 #sonar.projectName=BAL Mes Adresses API


### PR DESCRIPTION
## CONTEXT

Le type de position `inconnue` ne passe pas le validateur
Il faut retirer la possibilité d'utiliser le type de position `inconnue` dans l'application mes-adresses

## FONCTIONNALITE

- Mettre type position `entrée` par default a l'import
- Changer l'enum
- Ajouter les validateur de position sur les dto
- Faire une migration de toute les ancienne positions

## PR

- [ ] https://github.com/BaseAdresseNationale/mes-adresses/pull/941