### PR TITLE
feat: add signalement module

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -17,3 +17,6 @@ API_DEPOT_URL=https://plateforme-bal.adresse.data.gouv.fr/api-depot
 API_DEPOT_CLIENT_ID=
 API_DEPOT_CLIENT_SECRET=
 BAN_API_URL=https://plateforme.adresse.data.gouv.fr
+
+API_SIGNALEMENT_URL=https://api-signalement-prod.osc-secnum-fr1.scalingo.io/
+API_SIGNALEMENT_CLIENT_SECRET=

--- a/README.md
+++ b/README.md
@@ -104,24 +104,26 @@ $ yarn lint
 Cette application utilise des variables d'environnement pour sa configuration.
 Elles peuvent être définies classiquement ou en créant un fichier `.env` sur la base du modèle `.env.sample`.
 
-| Nom de la variable        | Description                                                                 |
-| ------------------------- | --------------------------------------------------------------------------- |
-| `POSTGRES_URL`            | Url de connection a la db postgres                                          |
-| `PORT`                    | Port à utiliser pour l'API                                                  |
-| `API_URL`                 | URL de base de l’API                                                        |
-| `API_DEPOT_URL`           | URL de l'api-depot                                                          |
-| `API_DEPOT_CLIENT_ID`     | Id du client de l'api-depot                                                 |
-| `API_DEPOT_CLIENT_SECRET` | Token du client de l'api-depot                                              |
-| `EDITOR_URL_PATTERN`      | Pattern permettant de construire l'URL vers l'édition d'une BAL             |
-| `BAN_API_URL`             | URL de ban-plateform                                                        |
-| ---                       | ---                                                                         |
-| `SMTP_HOST`               | Nom d'hôte du serveur SMTP                                                  |
-| `SMTP_PORT`               | Port du serveur SMTP                                                        |
-| `SMTP_USER`               | Nom d'utilisateur pour se connecter au serveur SMTP                         |
-| `SMTP_PASS`               | Mot de passe pour se connecter au serveur SMTP                              |
-| `SMTP_SECURE`             | Indique si le serveur SMTP nécessite une connexion sécurisée (`YES`)        |
-| `SMTP_FROM`               | Adresse à utiliser en tant qu'expéditeur des emails                         |
-| `SMTP_BCC`                | Adresse(s) en copie cachée à utiliser pour tous les envois de notifications |
+| Nom de la variable              | Description                                                                 |
+| ------------------------------- | --------------------------------------------------------------------------- |
+| `POSTGRES_URL`                  | Url de connection a la db postgres                                          |
+| `PORT`                          | Port à utiliser pour l'API                                                  |
+| `API_URL`                       | URL de base de l’API                                                        |
+| `API_DEPOT_URL`                 | URL de l'api-depot                                                          |
+| `API_DEPOT_CLIENT_ID`           | Id du client de l'api-depot                                                 |
+| `API_DEPOT_CLIENT_SECRET`       | Token du client de l'api-depot                                              |
+| `EDITOR_URL_PATTERN`            | Pattern permettant de construire l'URL vers l'édition d'une BAL             |
+| `BAN_API_URL`                   | URL de ban-plateform                                                        |
+| `API_SIGNALEMENT_URL`           | URL de l'API Signalement                                                    |
+| `API_SIGNALEMENT_CLIENT_SECRET` | URL du client de l'API Signalement                                          |
+| ---                             | ---                                                                         |
+| `SMTP_HOST`                     | Nom d'hôte du serveur SMTP                                                  |
+| `SMTP_PORT`                     | Port du serveur SMTP                                                        |
+| `SMTP_USER`                     | Nom d'utilisateur pour se connecter au serveur SMTP                         |
+| `SMTP_PASS`                     | Mot de passe pour se connecter au serveur SMTP                              |
+| `SMTP_SECURE`                   | Indique si le serveur SMTP nécessite une connexion sécurisée (`YES`)        |
+| `SMTP_FROM`                     | Adresse à utiliser en tant qu'expéditeur des emails                         |
+| `SMTP_BCC`                      | Adresse(s) en copie cachée à utiliser pour tous les envois de notifications |
 
 Toutes ces variables ont des valeurs par défaut que vous trouverez dans le fichier `.env.sample`.
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Elles peuvent être définies classiquement ou en créant un fichier `.env` sur 
 | `EDITOR_URL_PATTERN`            | Pattern permettant de construire l'URL vers l'édition d'une BAL             |
 | `BAN_API_URL`                   | URL de ban-plateform                                                        |
 | `API_SIGNALEMENT_URL`           | URL de l'API Signalement                                                    |
-| `API_SIGNALEMENT_CLIENT_SECRET` | URL du client de l'API Signalement                                          |
+| `API_SIGNALEMENT_CLIENT_SECRET` | Secret du client de l'API Signalement                                       |
 | ---                             | ---                                                                         |
 | `SMTP_HOST`                     | Nom d'hôte du serveur SMTP                                                  |
 | `SMTP_PORT`                     | Port du serveur SMTP                                                        |

--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -18,6 +18,7 @@ import { StatsModule } from './modules/stats/stats.module';
 import { MailerModule } from '@nestjs-modules/mailer';
 import { MailerParams } from '@/shared/params/mailer.params';
 import { AdminModule } from './modules/admin/admin.module';
+import { SignalementModule } from './modules/signalement/signalement.module';
 
 @Module({
   imports: [
@@ -44,6 +45,7 @@ import { AdminModule } from './modules/admin/admin.module';
     ToponymeModule,
     StatsModule,
     AdminModule,
+    SignalementModule,
   ],
   controllers: [],
   providers: [],

--- a/apps/api/src/modules/signalement/dto/update-signalement-dto.ts
+++ b/apps/api/src/modules/signalement/dto/update-signalement-dto.ts
@@ -1,0 +1,18 @@
+import { Signalement } from '@/shared/openapi-signalement';
+import { ApiProperty } from '@nestjs/swagger';
+import { ArrayMinSize, IsEnum } from 'class-validator';
+
+export class UpdateSignalementDTO {
+  @ApiProperty({
+    type: String,
+    required: true,
+    nullable: false,
+    isArray: true,
+  })
+  @ArrayMinSize(1)
+  ids: string[];
+
+  @ApiProperty({ required: true, nullable: false, enum: Signalement.status })
+  @IsEnum(Signalement.status)
+  status: Signalement.status;
+}

--- a/apps/api/src/modules/signalement/openAPI-signalement.service.ts
+++ b/apps/api/src/modules/signalement/openAPI-signalement.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+import {
+  SignalementsService,
+  OpenAPI as OpenAPISignalement,
+  UpdateSignalementDTO,
+} from '@/shared/openapi-signalement';
+
+@Injectable()
+export class OpenAPISignalementService {
+  constructor(private configService: ConfigService) {
+    OpenAPISignalement.BASE = this.configService.get('API_SIGNALEMENT_URL');
+    OpenAPISignalement.TOKEN = this.configService.get(
+      'API_SIGNALEMENT_CLIENT_SECRET',
+    );
+  }
+
+  getSignalementById(signalementId: string) {
+    return SignalementsService.getSignalementById(signalementId);
+  }
+
+  async updateSignalement(
+    signalementId: string,
+    updateSignalementDTO: UpdateSignalementDTO,
+  ) {
+    return SignalementsService.updateSignalement(
+      signalementId,
+      updateSignalementDTO,
+    );
+  }
+}

--- a/apps/api/src/modules/signalement/signalement.controller.ts
+++ b/apps/api/src/modules/signalement/signalement.controller.ts
@@ -1,0 +1,59 @@
+import {
+  Body,
+  Controller,
+  HttpStatus,
+  Inject,
+  Put,
+  Req,
+  Res,
+  UseGuards,
+  forwardRef,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Response } from 'express';
+
+import { AdminGuard } from '@/lib/guards/admin.guard';
+import { CustomRequest } from '@/lib/types/request.type';
+import { SignalementService } from './signalement.service';
+import { UpdateSignalementDTO } from './dto/update-signalement-dto';
+
+@ApiTags('signalements')
+@Controller('signalements')
+export class SignalementController {
+  constructor(
+    @Inject(forwardRef(() => SignalementService))
+    private signalementService: SignalementService,
+  ) {}
+
+  @Put(':baseLocaleId')
+  @ApiOperation({
+    summary: 'Update signalements',
+    operationId: 'updateSignalements',
+  })
+  @ApiParam({ name: 'baseLocaleId', required: true, type: String })
+  @ApiBody({ type: UpdateSignalementDTO, required: true })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: Boolean,
+  })
+  @ApiBearerAuth('admin-token')
+  @UseGuards(AdminGuard)
+  async update(
+    @Req() req: CustomRequest,
+    @Body() updateSignalementDTO: UpdateSignalementDTO,
+    @Res() res: Response,
+  ) {
+    await this.signalementService.updateMany(
+      req.baseLocale,
+      updateSignalementDTO,
+    );
+    res.status(HttpStatus.OK).json(true);
+  }
+}

--- a/apps/api/src/modules/signalement/signalement.controller.ts
+++ b/apps/api/src/modules/signalement/signalement.controller.ts
@@ -1,8 +1,10 @@
 import {
   Body,
   Controller,
+  Get,
   HttpStatus,
   Inject,
+  Param,
   Put,
   Req,
   Res,
@@ -55,5 +57,28 @@ export class SignalementController {
       updateSignalementDTO,
     );
     res.status(HttpStatus.OK).json(true);
+  }
+
+  @Get('/:baseLocaleId/:idSignalement/author')
+  @ApiOperation({
+    summary: 'Get author by signalement id',
+    operationId: 'getAuthor',
+  })
+  @ApiParam({ name: 'baseLocaleId', required: true, type: String })
+  @ApiParam({ name: 'idSignalement', required: true, type: String })
+  @ApiBearerAuth('admin-token')
+  @UseGuards(AdminGuard)
+  @ApiResponse({
+    status: HttpStatus.OK,
+  })
+  async getAuthor(
+    @Req() req: Request,
+    @Res() res: Response,
+    @Param('idSignalement') idSignalement: string,
+  ) {
+    const signalement =
+      await this.signalementService.findOneOrFail(idSignalement);
+
+    res.status(HttpStatus.OK).json(signalement.author);
   }
 }

--- a/apps/api/src/modules/signalement/signalement.module.ts
+++ b/apps/api/src/modules/signalement/signalement.module.ts
@@ -1,0 +1,20 @@
+import { Module, MiddlewareConsumer, forwardRef } from '@nestjs/common';
+
+import { BaseLocaleMiddleware } from '@/modules/base_locale/base_locale.middleware';
+import { ConfigModule } from '@nestjs/config';
+import { BaseLocaleModule } from '../base_locale/base_locale.module';
+import { SignalementService } from './signalement.service';
+import { SignalementController } from './signalement.controller';
+import { OpenAPISignalementService } from './openAPI-signalement.service';
+
+@Module({
+  imports: [ConfigModule, forwardRef(() => BaseLocaleModule)],
+  providers: [SignalementService, OpenAPISignalementService],
+  controllers: [SignalementController],
+  exports: [SignalementService],
+})
+export class SignalementModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(BaseLocaleMiddleware).forRoutes(SignalementController);
+  }
+}

--- a/apps/api/src/modules/signalement/signalement.service.ts
+++ b/apps/api/src/modules/signalement/signalement.service.ts
@@ -1,0 +1,51 @@
+import {
+  BaseLocale,
+  StatusBaseLocalEnum,
+} from '@/shared/entities/base_locale.entity';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { UpdateSignalementDTO } from './dto/update-signalement-dto';
+import { OpenAPISignalementService } from './openAPI-signalement.service';
+
+@Injectable()
+export class SignalementService {
+  constructor(private openAPISignalementService: OpenAPISignalementService) {}
+
+  async updateMany(
+    baseLocale: BaseLocale,
+    updateSignalementDTO: UpdateSignalementDTO,
+  ) {
+    const { ids, status } = updateSignalementDTO;
+
+    if (baseLocale.status !== StatusBaseLocalEnum.PUBLISHED) {
+      throw new HttpException(
+        'BaseLocale is not published',
+        HttpStatus.PRECONDITION_FAILED,
+      );
+    }
+
+    for (const signalementId of ids) {
+      const fetchedSignalement =
+        await this.openAPISignalementService.getSignalementById(signalementId);
+
+      if (!fetchedSignalement) {
+        throw new HttpException(
+          `Signalement ${signalementId} not found`,
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      if (baseLocale.commune !== fetchedSignalement.codeCommune) {
+        throw new HttpException(
+          `Communes do not match for signalement ${signalementId}`,
+          HttpStatus.PRECONDITION_FAILED,
+        );
+      }
+
+      await this.openAPISignalementService.updateSignalement(signalementId, {
+        status,
+      });
+    }
+
+    return true;
+  }
+}

--- a/apps/api/src/modules/signalement/signalement.service.ts
+++ b/apps/api/src/modules/signalement/signalement.service.ts
@@ -10,6 +10,20 @@ import { OpenAPISignalementService } from './openAPI-signalement.service';
 export class SignalementService {
   constructor(private openAPISignalementService: OpenAPISignalementService) {}
 
+  async findOneOrFail(signalementId: string) {
+    const fetchedSignalement =
+      await this.openAPISignalementService.getSignalementById(signalementId);
+
+    if (!fetchedSignalement) {
+      throw new HttpException(
+        `Signalement ${signalementId} not found`,
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    return fetchedSignalement;
+  }
+
   async updateMany(
     baseLocale: BaseLocale,
     updateSignalementDTO: UpdateSignalementDTO,
@@ -24,15 +38,7 @@ export class SignalementService {
     }
 
     for (const signalementId of ids) {
-      const fetchedSignalement =
-        await this.openAPISignalementService.getSignalementById(signalementId);
-
-      if (!fetchedSignalement) {
-        throw new HttpException(
-          `Signalement ${signalementId} not found`,
-          HttpStatus.NOT_FOUND,
-        );
-      }
+      const fetchedSignalement = await this.findOneOrFail(signalementId);
 
       if (baseLocale.commune !== fetchedSignalement.codeCommune) {
         throw new HttpException(

--- a/apps/api/test/signalement.e2e-spec.ts
+++ b/apps/api/test/signalement.e2e-spec.ts
@@ -1,0 +1,242 @@
+import {
+  PostgreSqlContainer,
+  StartedPostgreSqlContainer,
+} from '@testcontainers/postgresql';
+import { Client } from 'pg';
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  forwardRef,
+  INestApplication,
+  MiddlewareConsumer,
+  Module,
+  ValidationPipe,
+} from '@nestjs/common';
+import * as request from 'supertest';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { v4 as uuid } from 'uuid';
+
+import { Numero } from '@/shared/entities/numero.entity';
+import { Voie } from '@/shared/entities/voie.entity';
+import { Toponyme } from '@/shared/entities/toponyme.entity';
+import {
+  BaseLocale,
+  StatusBaseLocalEnum,
+} from '@/shared/entities/base_locale.entity';
+import { Position } from '@/shared/entities/position.entity';
+
+import { BaseLocaleModule } from '@/modules/base_locale/base_locale.module';
+import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Signalement } from '@/shared/openapi-signalement';
+import { MailerModule } from '@/shared/test/mailer.module.test';
+import { SignalementService } from '@/modules/signalement/signalement.service';
+import { OpenAPISignalementService } from '@/modules/signalement/openAPI-signalement.service';
+import { SignalementController } from '@/modules/signalement/signalement.controller';
+import { BaseLocaleMiddleware } from '@/modules/base_locale/base_locale.middleware';
+
+const signalement = {
+  createdAt: '2024-11-28T16:41:54.271Z',
+  updatedAt: '2024-12-05T08:40:24.625Z',
+  deletedAt: null,
+  id: '4ecd95ca-cd6d-48ae-9b24-0b4580cd4ad8',
+  codeCommune: '37003',
+  type: 'LOCATION_TO_UPDATE',
+  existingLocation: {
+    nom: 'Place de la Gare',
+    type: 'TOPONYME',
+    banId: null,
+    position: {
+      point: {
+        type: 'Point',
+        coordinates: [null, null],
+      },
+    },
+    parcelles: [],
+  },
+  changesRequested: {
+    nom: 'Place des gares',
+    comment: '',
+    parcelles: [],
+    positions: [
+      {
+        type: 'segment',
+        point: {
+          type: 'Point',
+          coordinates: [0.980669, 47.421277],
+        },
+      },
+    ],
+  },
+  status: 'PENDING',
+  source: {
+    createdAt: '2024-11-21T13:13:29.575Z',
+    updatedAt: '2024-11-21T13:13:29.575Z',
+    deletedAt: null,
+    id: '93978e92-c686-4093-be1a-0caaad53b445',
+    nom: 'SIG Ville',
+    type: 'PRIVATE',
+  },
+};
+
+const OpenAPISignalementServiceMock = {
+  getSignalementById: jest.fn(() => Promise.resolve(signalement)),
+  updateSignalement: jest.fn(() => Promise.resolve(signalement)),
+};
+
+@Module({
+  imports: [forwardRef(() => BaseLocaleModule)],
+  providers: [
+    SignalementService,
+    {
+      provide: OpenAPISignalementService,
+      useValue: OpenAPISignalementServiceMock,
+    },
+  ],
+  controllers: [SignalementController],
+  exports: [SignalementService],
+})
+class SignalementModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(BaseLocaleMiddleware).forRoutes(SignalementController);
+  }
+}
+
+describe('SIGNALEMENT MODULE', () => {
+  let app: INestApplication;
+  // DB
+  let postgresContainer: StartedPostgreSqlContainer;
+  let postgresClient: Client;
+  let balRepository: Repository<BaseLocale>;
+  // VAR
+  const token = 'xxxx';
+  const createdAt = new Date('2000-01-01');
+  const updatedAt = new Date('2000-01-02');
+  // AXIOS
+  const axiosMock = new MockAdapter(axios);
+
+  beforeAll(async () => {
+    // INIT DB
+    postgresContainer = await new PostgreSqlContainer(
+      'postgis/postgis:12-3.0',
+    ).start();
+    postgresClient = new Client({
+      host: postgresContainer.getHost(),
+      port: postgresContainer.getPort(),
+      database: postgresContainer.getDatabase(),
+      user: postgresContainer.getUsername(),
+      password: postgresContainer.getPassword(),
+    });
+    await postgresClient.connect();
+    // INIT MODULE
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'postgres',
+          host: postgresContainer.getHost(),
+          port: postgresContainer.getPort(),
+          username: postgresContainer.getUsername(),
+          password: postgresContainer.getPassword(),
+          database: postgresContainer.getDatabase(),
+          synchronize: true,
+          entities: [BaseLocale, Voie, Numero, Toponyme, Position],
+        }),
+        BaseLocaleModule,
+        MailerModule,
+        SignalementModule,
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe());
+    await app.init();
+    // INIT REPOSITORY
+    balRepository = app.get(getRepositoryToken(BaseLocale));
+  });
+
+  afterAll(async () => {
+    await postgresClient.end();
+    await postgresContainer.stop();
+    await app.close();
+  });
+
+  afterEach(async () => {
+    axiosMock.reset();
+    await balRepository.delete({});
+  });
+
+  async function createBal(props: Partial<BaseLocale> = {}) {
+    const payload: Partial<BaseLocale> = {
+      banId: uuid(),
+      createdAt,
+      updatedAt,
+      status: props.status ?? StatusBaseLocalEnum.DRAFT,
+      token,
+      ...props,
+    };
+    const entityToInsert = balRepository.create(payload);
+    const result = await balRepository.save(entityToInsert);
+    return result.id;
+  }
+
+  describe('PUT /signalements/:baseLocaleId', () => {
+    it('should not update signalement if BAL is not published', async () => {
+      const balId = await createBal({ nom: 'bal', commune: '91400' });
+
+      const payload = {
+        ids: ['xxxx'],
+        status: Signalement.status.PROCESSED,
+      };
+
+      const response = await request(app.getHttpServer())
+        .put(`/signalements/${balId}`)
+        .send(payload)
+        .set('authorization', `Bearer ${token}`)
+        .expect(412);
+
+      expect(response.body.message).toBe('BaseLocale is not published');
+    });
+
+    it('should not update signalement if communes do not match', async () => {
+      const balId = await createBal({
+        nom: 'bal',
+        commune: '91400',
+        status: StatusBaseLocalEnum.PUBLISHED,
+      });
+
+      const payload = {
+        ids: ['xxxx'],
+        status: Signalement.status.PROCESSED,
+      };
+
+      const response = await request(app.getHttpServer())
+        .put(`/signalements/${balId}`)
+        .send(payload)
+        .set('authorization', `Bearer ${token}`)
+        .expect(412);
+
+      expect(response.body.message).toBe(
+        'Communes do not match for signalement xxxx',
+      );
+    });
+
+    it('should update signalement list', async () => {
+      const balId = await createBal({
+        nom: 'bal',
+        commune: '37003',
+        status: StatusBaseLocalEnum.PUBLISHED,
+      });
+
+      const payload = {
+        ids: ['xxxx', 'yyyy'],
+        status: Signalement.status.PROCESSED,
+      };
+
+      await request(app.getHttpServer())
+        .put(`/signalements/${balId}`)
+        .send(payload)
+        .set('authorization', `Bearer ${token}`)
+        .expect(200);
+    });
+  });
+});

--- a/libs/shared/src/openapi-signalement/core/ApiError.ts
+++ b/libs/shared/src/openapi-signalement/core/ApiError.ts
@@ -1,0 +1,25 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { ApiResult } from './ApiResult';
+
+export class ApiError extends Error {
+    public readonly url: string;
+    public readonly status: number;
+    public readonly statusText: string;
+    public readonly body: any;
+    public readonly request: ApiRequestOptions;
+
+    constructor(request: ApiRequestOptions, response: ApiResult, message: string) {
+        super(message);
+
+        this.name = 'ApiError';
+        this.url = response.url;
+        this.status = response.status;
+        this.statusText = response.statusText;
+        this.body = response.body;
+        this.request = request;
+    }
+}

--- a/libs/shared/src/openapi-signalement/core/ApiRequestOptions.ts
+++ b/libs/shared/src/openapi-signalement/core/ApiRequestOptions.ts
@@ -1,0 +1,17 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ApiRequestOptions = {
+    readonly method: 'GET' | 'PUT' | 'POST' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'PATCH';
+    readonly url: string;
+    readonly path?: Record<string, any>;
+    readonly cookies?: Record<string, any>;
+    readonly headers?: Record<string, any>;
+    readonly query?: Record<string, any>;
+    readonly formData?: Record<string, any>;
+    readonly body?: any;
+    readonly mediaType?: string;
+    readonly responseHeader?: string;
+    readonly errors?: Record<number, string>;
+};

--- a/libs/shared/src/openapi-signalement/core/ApiResult.ts
+++ b/libs/shared/src/openapi-signalement/core/ApiResult.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ApiResult = {
+    readonly url: string;
+    readonly ok: boolean;
+    readonly status: number;
+    readonly statusText: string;
+    readonly body: any;
+};

--- a/libs/shared/src/openapi-signalement/core/CancelablePromise.ts
+++ b/libs/shared/src/openapi-signalement/core/CancelablePromise.ts
@@ -1,0 +1,131 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export class CancelError extends Error {
+
+    constructor(message: string) {
+        super(message);
+        this.name = 'CancelError';
+    }
+
+    public get isCancelled(): boolean {
+        return true;
+    }
+}
+
+export interface OnCancel {
+    readonly isResolved: boolean;
+    readonly isRejected: boolean;
+    readonly isCancelled: boolean;
+
+    (cancelHandler: () => void): void;
+}
+
+export class CancelablePromise<T> implements Promise<T> {
+    #isResolved: boolean;
+    #isRejected: boolean;
+    #isCancelled: boolean;
+    readonly #cancelHandlers: (() => void)[];
+    readonly #promise: Promise<T>;
+    #resolve?: (value: T | PromiseLike<T>) => void;
+    #reject?: (reason?: any) => void;
+
+    constructor(
+        executor: (
+            resolve: (value: T | PromiseLike<T>) => void,
+            reject: (reason?: any) => void,
+            onCancel: OnCancel
+        ) => void
+    ) {
+        this.#isResolved = false;
+        this.#isRejected = false;
+        this.#isCancelled = false;
+        this.#cancelHandlers = [];
+        this.#promise = new Promise<T>((resolve, reject) => {
+            this.#resolve = resolve;
+            this.#reject = reject;
+
+            const onResolve = (value: T | PromiseLike<T>): void => {
+                if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+                    return;
+                }
+                this.#isResolved = true;
+                if (this.#resolve) this.#resolve(value);
+            };
+
+            const onReject = (reason?: any): void => {
+                if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+                    return;
+                }
+                this.#isRejected = true;
+                if (this.#reject) this.#reject(reason);
+            };
+
+            const onCancel = (cancelHandler: () => void): void => {
+                if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+                    return;
+                }
+                this.#cancelHandlers.push(cancelHandler);
+            };
+
+            Object.defineProperty(onCancel, 'isResolved', {
+                get: (): boolean => this.#isResolved,
+            });
+
+            Object.defineProperty(onCancel, 'isRejected', {
+                get: (): boolean => this.#isRejected,
+            });
+
+            Object.defineProperty(onCancel, 'isCancelled', {
+                get: (): boolean => this.#isCancelled,
+            });
+
+            return executor(onResolve, onReject, onCancel as OnCancel);
+        });
+    }
+
+    get [Symbol.toStringTag]() {
+        return "Cancellable Promise";
+    }
+
+    public then<TResult1 = T, TResult2 = never>(
+        onFulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
+        onRejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null
+    ): Promise<TResult1 | TResult2> {
+        return this.#promise.then(onFulfilled, onRejected);
+    }
+
+    public catch<TResult = never>(
+        onRejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null
+    ): Promise<T | TResult> {
+        return this.#promise.catch(onRejected);
+    }
+
+    public finally(onFinally?: (() => void) | null): Promise<T> {
+        return this.#promise.finally(onFinally);
+    }
+
+    public cancel(): void {
+        if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+            return;
+        }
+        this.#isCancelled = true;
+        if (this.#cancelHandlers.length) {
+            try {
+                for (const cancelHandler of this.#cancelHandlers) {
+                    cancelHandler();
+                }
+            } catch (error) {
+                console.warn('Cancellation threw an error', error);
+                return;
+            }
+        }
+        this.#cancelHandlers.length = 0;
+        if (this.#reject) this.#reject(new CancelError('Request aborted'));
+    }
+
+    public get isCancelled(): boolean {
+        return this.#isCancelled;
+    }
+}

--- a/libs/shared/src/openapi-signalement/core/OpenAPI.ts
+++ b/libs/shared/src/openapi-signalement/core/OpenAPI.ts
@@ -1,0 +1,32 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ApiRequestOptions } from './ApiRequestOptions';
+
+type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
+type Headers = Record<string, string>;
+
+export type OpenAPIConfig = {
+    BASE: string;
+    VERSION: string;
+    WITH_CREDENTIALS: boolean;
+    CREDENTIALS: 'include' | 'omit' | 'same-origin';
+    TOKEN?: string | Resolver<string> | undefined;
+    USERNAME?: string | Resolver<string> | undefined;
+    PASSWORD?: string | Resolver<string> | undefined;
+    HEADERS?: Headers | Resolver<Headers> | undefined;
+    ENCODE_PATH?: ((path: string) => string) | undefined;
+};
+
+export const OpenAPI: OpenAPIConfig = {
+    BASE: '',
+    VERSION: '1.0',
+    WITH_CREDENTIALS: false,
+    CREDENTIALS: 'include',
+    TOKEN: undefined,
+    USERNAME: undefined,
+    PASSWORD: undefined,
+    HEADERS: undefined,
+    ENCODE_PATH: undefined,
+};

--- a/libs/shared/src/openapi-signalement/core/request.ts
+++ b/libs/shared/src/openapi-signalement/core/request.ts
@@ -1,0 +1,322 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import { ApiError } from './ApiError';
+import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { ApiResult } from './ApiResult';
+import { CancelablePromise } from './CancelablePromise';
+import type { OnCancel } from './CancelablePromise';
+import type { OpenAPIConfig } from './OpenAPI';
+
+export const isDefined = <T>(value: T | null | undefined): value is Exclude<T, null | undefined> => {
+    return value !== undefined && value !== null;
+};
+
+export const isString = (value: any): value is string => {
+    return typeof value === 'string';
+};
+
+export const isStringWithValue = (value: any): value is string => {
+    return isString(value) && value !== '';
+};
+
+export const isBlob = (value: any): value is Blob => {
+    return (
+        typeof value === 'object' &&
+        typeof value.type === 'string' &&
+        typeof value.stream === 'function' &&
+        typeof value.arrayBuffer === 'function' &&
+        typeof value.constructor === 'function' &&
+        typeof value.constructor.name === 'string' &&
+        /^(Blob|File)$/.test(value.constructor.name) &&
+        /^(Blob|File)$/.test(value[Symbol.toStringTag])
+    );
+};
+
+export const isFormData = (value: any): value is FormData => {
+    return value instanceof FormData;
+};
+
+export const base64 = (str: string): string => {
+    try {
+        return btoa(str);
+    } catch (err) {
+        // @ts-ignore
+        return Buffer.from(str).toString('base64');
+    }
+};
+
+export const getQueryString = (params: Record<string, any>): string => {
+    const qs: string[] = [];
+
+    const append = (key: string, value: any) => {
+        qs.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
+    };
+
+    const process = (key: string, value: any) => {
+        if (isDefined(value)) {
+            if (Array.isArray(value)) {
+                value.forEach(v => {
+                    process(key, v);
+                });
+            } else if (typeof value === 'object') {
+                Object.entries(value).forEach(([k, v]) => {
+                    process(`${key}[${k}]`, v);
+                });
+            } else {
+                append(key, value);
+            }
+        }
+    };
+
+    Object.entries(params).forEach(([key, value]) => {
+        process(key, value);
+    });
+
+    if (qs.length > 0) {
+        return `?${qs.join('&')}`;
+    }
+
+    return '';
+};
+
+const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {
+    const encoder = config.ENCODE_PATH || encodeURI;
+
+    const path = options.url
+        .replace('{api-version}', config.VERSION)
+        .replace(/{(.*?)}/g, (substring: string, group: string) => {
+            if (options.path?.hasOwnProperty(group)) {
+                return encoder(String(options.path[group]));
+            }
+            return substring;
+        });
+
+    const url = `${config.BASE}${path}`;
+    if (options.query) {
+        return `${url}${getQueryString(options.query)}`;
+    }
+    return url;
+};
+
+export const getFormData = (options: ApiRequestOptions): FormData | undefined => {
+    if (options.formData) {
+        const formData = new FormData();
+
+        const process = (key: string, value: any) => {
+            if (isString(value) || isBlob(value)) {
+                formData.append(key, value);
+            } else {
+                formData.append(key, JSON.stringify(value));
+            }
+        };
+
+        Object.entries(options.formData)
+            .filter(([_, value]) => isDefined(value))
+            .forEach(([key, value]) => {
+                if (Array.isArray(value)) {
+                    value.forEach(v => process(key, v));
+                } else {
+                    process(key, value);
+                }
+            });
+
+        return formData;
+    }
+    return undefined;
+};
+
+type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
+
+export const resolve = async <T>(options: ApiRequestOptions, resolver?: T | Resolver<T>): Promise<T | undefined> => {
+    if (typeof resolver === 'function') {
+        return (resolver as Resolver<T>)(options);
+    }
+    return resolver;
+};
+
+export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
+    const [token, username, password, additionalHeaders] = await Promise.all([
+        resolve(options, config.TOKEN),
+        resolve(options, config.USERNAME),
+        resolve(options, config.PASSWORD),
+        resolve(options, config.HEADERS),
+    ]);
+
+    const headers = Object.entries({
+        Accept: 'application/json',
+        ...additionalHeaders,
+        ...options.headers,
+    })
+        .filter(([_, value]) => isDefined(value))
+        .reduce((headers, [key, value]) => ({
+            ...headers,
+            [key]: String(value),
+        }), {} as Record<string, string>);
+
+    if (isStringWithValue(token)) {
+        headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (isStringWithValue(username) && isStringWithValue(password)) {
+        const credentials = base64(`${username}:${password}`);
+        headers['Authorization'] = `Basic ${credentials}`;
+    }
+
+    if (options.body !== undefined) {
+        if (options.mediaType) {
+            headers['Content-Type'] = options.mediaType;
+        } else if (isBlob(options.body)) {
+            headers['Content-Type'] = options.body.type || 'application/octet-stream';
+        } else if (isString(options.body)) {
+            headers['Content-Type'] = 'text/plain';
+        } else if (!isFormData(options.body)) {
+            headers['Content-Type'] = 'application/json';
+        }
+    }
+
+    return new Headers(headers);
+};
+
+export const getRequestBody = (options: ApiRequestOptions): any => {
+    if (options.body !== undefined) {
+        if (options.mediaType?.includes('/json')) {
+            return JSON.stringify(options.body)
+        } else if (isString(options.body) || isBlob(options.body) || isFormData(options.body)) {
+            return options.body;
+        } else {
+            return JSON.stringify(options.body);
+        }
+    }
+    return undefined;
+};
+
+export const sendRequest = async (
+    config: OpenAPIConfig,
+    options: ApiRequestOptions,
+    url: string,
+    body: any,
+    formData: FormData | undefined,
+    headers: Headers,
+    onCancel: OnCancel
+): Promise<Response> => {
+    const controller = new AbortController();
+
+    const request: RequestInit = {
+        headers,
+        body: body ?? formData,
+        method: options.method,
+        signal: controller.signal,
+    };
+
+    if (config.WITH_CREDENTIALS) {
+        request.credentials = config.CREDENTIALS;
+    }
+
+    onCancel(() => controller.abort());
+
+    return await fetch(url, request);
+};
+
+export const getResponseHeader = (response: Response, responseHeader?: string): string | undefined => {
+    if (responseHeader) {
+        const content = response.headers.get(responseHeader);
+        if (isString(content)) {
+            return content;
+        }
+    }
+    return undefined;
+};
+
+export const getResponseBody = async (response: Response): Promise<any> => {
+    if (response.status !== 204) {
+        try {
+            const contentType = response.headers.get('Content-Type');
+            if (contentType) {
+                const jsonTypes = ['application/json', 'application/problem+json']
+                const isJSON = jsonTypes.some(type => contentType.toLowerCase().startsWith(type));
+                if (isJSON) {
+                    return await response.json();
+                } else {
+                    return await response.text();
+                }
+            }
+        } catch (error) {
+            console.error(error);
+        }
+    }
+    return undefined;
+};
+
+export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void => {
+    const errors: Record<number, string> = {
+        400: 'Bad Request',
+        401: 'Unauthorized',
+        403: 'Forbidden',
+        404: 'Not Found',
+        500: 'Internal Server Error',
+        502: 'Bad Gateway',
+        503: 'Service Unavailable',
+        ...options.errors,
+    }
+
+    const error = errors[result.status];
+    if (error) {
+        throw new ApiError(options, result, error);
+    }
+
+    if (!result.ok) {
+        const errorStatus = result.status ?? 'unknown';
+        const errorStatusText = result.statusText ?? 'unknown';
+        const errorBody = (() => {
+            try {
+                return JSON.stringify(result.body, null, 2);
+            } catch (e) {
+                return undefined;
+            }
+        })();
+
+        throw new ApiError(options, result,
+            `Generic Error: status: ${errorStatus}; status text: ${errorStatusText}; body: ${errorBody}`
+        );
+    }
+};
+
+/**
+ * Request method
+ * @param config The OpenAPI configuration object
+ * @param options The request options from the service
+ * @returns CancelablePromise<T>
+ * @throws ApiError
+ */
+export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
+    return new CancelablePromise(async (resolve, reject, onCancel) => {
+        try {
+            const url = getUrl(config, options);
+            const formData = getFormData(options);
+            const body = getRequestBody(options);
+            const headers = await getHeaders(config, options);
+
+            if (!onCancel.isCancelled) {
+                const response = await sendRequest(config, options, url, body, formData, headers, onCancel);
+                const responseBody = await getResponseBody(response);
+                const responseHeader = getResponseHeader(response, options.responseHeader);
+
+                const result: ApiResult = {
+                    url,
+                    ok: response.ok,
+                    status: response.status,
+                    statusText: response.statusText,
+                    body: responseHeader ?? responseBody,
+                };
+
+                catchErrorCodes(options, result);
+
+                resolve(result.body);
+            }
+        } catch (error) {
+            reject(error);
+        }
+    });
+};

--- a/libs/shared/src/openapi-signalement/index.ts
+++ b/libs/shared/src/openapi-signalement/index.ts
@@ -1,0 +1,37 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export { ApiError } from './core/ApiError';
+export { CancelablePromise, CancelError } from './core/CancelablePromise';
+export { OpenAPI } from './core/OpenAPI';
+export type { OpenAPIConfig } from './core/OpenAPI';
+
+export type { Author } from './models/Author';
+export type { AuthorInput } from './models/AuthorInput';
+export type { Client } from './models/Client';
+export type { CreateClientDTO } from './models/CreateClientDTO';
+export { CreateSignalementDTO } from './models/CreateSignalementDTO';
+export { CreateSourceDTO } from './models/CreateSourceDTO';
+export type { DeleteNumeroChangesRequestedDTO } from './models/DeleteNumeroChangesRequestedDTO';
+export { ExistingLocation } from './models/ExistingLocation';
+export { ExistingNumero } from './models/ExistingNumero';
+export { ExistingToponyme } from './models/ExistingToponyme';
+export { ExistingVoie } from './models/ExistingVoie';
+export type { NumeroChangesRequestedDTO } from './models/NumeroChangesRequestedDTO';
+export type { PaginatedSignalementsDTO } from './models/PaginatedSignalementsDTO';
+export type { Point } from './models/Point';
+export { Position } from './models/Position';
+export type { PositionCoordinatesDTO } from './models/PositionCoordinatesDTO';
+export { PositionDTO } from './models/PositionDTO';
+export { Signalement } from './models/Signalement';
+export type { SignalementStatsDTO } from './models/SignalementStatsDTO';
+export { Source } from './models/Source';
+export type { ToponymeChangesRequestedDTO } from './models/ToponymeChangesRequestedDTO';
+export { UpdateSignalementDTO } from './models/UpdateSignalementDTO';
+export type { VoieChangesRequestedDTO } from './models/VoieChangesRequestedDTO';
+
+export { ClientsService } from './services/ClientsService';
+export { SignalementsService } from './services/SignalementsService';
+export { SourcesService } from './services/SourcesService';
+export { StatsService } from './services/StatsService';

--- a/libs/shared/src/openapi-signalement/models/Author.ts
+++ b/libs/shared/src/openapi-signalement/models/Author.ts
@@ -3,6 +3,8 @@
 /* tslint:disable */
 /* eslint-disable */
 export type Author = {
+    firstName?: string | null;
+    lastName?: string | null;
     email?: string | null;
 };
 

--- a/libs/shared/src/openapi-signalement/models/Author.ts
+++ b/libs/shared/src/openapi-signalement/models/Author.ts
@@ -1,0 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type Author = {
+    email?: string | null;
+};
+

--- a/libs/shared/src/openapi-signalement/models/AuthorInput.ts
+++ b/libs/shared/src/openapi-signalement/models/AuthorInput.ts
@@ -3,6 +3,8 @@
 /* tslint:disable */
 /* eslint-disable */
 export type AuthorInput = {
+    firstName?: string | null;
+    lastName?: string | null;
     email?: string | null;
 };
 

--- a/libs/shared/src/openapi-signalement/models/AuthorInput.ts
+++ b/libs/shared/src/openapi-signalement/models/AuthorInput.ts
@@ -1,0 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type AuthorInput = {
+    email?: string | null;
+};
+

--- a/libs/shared/src/openapi-signalement/models/Client.ts
+++ b/libs/shared/src/openapi-signalement/models/Client.ts
@@ -1,0 +1,13 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type Client = {
+    id: string;
+    createdAt: string;
+    updatedAt: string;
+    deletedAt?: string | null;
+    nom: string;
+    processedSignalements?: Array<string> | null;
+};
+

--- a/libs/shared/src/openapi-signalement/models/CreateClientDTO.ts
+++ b/libs/shared/src/openapi-signalement/models/CreateClientDTO.ts
@@ -1,0 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type CreateClientDTO = {
+    nom: string;
+};
+

--- a/libs/shared/src/openapi-signalement/models/CreateSignalementDTO.ts
+++ b/libs/shared/src/openapi-signalement/models/CreateSignalementDTO.ts
@@ -1,0 +1,27 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { AuthorInput } from './AuthorInput';
+import type { DeleteNumeroChangesRequestedDTO } from './DeleteNumeroChangesRequestedDTO';
+import type { ExistingNumero } from './ExistingNumero';
+import type { ExistingToponyme } from './ExistingToponyme';
+import type { ExistingVoie } from './ExistingVoie';
+import type { NumeroChangesRequestedDTO } from './NumeroChangesRequestedDTO';
+import type { ToponymeChangesRequestedDTO } from './ToponymeChangesRequestedDTO';
+import type { VoieChangesRequestedDTO } from './VoieChangesRequestedDTO';
+export type CreateSignalementDTO = {
+    codeCommune: string;
+    type: CreateSignalementDTO.type;
+    author?: AuthorInput | null;
+    existingLocation?: (ExistingNumero | ExistingVoie | ExistingToponyme) | null;
+    changesRequested: (NumeroChangesRequestedDTO | DeleteNumeroChangesRequestedDTO | ToponymeChangesRequestedDTO | VoieChangesRequestedDTO) | null;
+};
+export namespace CreateSignalementDTO {
+    export enum type {
+        LOCATION_TO_UPDATE = 'LOCATION_TO_UPDATE',
+        LOCATION_TO_DELETE = 'LOCATION_TO_DELETE',
+        LOCATION_TO_CREATE = 'LOCATION_TO_CREATE',
+    }
+}
+

--- a/libs/shared/src/openapi-signalement/models/CreateSourceDTO.ts
+++ b/libs/shared/src/openapi-signalement/models/CreateSourceDTO.ts
@@ -1,0 +1,15 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type CreateSourceDTO = {
+    nom: string;
+    type: CreateSourceDTO.type;
+};
+export namespace CreateSourceDTO {
+    export enum type {
+        PUBLIC = 'PUBLIC',
+        PRIVATE = 'PRIVATE',
+    }
+}
+

--- a/libs/shared/src/openapi-signalement/models/DeleteNumeroChangesRequestedDTO.ts
+++ b/libs/shared/src/openapi-signalement/models/DeleteNumeroChangesRequestedDTO.ts
@@ -1,0 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type DeleteNumeroChangesRequestedDTO = {
+    comment: string;
+};
+

--- a/libs/shared/src/openapi-signalement/models/ExistingLocation.ts
+++ b/libs/shared/src/openapi-signalement/models/ExistingLocation.ts
@@ -1,0 +1,16 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ExistingLocation = {
+    type: ExistingLocation.type;
+    banId?: string | null;
+};
+export namespace ExistingLocation {
+    export enum type {
+        NUMERO = 'NUMERO',
+        VOIE = 'VOIE',
+        TOPONYME = 'TOPONYME',
+    }
+}
+

--- a/libs/shared/src/openapi-signalement/models/ExistingNumero.ts
+++ b/libs/shared/src/openapi-signalement/models/ExistingNumero.ts
@@ -1,0 +1,25 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ExistingToponyme } from './ExistingToponyme';
+import type { ExistingVoie } from './ExistingVoie';
+import type { Position } from './Position';
+export type ExistingNumero = {
+    type: ExistingNumero.type;
+    banId?: string | null;
+    numero: number;
+    suffixe: string;
+    position: Position;
+    parcelles?: Array<string> | null;
+    toponyme: (ExistingVoie | ExistingToponyme);
+    nomComplement?: string;
+};
+export namespace ExistingNumero {
+    export enum type {
+        NUMERO = 'NUMERO',
+        VOIE = 'VOIE',
+        TOPONYME = 'TOPONYME',
+    }
+}
+

--- a/libs/shared/src/openapi-signalement/models/ExistingToponyme.ts
+++ b/libs/shared/src/openapi-signalement/models/ExistingToponyme.ts
@@ -1,0 +1,20 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { Position } from './Position';
+export type ExistingToponyme = {
+    type: ExistingToponyme.type;
+    banId?: string | null;
+    nom: string;
+    position: Position;
+    parcelles?: Array<string> | null;
+};
+export namespace ExistingToponyme {
+    export enum type {
+        NUMERO = 'NUMERO',
+        VOIE = 'VOIE',
+        TOPONYME = 'TOPONYME',
+    }
+}
+

--- a/libs/shared/src/openapi-signalement/models/ExistingVoie.ts
+++ b/libs/shared/src/openapi-signalement/models/ExistingVoie.ts
@@ -1,0 +1,17 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ExistingVoie = {
+    type: ExistingVoie.type;
+    banId?: string | null;
+    nom: string;
+};
+export namespace ExistingVoie {
+    export enum type {
+        NUMERO = 'NUMERO',
+        VOIE = 'VOIE',
+        TOPONYME = 'TOPONYME',
+    }
+}
+

--- a/libs/shared/src/openapi-signalement/models/NumeroChangesRequestedDTO.ts
+++ b/libs/shared/src/openapi-signalement/models/NumeroChangesRequestedDTO.ts
@@ -1,0 +1,15 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { PositionDTO } from './PositionDTO';
+export type NumeroChangesRequestedDTO = {
+    numero: number;
+    suffixe?: string;
+    nomVoie: string;
+    nomComplement?: string;
+    parcelles: Array<string>;
+    positions: Array<PositionDTO>;
+    comment?: string | null;
+};
+

--- a/libs/shared/src/openapi-signalement/models/PaginatedSignalementsDTO.ts
+++ b/libs/shared/src/openapi-signalement/models/PaginatedSignalementsDTO.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type PaginatedSignalementsDTO = {
+    data: Array<any[]>;
+    page: number;
+    limit: number;
+    total: number;
+};
+

--- a/libs/shared/src/openapi-signalement/models/Point.ts
+++ b/libs/shared/src/openapi-signalement/models/Point.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type Point = {
+    type: string;
+    coordinates: Array<number>;
+};
+

--- a/libs/shared/src/openapi-signalement/models/Position.ts
+++ b/libs/shared/src/openapi-signalement/models/Position.ts
@@ -1,0 +1,22 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { Point } from './Point';
+export type Position = {
+    point: Point;
+    type: Position.type;
+};
+export namespace Position {
+    export enum type {
+        ENTR_E = 'entrée',
+        B_TIMENT = 'bâtiment',
+        CAGE_D_ESCALIER = 'cage d’escalier',
+        LOGEMENT = 'logement',
+        SERVICE_TECHNIQUE = 'service technique',
+        D_LIVRANCE_POSTALE = 'délivrance postale',
+        PARCELLE = 'parcelle',
+        SEGMENT = 'segment',
+    }
+}
+

--- a/libs/shared/src/openapi-signalement/models/PositionCoordinatesDTO.ts
+++ b/libs/shared/src/openapi-signalement/models/PositionCoordinatesDTO.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type PositionCoordinatesDTO = {
+    coordinates: Array<number>;
+    type: string;
+};
+

--- a/libs/shared/src/openapi-signalement/models/PositionDTO.ts
+++ b/libs/shared/src/openapi-signalement/models/PositionDTO.ts
@@ -1,0 +1,22 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { PositionCoordinatesDTO } from './PositionCoordinatesDTO';
+export type PositionDTO = {
+    point: PositionCoordinatesDTO;
+    type: PositionDTO.type;
+};
+export namespace PositionDTO {
+    export enum type {
+        ENTR_E = 'entrée',
+        B_TIMENT = 'bâtiment',
+        CAGE_D_ESCALIER = 'cage d’escalier',
+        LOGEMENT = 'logement',
+        SERVICE_TECHNIQUE = 'service technique',
+        D_LIVRANCE_POSTALE = 'délivrance postale',
+        PARCELLE = 'parcelle',
+        SEGMENT = 'segment',
+    }
+}
+

--- a/libs/shared/src/openapi-signalement/models/Signalement.ts
+++ b/libs/shared/src/openapi-signalement/models/Signalement.ts
@@ -1,0 +1,42 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { Author } from './Author';
+import type { Client } from './Client';
+import type { DeleteNumeroChangesRequestedDTO } from './DeleteNumeroChangesRequestedDTO';
+import type { ExistingNumero } from './ExistingNumero';
+import type { ExistingToponyme } from './ExistingToponyme';
+import type { ExistingVoie } from './ExistingVoie';
+import type { NumeroChangesRequestedDTO } from './NumeroChangesRequestedDTO';
+import type { Source } from './Source';
+import type { ToponymeChangesRequestedDTO } from './ToponymeChangesRequestedDTO';
+import type { VoieChangesRequestedDTO } from './VoieChangesRequestedDTO';
+export type Signalement = {
+    id: string;
+    createdAt: string;
+    updatedAt: string;
+    deletedAt?: string | null;
+    codeCommune: string;
+    type: Signalement.type;
+    author?: Author | null;
+    existingLocation?: (ExistingNumero | ExistingVoie | ExistingToponyme) | null;
+    changesRequested: (NumeroChangesRequestedDTO | DeleteNumeroChangesRequestedDTO | ToponymeChangesRequestedDTO | VoieChangesRequestedDTO);
+    status?: Signalement.status | null;
+    source: Source;
+    processedBy?: Client | null;
+};
+export namespace Signalement {
+    export enum type {
+        LOCATION_TO_UPDATE = 'LOCATION_TO_UPDATE',
+        LOCATION_TO_DELETE = 'LOCATION_TO_DELETE',
+        LOCATION_TO_CREATE = 'LOCATION_TO_CREATE',
+    }
+    export enum status {
+        PENDING = 'PENDING',
+        IGNORED = 'IGNORED',
+        PROCESSED = 'PROCESSED',
+        EXPIRED = 'EXPIRED',
+    }
+}
+

--- a/libs/shared/src/openapi-signalement/models/SignalementStatsDTO.ts
+++ b/libs/shared/src/openapi-signalement/models/SignalementStatsDTO.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type SignalementStatsDTO = {
+    total: number;
+    fromSources: Record<string, any>;
+    processedBy: Record<string, any>;
+};
+

--- a/libs/shared/src/openapi-signalement/models/Source.ts
+++ b/libs/shared/src/openapi-signalement/models/Source.ts
@@ -1,0 +1,20 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type Source = {
+    id: string;
+    createdAt: string;
+    updatedAt: string;
+    deletedAt?: string | null;
+    nom: string;
+    type: Source.type;
+    signalements?: Array<string> | null;
+};
+export namespace Source {
+    export enum type {
+        PUBLIC = 'PUBLIC',
+        PRIVATE = 'PRIVATE',
+    }
+}
+

--- a/libs/shared/src/openapi-signalement/models/ToponymeChangesRequestedDTO.ts
+++ b/libs/shared/src/openapi-signalement/models/ToponymeChangesRequestedDTO.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { PositionDTO } from './PositionDTO';
+export type ToponymeChangesRequestedDTO = {
+    nom: string;
+    parcelles: Array<string>;
+    positions: Array<PositionDTO>;
+    comment?: string | null;
+};
+

--- a/libs/shared/src/openapi-signalement/models/UpdateSignalementDTO.ts
+++ b/libs/shared/src/openapi-signalement/models/UpdateSignalementDTO.ts
@@ -1,0 +1,16 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type UpdateSignalementDTO = {
+    status: UpdateSignalementDTO.status;
+};
+export namespace UpdateSignalementDTO {
+    export enum status {
+        PENDING = 'PENDING',
+        IGNORED = 'IGNORED',
+        PROCESSED = 'PROCESSED',
+        EXPIRED = 'EXPIRED',
+    }
+}
+

--- a/libs/shared/src/openapi-signalement/models/VoieChangesRequestedDTO.ts
+++ b/libs/shared/src/openapi-signalement/models/VoieChangesRequestedDTO.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type VoieChangesRequestedDTO = {
+    nom: string;
+    comment?: string | null;
+};
+

--- a/libs/shared/src/openapi-signalement/services/ClientsService.ts
+++ b/libs/shared/src/openapi-signalement/services/ClientsService.ts
@@ -1,0 +1,27 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { Client } from '../models/Client';
+import type { CreateClientDTO } from '../models/CreateClientDTO';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class ClientsService {
+    /**
+     * Create a new Client
+     * @param requestBody
+     * @returns Client
+     * @throws ApiError
+     */
+    public static createClient(
+        requestBody: CreateClientDTO,
+    ): CancelablePromise<Client> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/clients',
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+}

--- a/libs/shared/src/openapi-signalement/services/SignalementsService.ts
+++ b/libs/shared/src/openapi-signalement/services/SignalementsService.ts
@@ -65,6 +65,7 @@ export class SignalementsService {
     }
     /**
      * Get signalement by id
+     * Get a signalement by its id, returns author info if client is authenticated
      * @param idSignalement
      * @returns Signalement
      * @throws ApiError

--- a/libs/shared/src/openapi-signalement/services/SignalementsService.ts
+++ b/libs/shared/src/openapi-signalement/services/SignalementsService.ts
@@ -1,0 +1,104 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { CreateSignalementDTO } from '../models/CreateSignalementDTO';
+import type { PaginatedSignalementsDTO } from '../models/PaginatedSignalementsDTO';
+import type { Signalement } from '../models/Signalement';
+import type { UpdateSignalementDTO } from '../models/UpdateSignalementDTO';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class SignalementsService {
+    /**
+     * Get signalements
+     * @param limit
+     * @param page
+     * @param status
+     * @param types
+     * @param sourceIds
+     * @param codeCommunes
+     * @returns PaginatedSignalementsDTO
+     * @throws ApiError
+     */
+    public static getSignalements(
+        limit?: number,
+        page?: number,
+        status?: Array<'PENDING' | 'IGNORED' | 'PROCESSED' | 'EXPIRED'>,
+        types?: Array<'LOCATION_TO_UPDATE' | 'LOCATION_TO_DELETE' | 'LOCATION_TO_CREATE'>,
+        sourceIds?: Array<string>,
+        codeCommunes?: Array<string>,
+    ): CancelablePromise<PaginatedSignalementsDTO> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/signalements',
+            query: {
+                'limit': limit,
+                'page': page,
+                'status': status,
+                'types': types,
+                'sourceIds': sourceIds,
+                'codeCommunes': codeCommunes,
+            },
+        });
+    }
+    /**
+     * Create a new signalement
+     * @param requestBody
+     * @param sourceId
+     * @returns Signalement
+     * @throws ApiError
+     */
+    public static createSignalement(
+        requestBody: CreateSignalementDTO,
+        sourceId?: string,
+    ): CancelablePromise<Signalement> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/signalements',
+            query: {
+                'sourceId': sourceId,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+    /**
+     * Get signalement by id
+     * @param idSignalement
+     * @returns Signalement
+     * @throws ApiError
+     */
+    public static getSignalementById(
+        idSignalement: string,
+    ): CancelablePromise<Signalement> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/signalements/{idSignalement}',
+            path: {
+                'idSignalement': idSignalement,
+            },
+        });
+    }
+    /**
+     * Update a given signalement
+     * @param idSignalement
+     * @param requestBody
+     * @returns Signalement
+     * @throws ApiError
+     */
+    public static updateSignalement(
+        idSignalement: string,
+        requestBody: UpdateSignalementDTO,
+    ): CancelablePromise<Signalement> {
+        return __request(OpenAPI, {
+            method: 'PUT',
+            url: '/signalements/{idSignalement}',
+            path: {
+                'idSignalement': idSignalement,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+}

--- a/libs/shared/src/openapi-signalement/services/SourcesService.ts
+++ b/libs/shared/src/openapi-signalement/services/SourcesService.ts
@@ -1,0 +1,78 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { CreateSourceDTO } from '../models/CreateSourceDTO';
+import type { Source } from '../models/Source';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class SourcesService {
+    /**
+     * Get all sources
+     * @param type
+     * @returns any[]
+     * @throws ApiError
+     */
+    public static getSources(
+        type?: 'PUBLIC' | 'PRIVATE',
+    ): CancelablePromise<any[]> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/sources',
+            query: {
+                'type': type,
+            },
+        });
+    }
+    /**
+     * Create a new source
+     * @param requestBody
+     * @returns Source
+     * @throws ApiError
+     */
+    public static createSource(
+        requestBody: CreateSourceDTO,
+    ): CancelablePromise<Source> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/sources',
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+    /**
+     * Get source by id
+     * @param idSource
+     * @returns Source
+     * @throws ApiError
+     */
+    public static getSourceById(
+        idSource: string,
+    ): CancelablePromise<Source> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/sources/{idSource}',
+            path: {
+                'idSource': idSource,
+            },
+        });
+    }
+    /**
+     * Get source by token
+     * @param token
+     * @returns Source
+     * @throws ApiError
+     */
+    public static getSourceByToken(
+        token: string,
+    ): CancelablePromise<Source> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/sources/token/{token}',
+            path: {
+                'token': token,
+            },
+        });
+    }
+}

--- a/libs/shared/src/openapi-signalement/services/StatsService.ts
+++ b/libs/shared/src/openapi-signalement/services/StatsService.ts
@@ -1,0 +1,21 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { SignalementStatsDTO } from '../models/SignalementStatsDTO';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class StatsService {
+    /**
+     * Get stats
+     * @returns SignalementStatsDTO
+     * @throws ApiError
+     */
+    public static getStats(): CancelablePromise<SignalementStatsDTO> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/stats',
+        });
+    }
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "push-staging": "./scripts/push-staging.sh",
     "typeorm": "typeorm-ts-node-commonjs",
     "typeorm:migration:run": "yarn typeorm migration:run -- -d ./typeorm.config.ts",
-    "typeorm:migration:down": "yarn typeorm migration:revert -- -d ./typeorm.config.ts"
+    "typeorm:migration:down": "yarn typeorm migration:revert -- -d ./typeorm.config.ts",
+    "generate:openapi:signalement": "openapi --input http://localhost:5005/api-json --output ./libs/shared/src/openapi-signalement"
   },
   "dependencies": {
     "@ban-team/adresses-util": "^0.9.0",
@@ -106,6 +107,7 @@
     "jest": "^29.5.0",
     "nock": "^13.3.3",
     "nyc": "^15.1.0",
+    "openapi-typescript-codegen": "^0.29.0",
     "prettier": "^3.0.0",
     "source-map-support": "^0.5.21",
     "supertest": "^6.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -72,6 +72,15 @@
     ora "5.4.1"
     rxjs "7.8.1"
 
+"@apidevtools/json-schema-ref-parser@^11.5.4":
+  version "11.7.2"
+  resolved "https://registry.yarnpkg.com/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.7.2.tgz#cdf3e0aded21492364a70e193b45b7cf4177f031"
+  integrity sha512-4gY54eEGEstClvEkGnwVkTkrx0sqwemEFG5OSRRn3tD91XH0+Q8XIkYIfo7IwEWPpJZwILb9GUXeShtplRc/eA==
+  dependencies:
+    "@jsdevtools/ono" "^7.1.3"
+    "@types/json-schema" "^7.0.15"
+    js-yaml "^4.1.0"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.7", "@babel/code-frame@^7.22.13":
   version "7.22.13"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.13.tgz#e3c1c099402598483b7a8c46a721d1038803755e"
@@ -905,6 +914,11 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@jsdevtools/ono@^7.1.3":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
+  integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
 "@lukeed/csprng@^1.0.0":
   version "1.1.0"
@@ -2553,6 +2567,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.13.tgz#02c24f4363176d2d18fc8b70b9f3c54aba178a85"
   integrity sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==
 
+"@types/json-schema@^7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
+  integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
+
 "@types/keyv@^3.1.4":
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/@types/keyv/-/keyv-3.1.4.tgz#3ccdb1c6751b0c7e52300bcdacd5bcbf8faa75b6"
@@ -3727,7 +3746,7 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-camelcase@^6.2.0:
+camelcase@^6.2.0, camelcase@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
@@ -4090,6 +4109,11 @@ commander@^10.0.0:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
   integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
+
+commander@^12.0.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-12.1.0.tgz#01423b36f501259fdaac4d0e4d60c96c991585d3"
+  integrity sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==
 
 commander@^6.1.0:
   version "6.2.1"
@@ -5447,6 +5471,15 @@ fs-extra@^10.0.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
   integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
+fs-extra@^11.2.0:
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.2.0.tgz#e70e17dfad64232287d01929399e0ea7c86b0e5b"
+  integrity sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==
   dependencies:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
@@ -8057,6 +8090,17 @@ open@^9.1.0:
     define-lazy-prop "^3.0.0"
     is-inside-container "^1.0.0"
     is-wsl "^2.2.0"
+
+openapi-typescript-codegen@^0.29.0:
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/openapi-typescript-codegen/-/openapi-typescript-codegen-0.29.0.tgz#e98a1daa223ccdeb1cc51b2e2dc11bafae6fe746"
+  integrity sha512-/wC42PkD0LGjDTEULa/XiWQbv4E9NwLjwLjsaJ/62yOsoYhwvmBR31kPttn1DzQ2OlGe5stACcF/EIkZk43M6w==
+  dependencies:
+    "@apidevtools/json-schema-ref-parser" "^11.5.4"
+    camelcase "^6.3.0"
+    commander "^12.0.0"
+    fs-extra "^11.2.0"
+    handlebars "^4.7.8"
 
 optionator@^0.9.3:
   version "0.9.3"


### PR DESCRIPTION
Ce module permet de mettre à jour les signalements depuis mes-adresses.
Lors d'une MAJ, on vérifie que la BAL demandeuse est bien publiée et que les codes communes des signalements qu'elle veut mettre à jour correspondent à celui de la BAL.
