### PR TITLE
feat: add computed communeNom to bal entity

### DIFF
--- a/apps/api/test/base_locale.e2e-spec.ts
+++ b/apps/api/test/base_locale.e2e-spec.ts
@@ -38,6 +38,7 @@ const baseLocalePublicProperties = [
   'banId',
   'nom',
   'communeNomsAlt',
+  'communeNom',
   'commune',
   'nbNumeros',
   'nbNumerosCertifies',

--- a/apps/api/test/stats.e2e-spec.ts
+++ b/apps/api/test/stats.e2e-spec.ts
@@ -129,11 +129,13 @@ describe('STATS MODULE', () => {
         {
           id: balId1,
           commune: '37003',
+          communeNom: 'Amboise',
           status: StatusBaseLocalEnum.DRAFT,
         },
         {
           id: balId2,
           commune: '37003',
+          communeNom: 'Amboise',
           status: StatusBaseLocalEnum.PUBLISHED,
         },
       ];

--- a/libs/shared/src/entities/base_locale.entity.ts
+++ b/libs/shared/src/entities/base_locale.entity.ts
@@ -1,9 +1,10 @@
 import { GlobalEntity } from './global.entity';
 import { ApiProperty } from '@nestjs/swagger';
-import { Column, Entity, OneToMany } from 'typeorm';
+import { AfterLoad, Column, Entity, OneToMany } from 'typeorm';
 import { Voie } from './voie.entity';
 import { Numero } from './numero.entity';
 import { Toponyme } from './toponyme.entity';
+import { getCommune } from '../utils/cog.utils';
 
 export enum StatusBaseLocalEnum {
   DRAFT = 'draft',
@@ -37,6 +38,9 @@ export class BaseLocale extends GlobalEntity {
   @ApiProperty()
   @Column('text', { nullable: false })
   nom: string;
+
+  @ApiProperty({ required: false, type: String })
+  communeNom?: string;
 
   @ApiProperty()
   @Column('json', { name: 'commune_noms_alt', nullable: true })
@@ -77,4 +81,9 @@ export class BaseLocale extends GlobalEntity {
   @ApiProperty({ type: () => Numero, isArray: true })
   @OneToMany(() => Numero, (numero) => numero.baseLocale)
   numeros?: Numero[];
+
+  @AfterLoad()
+  getCommuneNom?(): void {
+    this.communeNom = getCommune(this.commune)?.nom;
+  }
 }


### PR DESCRIPTION
Ajoute le champ calculé "communeNom" au chargement des entités base locale (pour éviter de faire des call à l'API géo côté front juste pour récupérer le nom de la commune)