### PR TITLE
hotfix: bug search bal

### DIFF
--- a/apps/api/src/modules/base_locale/base_locale.service.ts
+++ b/apps/api/src/modules/base_locale/base_locale.service.ts
@@ -110,14 +110,17 @@ export class BaseLocaleService {
     limit?: number,
     offset?: number,
   ): Promise<BaseLocale[]> {
-    return this.basesLocalesRepository
+    const query = this.basesLocalesRepository
       .createQueryBuilder()
       .select()
       .where(where)
-      .andWhere('lower(emails::text)::text[] @> ARRAY[:email]', { email })
       .limit(limit)
-      .offset(offset)
-      .getMany();
+      .offset(offset);
+
+    if (email) {
+      query.andWhere('lower(emails::text)::text[] @> ARRAY[:email]', { email });
+    }
+    return query.getMany();
   }
 
   public async countGroupByStatus(): Promise<any[]> {

--- a/apps/api/src/modules/base_locale/pipe/search_query.pipe.ts
+++ b/apps/api/src/modules/base_locale/pipe/search_query.pipe.ts
@@ -4,7 +4,7 @@ import {
   HttpException,
   HttpStatus,
 } from '@nestjs/common';
-import { FindOptionsWhere, Not } from 'typeorm';
+import { FindOptionsWhere, IsNull, Not } from 'typeorm';
 
 import {
   BaseLocale,
@@ -46,9 +46,9 @@ export class SearchQueryPipe implements PipeTransform {
     }
 
     if (query.deleted === 'false') {
-      res.filters.deletedAt = null;
+      res.filters.deletedAt = IsNull();
     } else if (query.deleted === 'true') {
-      res.filters.deletedAt = Not(null);
+      res.filters.deletedAt = Not(IsNull());
     } else if (query.deleted) {
       throw new HttpException(
         'La valeur du champ "deleted" est invalide',


### PR DESCRIPTION
## CONTEXT

Les Bal n'apparaissent pas coté bal-admin

## FIX

- On enlève le andWhere (des emails) dans la requète search si l'email n'est pas defini dans le DTO
- On remplace `= null` qui n'est pas interprété par typeorm par `IsNull()` (pour le deletedAt)