### PR TITLE
feat: delete position inconnue

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,1 @@
 clock: yarn start:cron
-postdeploy: yarn typeorm:migration:run

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 clock: yarn start:cron
+postdeploy: bash bin/postdeploy.sh

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 clock: yarn start:cron
-postdeploy: bash bin/postdeploy.sh
+postdeploy: bash scripts/postdeploy.sh

--- a/apps/api/src/lib/utils/csv.utils.ts
+++ b/apps/api/src/lib/utils/csv.utils.ts
@@ -56,7 +56,7 @@ export function extractCodeCommune({
 function extractPosition(row: any) {
   return {
     source: row.parsedValues.source || null,
-    type: row.parsedValues.position || PositionTypeEnum.INCONNUE,
+    type: row.parsedValues.position || PositionTypeEnum.ENTREE,
     point: {
       type: 'Point',
       coordinates: [row.parsedValues.long, row.parsedValues.lat],

--- a/apps/api/src/modules/numeros/dto/update_batch_numero_change.dto.ts
+++ b/apps/api/src/modules/numeros/dto/update_batch_numero_change.dto.ts
@@ -6,9 +6,11 @@ import {
   IsNotEmpty,
   IsMongoId,
   ValidateIf,
+  Validate,
 } from 'class-validator';
 
 import { PositionTypeEnum } from '@/shared/entities/position.entity';
+import { ValidatorBal } from '@/shared/validators/validator_bal.validator';
 
 export class UpdateBatchNumeroChangeDTO {
   @IsOptional()
@@ -31,6 +33,7 @@ export class UpdateBatchNumeroChangeDTO {
   @IsOptional()
   @IsNotEmpty()
   @IsEnum(PositionTypeEnum)
+  @Validate(ValidatorBal, ['position'])
   @ApiProperty({ required: false, nullable: false })
   positionType?: PositionTypeEnum;
 

--- a/apps/api/test/base_locale.e2e-spec.ts
+++ b/apps/api/test/base_locale.e2e-spec.ts
@@ -186,7 +186,7 @@ describe('BASE LOCAL MODULE', () => {
     };
     return {
       id,
-      type: PositionTypeEnum.INCONNUE,
+      type: PositionTypeEnum.ENTREE,
       source: 'ban',
       point,
     } as Position;
@@ -578,8 +578,8 @@ describe('BASE LOCAL MODULE', () => {
         'text/csv; charset=utf-8',
       );
       const csvFile = `cle_interop;id_ban_commune;id_ban_toponyme;id_ban_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;certification_commune;commune_insee;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj
-    91534_xxxx_00001_bis;${communeUuid};${voieUuid1};${numeroUuid1};rue de la paix;allée;1;bis;1;91534;Saclay;inconnue;8;42;1114835.92;6113076.85;;ban;2000-01-02
-    91534_xxxx_00001_ter;${communeUuid};${voieUuid2};${numeroUuid2};rue de paris;allée;1;ter;0;91534;Saclay;inconnue;8;42;1114835.92;6113076.85;;ban;2000-01-02
+    91534_xxxx_00001_bis;${communeUuid};${voieUuid1};${numeroUuid1};rue de la paix;allée;1;bis;1;91534;Saclay;entrée;8;42;1114835.92;6113076.85;;ban;2000-01-02
+    91534_xxxx_00001_ter;${communeUuid};${voieUuid2};${numeroUuid2};rue de paris;allée;1;ter;0;91534;Saclay;entrée;8;42;1114835.92;6113076.85;;ban;2000-01-02
     91534_xxxx_99999;${communeUuid};${toponymeUuid1};;allée;;99999;;;91534;Saclay;;;;;;;commune;2000-01-02`;
       expect(response.text.replace(/\s/g, '')).toEqual(
         csvFile.replace(/\s/g, ''),

--- a/apps/api/test/numero.e2e-spec.ts
+++ b/apps/api/test/numero.e2e-spec.ts
@@ -402,7 +402,7 @@ describe('NUMERO', () => {
         positions: [
           {
             id: new ObjectId().toHexString(),
-            type: PositionTypeEnum.INCONNUE,
+            type: PositionTypeEnum.ENTREE,
             source: 'ban',
             point: {
               type: 'Point',

--- a/apps/api/test/publication.e2e-spec.ts
+++ b/apps/api/test/publication.e2e-spec.ts
@@ -159,7 +159,7 @@ describe('PUBLICATION MODULE', () => {
     };
     return {
       id,
-      type: PositionTypeEnum.INCONNUE,
+      type: PositionTypeEnum.ENTREE,
       source: 'ban',
       point,
     } as Position;
@@ -225,7 +225,7 @@ describe('PUBLICATION MODULE', () => {
       axiosMock.onPost(`/revisions/${revisionId}/compute`).reply(200, revision);
 
       const csvFile = `cle_interop;id_ban_commune;id_ban_toponyme;id_ban_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;certification_commune;commune_insee;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj
-    91534_xxxx_00001_bis;${communeUuid};${voieUuid};${numeroUuid};rue de la paix;;1;bis;1;91534;Saclay;inconnue;8;42;1114835.92;6113076.85;;ban;2000-01-01`;
+    91534_xxxx_00001_bis;${communeUuid};${voieUuid};${numeroUuid};rue de la paix;;1;bis;1;91534;Saclay;entrée;8;42;1114835.92;6113076.85;;ban;2000-01-01`;
       axiosMock
         .onPut(`/revisions/${revisionId}/files/bal`)
         .reply(({ data }) => {
@@ -346,7 +346,7 @@ describe('PUBLICATION MODULE', () => {
       axiosMock.onPost(`/revisions/${revisionId}/compute`).reply(200, revision);
 
       const csvFile = `cle_interop;id_ban_commune;id_ban_toponyme;id_ban_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;certification_commune;commune_insee;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj
-      91534_xxxx_00001_bis;${communeUuid};${toponymeUuid};${numeroUuid};rue de la paix;;1;bis;1;91534;Saclay;inconnue;8;42;1114835.92;6113076.85;;ban;2000-01-01`;
+      91534_xxxx_00001_bis;${communeUuid};${toponymeUuid};${numeroUuid};rue de la paix;;1;bis;1;91534;Saclay;entrée;8;42;1114835.92;6113076.85;;ban;2000-01-01`;
       axiosMock
         .onPut(`/revisions/${revisionId}/files/bal`)
         .reply(({ data }) => {
@@ -409,7 +409,7 @@ describe('PUBLICATION MODULE', () => {
         files: [
           {
             type: 'bal',
-            hash: '0c5d808a7e5612c9467607c574cb2317a76fe04d493efbd61b55a31bbd194227',
+            hash: '8e23f1782299e8d5970c1fa800a7074beaac7eeac4c1f0c484e4f6441f680011',
           },
         ],
       };

--- a/apps/api/test/toponyme.e2e-spec.ts
+++ b/apps/api/test/toponyme.e2e-spec.ts
@@ -158,7 +158,7 @@ describe('TOPONYME MODULE', () => {
     };
     return {
       id,
-      type: PositionTypeEnum.INCONNUE,
+      type: PositionTypeEnum.ENTREE,
       source: 'ban',
       point,
     } as Position;

--- a/apps/cron/test/task.e2e-spec.ts
+++ b/apps/cron/test/task.e2e-spec.ts
@@ -208,7 +208,7 @@ describe('TASK MODULE', () => {
     };
     return {
       id,
-      type: PositionTypeEnum.INCONNUE,
+      type: PositionTypeEnum.ENTREE,
       source: 'ban',
       point,
     } as Position;
@@ -370,7 +370,7 @@ describe('TASK MODULE', () => {
     axiosMock.onPost(`/revisions/${revisionId}/compute`).reply(200, revision);
 
     const csvFile = `cle_interop;id_ban_commune;id_ban_toponyme;id_ban_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;certification_commune;commune_insee;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj
-  91534_xxxx_00001_bis;52c4de09-6b82-45eb-8ed7-b212607282f7;26734c2d-2a14-4eeb-ac5b-1be055c0a5ae;2da3bb47-1a10-495a-8c29-6b8d0e79f9af;rue de la paix;;1;bis;1;91534;Saclay;inconnue;8;42;1114835.92;6113076.85;;ban;2000-01-01`;
+  91534_xxxx_00001_bis;52c4de09-6b82-45eb-8ed7-b212607282f7;26734c2d-2a14-4eeb-ac5b-1be055c0a5ae;2da3bb47-1a10-495a-8c29-6b8d0e79f9af;rue de la paix;;1;bis;1;91534;Saclay;entrée;8;42;1114835.92;6113076.85;;ban;2000-01-01`;
     axiosMock.onPut(`/revisions/${revisionId}/files/bal`).reply(({ data }) => {
       expect(data.replace(/\s/g, '')).toEqual(csvFile.replace(/\s/g, ''));
       return [200, null];
@@ -425,7 +425,7 @@ describe('TASK MODULE', () => {
       files: [
         {
           type: 'bal',
-          hash: 'a62492c9dbd6c74e7cfb2b67b3a9e49be89da7b8fa4dff3c061b0f82805b65c9',
+          hash: '5a9646ce4fe552b0dc619e166b0ce7968fa34c94e634331b090452a26c888f7d',
         },
       ],
     };

--- a/libs/shared/src/entities/position.entity.ts
+++ b/libs/shared/src/entities/position.entity.ts
@@ -14,6 +14,7 @@ import { Toponyme } from './toponyme.entity';
 import { ObjectId } from 'mongodb';
 import { Validate } from 'class-validator';
 import { PointValidator } from '../validators/coord.validator';
+import { ValidatorBal } from '../validators/validator_bal.validator';
 
 export enum PositionTypeEnum {
   ENTREE = 'entrée',
@@ -24,7 +25,6 @@ export enum PositionTypeEnum {
   DELIVRANCE_POSTALE = 'délivrance postale',
   PARCELLE = 'parcelle',
   SEGMENT = 'segment',
-  INCONNUE = 'inconnue',
 }
 
 @Entity({ name: 'positions' })
@@ -49,6 +49,7 @@ export class Position {
   numeroId?: string;
 
   @ApiProperty({ enum: PositionTypeEnum })
+  @Validate(ValidatorBal, ['position'])
   @Column('enum', {
     enum: PositionTypeEnum,
     default: PositionTypeEnum.ENTREE,

--- a/migrations/1736244568004-delete_position_inconnue.ts
+++ b/migrations/1736244568004-delete_position_inconnue.ts
@@ -1,0 +1,46 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class DeletePositionInconnue1736244568004 implements MigrationInterface {
+  name = 'DeletePositionInconnue1736244568004';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE positions SET type = 'entrée' WHERE type = 'inconnue'`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."positions_type_enum" RENAME TO "positions_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."positions_type_enum" AS ENUM('entrée', 'bâtiment', 'cage d’escalier', 'logement', 'service technique', 'délivrance postale', 'parcelle', 'segment')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "positions" ALTER COLUMN "type" DROP DEFAULT`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "positions" ALTER COLUMN "type" TYPE "public"."positions_type_enum" USING "type"::"text"::"public"."positions_type_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "positions" ALTER COLUMN "type" SET DEFAULT 'entrée'`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."positions_type_enum_old"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."positions_type_enum_old" AS ENUM('entrée', 'bâtiment', 'cage d’escalier', 'logement', 'service technique', 'délivrance postale', 'parcelle', 'segment', 'inconnue')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "positions" ALTER COLUMN "type" DROP DEFAULT`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "positions" ALTER COLUMN "type" TYPE "public"."positions_type_enum_old" USING "type"::"text"::"public"."positions_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "positions" ALTER COLUMN "type" SET DEFAULT 'entrée'`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."positions_type_enum"`);
+    await queryRunner.query(
+      `ALTER TYPE "public"."positions_type_enum_old" RENAME TO "positions_type_enum"`,
+    );
+  }
+}

--- a/scripts/postdeploy.sh
+++ b/scripts/postdeploy.sh
@@ -1,0 +1,3 @@
+if [ $LAUNCH_MIGRATION_AT_START = "true" ] ; then
+    exec yarn typeorm:migration:run
+fi


### PR DESCRIPTION
## CONTEXT

Le type de position `inconnue` ne passe pas le validateur
Il faut retirer la possibilité d'utiliser le type de position `inconnue` dans l'application mes-adresses

## FONCTIONNALITE

- Mettre type position `entrée` par default a l'import
- Changer l'enum
- Ajouter les validateur de position sur les dto
- Faire une migration de toute les ancienne positions

## PR

- [ ] https://github.com/BaseAdresseNationale/mes-adresses/pull/941