### PR TITLE
fix: query postgres extended bal

### DIFF
--- a/apps/api/src/modules/base_locale/base_locale.service.ts
+++ b/apps/api/src/modules/base_locale/base_locale.service.ts
@@ -35,7 +35,6 @@ import {
   getApiUrl,
   getEditorUrl,
 } from '@/shared/utils/mailer.utils';
-import { extendWithNumeros } from '@/shared/utils/numero.utils';
 
 import { generateBase62String } from '@/lib/utils/token.utils';
 import { FromCsvType, extractFromCsv } from '@/lib/utils/csv.utils';
@@ -414,15 +413,18 @@ export class BaseLocaleService {
   async extendWithNumeros(
     baseLocale: BaseLocale,
   ): Promise<ExtendedBaseLocaleDTO> {
-    // On récupère les numeros de la Bal
-    const numeros = await this.numeroService.findMany(
-      {
-        balId: baseLocale.id,
-      },
-      { certifie: true, numero: true, comment: true },
-    );
-    // On rajoute les metas des numeros a la Bal
-    return extendWithNumeros(baseLocale, numeros);
+    const { nbNumeros, nbNumerosCertifies } =
+      await this.numeroService.countBalNumeroAndCertifie(baseLocale.id);
+    const balExtended: ExtendedBaseLocaleDTO = {
+      ...baseLocale,
+      nbNumeros: Number(nbNumeros),
+      nbNumerosCertifies: Number(nbNumerosCertifies),
+      isAllCertified:
+        Number(nbNumeros) > 0
+          ? Number(nbNumeros) === Number(nbNumerosCertifies)
+          : false,
+    };
+    return balExtended;
   }
 
   async getParcelles(basesLocale: BaseLocale): Promise<string[]> {

--- a/apps/api/src/modules/base_locale/dto/extended_base_locale.dto.ts
+++ b/apps/api/src/modules/base_locale/dto/extended_base_locale.dto.ts
@@ -1,5 +1,4 @@
 import { BaseLocale } from '@/shared/entities/base_locale.entity';
-import { Numero } from '@/shared/entities/numero.entity';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class ExtendedBaseLocaleDTO extends BaseLocale {
@@ -11,7 +10,4 @@ export class ExtendedBaseLocaleDTO extends BaseLocale {
 
   @ApiProperty()
   isAllCertified?: boolean;
-
-  @ApiProperty()
-  commentedNumeros?: Numero[];
 }

--- a/apps/api/src/modules/numeros/numero.service.ts
+++ b/apps/api/src/modules/numeros/numero.service.ts
@@ -87,6 +87,21 @@ export class NumeroService {
     });
   }
 
+  async countBalNumeroAndCertifie(balId: string): Promise<{
+    nbNumeros: string;
+    nbNumerosCertifies: string;
+  }> {
+    const query = this.numerosRepository
+      .createQueryBuilder()
+      .select('count(id)', 'nbNumeros')
+      .addSelect(
+        'count(CASE WHEN certifie THEN true END)',
+        'nbNumerosCertifies',
+      )
+      .where('bal_id = :balId', { balId });
+    return query.getRawOne();
+  }
+
   async findManyWithDeleted(
     where: FindOptionsWhere<Numero>,
   ): Promise<Numero[]> {

--- a/apps/api/test/base_locale.e2e-spec.ts
+++ b/apps/api/test/base_locale.e2e-spec.ts
@@ -41,7 +41,6 @@ const baseLocalePublicProperties = [
   'nbNumeros',
   'nbNumerosCertifies',
   'isAllCertified',
-  'commentedNumeros',
   'status',
   'updatedAt',
   'createdAt',
@@ -654,7 +653,6 @@ describe('BASE LOCAL MODULE', () => {
         nbNumeros: 0,
         nbNumerosCertifies: 0,
         isAllCertified: false,
-        commentedNumeros: [],
         status: StatusBaseLocalEnum.DRAFT,
         sync: null,
         habilitationId: null,
@@ -830,28 +828,6 @@ describe('BASE LOCAL MODULE', () => {
       expect(response.body.nbNumeros).toEqual(2);
       expect(response.body.nbNumerosCertifies).toEqual(2);
       expect(response.body.isAllCertified).toEqual(true);
-    });
-    it('Commented numeros', async () => {
-      const balId = await createBal({
-        nom: 'foo',
-        commune: '27115',
-        emails: ['me@domain.co'],
-      });
-      const voidId = await createVoie(balId, {
-        nom: 'rue',
-      });
-      await createNumero(balId, voidId, {
-        numero: 1,
-        comment: 'blabla',
-      });
-      await createNumero(balId, voidId, {
-        numero: 2,
-        comment: 'blibli',
-      });
-      const response = await request(app.getHttpServer())
-        .get(`/bases-locales/${balId}`)
-        .expect(200);
-      expect(response.body.commentedNumeros.length).toEqual(2);
     });
   });
 


### PR DESCRIPTION
## CONTEXT

Lors du chargement de la page d'accueil de mes-adresses cela peut être très lent si il y a beaucoup de BAL a charger.
Cela est du au fait qu'on récupère tous les numéros de chaque BAL pour mapper le nombre de numeros, certifie et commenataire.

## FIX

On utilise une requète spécifique avec des count pour postgres

## PR

- [x] https://github.com/BaseAdresseNationale/mes-adresses/pull/954
- [x] https://github.com/BaseAdresseNationale/bal-admin/pull/94