### PR TITLE
fix: bbox type from voie DTO

### DIFF
--- a/libs/shared/src/entities/voie.entity.ts
+++ b/libs/shared/src/entities/voie.entity.ts
@@ -57,7 +57,7 @@ export class Voie extends GlobalEntity {
   })
   trace: LineString | null;
 
-  @ApiProperty()
+  @ApiProperty({ type: Number, isArray: true })
   @Column('float', { nullable: true, array: true })
   bbox: number[] | null;
 


### PR DESCRIPTION
Fix du `ApiProperty` du champ `bbox` de l'entité `Voie`, pour le l'object généré par openapi soit bien de type `number[]`