### PR TITLE
fix: mailer mode dev

### DIFF
--- a/libs/shared/src/params/mailer.params.ts
+++ b/libs/shared/src/params/mailer.params.ts
@@ -5,25 +5,34 @@ import { join } from 'path';
 export const MailerParams = {
   imports: [ConfigModule],
   inject: [ConfigService],
-  useFactory: async (config: ConfigService) => ({
-    transport: {
-      host: config.get('SMTP_HOST'),
-      port: config.get('SMTP_PORT'),
-      secure: config.get('SMTP_SECURE') === 'YES',
-      auth: {
-        user: config.get('SMTP_USER'),
-        pass: config.get('SMTP_PASS'),
-      },
-    },
-    defaults: {
-      from: config.get('SMTP_FROM'),
-    },
-    template: {
-      dir: join(__dirname, '../../../', '/email-templates'),
-      adapter: new HandlebarsAdapter(),
-      options: {
-        strict: true,
-      },
-    },
-  }),
+  useFactory: async (config: ConfigService) =>
+    config.get('SMTP_HOST')
+      ? {
+          transport: {
+            host: config.get('SMTP_HOST'),
+            port: config.get('SMTP_PORT'),
+            secure: config.get('SMTP_SECURE') === 'YES',
+            auth: {
+              user: config.get('SMTP_USER'),
+              pass: config.get('SMTP_PASS'),
+            },
+          },
+          defaults: {
+            from: config.get('SMTP_FROM'),
+          },
+          template: {
+            dir: join(__dirname, '../../../', '/email-templates'),
+            adapter: new HandlebarsAdapter(),
+            options: {
+              strict: true,
+            },
+          },
+        }
+      : {
+          transport: {
+            streamTransport: true,
+            newline: 'unix',
+            buffer: true,
+          },
+        },
 };


### PR DESCRIPTION
## Context

L'application ne démarre pas si il n'y a pas les paramètre SMTP correct.
Ajout du mode dev, pour que l'application marche si SMTP_HOST n'est pas défini