### PR TITLE
feat: lock force publish bal

### DIFF
--- a/apps/api/src/modules/base_locale/base_locale.controller.ts
+++ b/apps/api/src/modules/base_locale/base_locale.controller.ts
@@ -420,9 +420,7 @@ export class BaseLocaleController {
   @ApiBearerAuth('admin-token')
   @UseGuards(AdminGuard)
   async publishBaseLocale(@Req() req: CustomRequest, @Res() res: Response) {
-    const baseLocale = await this.publicationService.exec(req.baseLocale.id, {
-      force: true,
-    });
+    const baseLocale = await this.baseLocaleService.publishBal(req.baseLocale);
     res.status(HttpStatus.OK).json(baseLocale);
   }
 

--- a/apps/api/test/publication.e2e-spec.ts
+++ b/apps/api/test/publication.e2e-spec.ts
@@ -33,6 +33,7 @@ import { BaseLocaleModule } from '@/modules/base_locale/base_locale.module';
 import { MailerModule } from '@/shared/test/mailer.module.test';
 import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
 import { Point, Repository } from 'typeorm';
+import { Cache } from '@/shared/entities/cache.entity';
 
 describe('PUBLICATION MODULE', () => {
   let app: INestApplication;
@@ -74,7 +75,7 @@ describe('PUBLICATION MODULE', () => {
           password: postgresContainer.getPassword(),
           database: postgresContainer.getDatabase(),
           synchronize: true,
-          entities: [BaseLocale, Voie, Numero, Toponyme, Position],
+          entities: [BaseLocale, Voie, Numero, Toponyme, Position, Cache],
         }),
         BaseLocaleModule,
         MailerModule,

--- a/apps/cron/src/cron.service.ts
+++ b/apps/cron/src/cron.service.ts
@@ -8,10 +8,11 @@ import { TaskQueue } from './task_queue.class';
 import { RemoveSoftDeleteBalTask } from './tasks/remove_soft_delete_bal.task';
 import { RemoveDemoBalTask } from './tasks/remove_demo_bal.task';
 import { UploadTracesTask } from './tasks/upload_traces.task';
+import { CacheService } from '@/shared/modules/cache/cache.service';
 
 @Injectable()
 export class CronService {
-  private queue: TaskQueue = new TaskQueue();
+  private queue: TaskQueue;
 
   constructor(
     private readonly detectOutdatedTask: DetectOutdatedTask,
@@ -20,7 +21,10 @@ export class CronService {
     private readonly removeSoftDeleteBalTask: RemoveSoftDeleteBalTask,
     private readonly removeDemoBalTask: RemoveDemoBalTask,
     private readonly uploadTracesTask: UploadTracesTask,
-  ) {}
+    private cacheService: CacheService,
+  ) {
+    this.queue = new TaskQueue(this.cacheService);
+  }
 
   // Every 30 seconds
   @Interval(30000)

--- a/libs/shared/src/modules/cache/cache.const.ts
+++ b/libs/shared/src/modules/cache/cache.const.ts
@@ -1,0 +1,1 @@
+export const KEY_LOCK_CRON = 'lockCron';

--- a/libs/shared/src/modules/cache/cache.service.ts
+++ b/libs/shared/src/modules/cache/cache.service.ts
@@ -29,4 +29,19 @@ export class CacheService {
 
     return this.cacheRepository.save({ key, value });
   }
+
+  async wait(key: string, repetition: number = 0) {
+    // timeout of 60 seconde
+    if (repetition >= 60) {
+      this.del(key);
+    }
+    const lock = await this.get(key);
+    if (lock) {
+      return new Promise((resolve) => {
+        setTimeout(async () => {
+          resolve(this.wait(key, repetition + 1));
+        }, 1000);
+      });
+    }
+  }
 }


### PR DESCRIPTION
## CONTEXT

Lorsque la route forcePublish s'execute en même temps que les cron detectConflict ou SYncOutdated, cela peut créer des BALs en conflits avec elle mêmes

## FONCTIONNALITE

Ajout d'un lock sur le cache de postgres pour que le la route forcePublish et les cron ne s'execute pas en même temps