### PR TITLE
scalingo: add hook scalingo-postbuild for typeorm migration

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+postdeploy: yarn typeorm:migration:run
 clock: yarn start:cron

--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -4,8 +4,6 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import { join } from 'path';
 
-import { Initialization1725371358514 } from 'migrations/1725371358514-initialization';
-import { OnDeleteCascadeNumeros1726747666619 } from 'migrations/1726747666619-on_delete_cascade_numeros';
 import { BaseLocale } from '@/shared/entities/base_locale.entity';
 import { Voie } from '@/shared/entities/voie.entity';
 import { Numero } from '@/shared/entities/numero.entity';
@@ -35,11 +33,6 @@ import { AdminModule } from './modules/admin/admin.module';
         url: config.get('POSTGRES_URL'),
         keepConnectionAlive: true,
         schema: 'public',
-        migrationsRun: true,
-        migrations: [
-          Initialization1725371358514,
-          OnDeleteCascadeNumeros1726747666619,
-        ],
         entities: [BaseLocale, Voie, Numero, Toponyme, Position],
       }),
       inject: [ConfigService],

--- a/apps/cron/src/cron.module.ts
+++ b/apps/cron/src/cron.module.ts
@@ -6,8 +6,6 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { CacheModule, CacheStore } from '@nestjs/cache-manager';
 import { redisStore } from 'cache-manager-redis-store';
 
-import { Initialization1725371358514 } from 'migrations/1725371358514-initialization';
-import { OnDeleteCascadeNumeros1726747666619 } from 'migrations/1726747666619-on_delete_cascade_numeros';
 import { PublicationModule } from '@/shared/modules/publication/publication.module';
 import { BaseLocale } from '@/shared/entities/base_locale.entity';
 import { ApiDepotModule } from '@/shared/modules/api_depot/api_depot.module';
@@ -34,11 +32,6 @@ import { CronService } from './cron.service';
         url: config.get('POSTGRES_URL'),
         keepConnectionAlive: true,
         schema: 'public',
-        migrationsRun: true,
-        migrations: [
-          Initialization1725371358514,
-          OnDeleteCascadeNumeros1726747666619,
-        ],
         entities: [BaseLocale, Voie, Numero, Toponyme, Position],
       }),
       inject: [ConfigService],

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "test:cron": "jest --config ./apps/cron/test/jest-e2e.json",
     "update-cadastre": "node ./scripts/update-communes-cadastre.js",
     "push-staging": "./scripts/push-staging.sh",
-    "typeorm": "typeorm-ts-node-commonjs"
+    "typeorm": "typeorm-ts-node-commonjs",
+    "typeorm:migration:run": "yarn typeorm migration:run -- -d ./typeorm.config.ts"
   },
   "dependencies": {
     "@ban-team/adresses-util": "^0.9.0",


### PR DESCRIPTION
## CONTEXT

Les mirgation typeorm ne passe pas sur scalingo, lorsqu'il y a plusieurs instance

## FIX

Ajouter la migration run dans le postdeploy du Procfile